### PR TITLE
Fix broken link to Chinese README in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TensorSharp
 
-[English](README.md) | [中文](README_cn.md)
+[English](README.md) | [中文](readme_cn.md)
 
 A C# inference engine for running large language models (LLMs) locally using GGUF model files. TensorSharp provides a console application, a web-based chatbot interface, and Ollama/OpenAI-compatible HTTP APIs for programmatic access.
 


### PR DESCRIPTION
### Motivation
- The top-level `README.md` linked to `README_cn.md` which does not match the actual filename `readme_cn.md`, causing the Chinese README link to be broken.

### Description
- Update the Chinese README hyperlink in `README.md` from `[中文](README_cn.md)` to `[中文](readme_cn.md)` to match the repository filename.

### Testing
- Verified the target file exists with `rg --files | rg -i 'readme.*cn'` and confirmed the updated link appears in `README.md` using `nl -ba README.md | sed -n '1,12p'`, and inspected the README diff with `git diff -- README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2c7744dc48321af4d7d9fadec55b2)