### PR TITLE
ci: deploy website/ wiki to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,47 @@
+name: Deploy Wiki to GitHub Pages
+
+# Publishes the static wiki in website/ to GitHub Pages.
+# Setup (one time): repo Settings -> Pages -> Build and deployment -> Source = "GitHub Actions".
+# After that, every push to main that touches website/ redeploys automatically;
+# you can also run it on demand from the Actions tab (workflow_dispatch).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+# Least-privilege token scopes required by the Pages deploy actions.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload website/ as the Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Add a GitHub Actions workflow that publishes the static wiki in website/ to GitHub Pages on pushes to main (and on demand via workflow_dispatch), plus a .nojekyll guard so the artifact is served as-is.