### PR TITLE
Make TensorSharp.slnx MSBuild-compatible

### DIFF
--- a/TensorSharp.slnx
+++ b/TensorSharp.slnx
@@ -1,8 +1,30 @@
-<Solution>
-  <Project Path="AdvUtils/AdvUtils.csproj" />
-  <Project Path="InferenceConsole/InferenceConsole.csproj" />
-  <Project Path="InferenceEngine/InferenceEngine.csproj" />
-  <Project Path="InferenceWeb/InferenceWeb.csproj" />
-  <Project Path="TensorSharp.GGML/TensorSharp.GGML.csproj" />
-  <Project Path="TensorSharp/TensorSharp.csproj" />
-</Solution>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectsToBuild Include="AdvUtils/AdvUtils.csproj" />
+    <ProjectsToBuild Include="InferenceConsole/InferenceConsole.csproj" />
+    <ProjectsToBuild Include="InferenceEngine/InferenceEngine.csproj" />
+    <ProjectsToBuild Include="InferenceWeb/InferenceWeb.csproj" />
+    <ProjectsToBuild Include="TensorSharp.GGML/TensorSharp.GGML.csproj" />
+    <ProjectsToBuild Include="TensorSharp/TensorSharp.csproj" />
+  </ItemGroup>
+
+  <Target Name="Build">
+    <MSBuild Projects="@(ProjectsToBuild)"
+             Targets="Build"
+             Properties="Configuration=$(Configuration);Platform=$(Platform)" />
+  </Target>
+
+  <Target Name="Clean">
+    <MSBuild Projects="@(ProjectsToBuild)"
+             Targets="Clean"
+             Properties="Configuration=$(Configuration);Platform=$(Platform)" />
+  </Target>
+
+  <Target Name="Restore">
+    <MSBuild Projects="@(ProjectsToBuild)"
+             Targets="Restore"
+             Properties="Configuration=$(Configuration);Platform=$(Platform)" />
+  </Target>
+
+  <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
+</Project>


### PR DESCRIPTION
### Motivation
- Fix the `MSB4068` parsing error where `<Solution>` in `TensorSharp.slnx` is unrecognized by some .NET/MSBuild toolchains by making the file valid MSBuild XML.

### Description
- Replace the custom `<Solution>` format in `TensorSharp.slnx` with a standard MSBuild `<Project>` file that includes all projects in a `ProjectsToBuild` item group and adds `Build`, `Clean`, `Restore`, and `Rebuild` targets that forward to each project while propagating `Configuration` and `Platform`.

### Testing
- Attempted `dotnet build TensorSharp.slnx -c Release` could not be executed in this environment because `dotnet` was not installed (error: `/bin/bash: dotnet: command not found`).
- Inspected the updated `TensorSharp.slnx` contents and verified it contains the `ItemGroup` with project entries and the expected MSBuild targets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2b9027fdc83218714ad7ace5f1716)