### PR TITLE
Fix CUDA CPU fallback crash on Float16 KV caches

### DIFF
--- a/InferenceWeb.Tests/CpuDecodeProfileBench.cs
+++ b/InferenceWeb.Tests/CpuDecodeProfileBench.cs
@@ -1,0 +1,99 @@
+// Opt-in CPU-backend decode profiler. Loads a GGUF on BackendType.Cpu, prefills a
+// prompt, decodes N tokens, and reports tok/s, average cores used
+// (process CPU-time / wall), and the matmul-vs-rest split (TS_CPU_MATMUL_PROFILE=1).
+//
+//   TS_CPU_BENCH=1 TS_CPU_MATMUL_PROFILE=1 \
+//   TS_CPU_MODEL="C:\Works\models\gemma_mtp\qat\gemma-4-12B-it-qat-UD-Q4_K_XL.gguf" \
+//   dotnet test --filter CpuDecodeProfile_Bench -c Release
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using TensorSharp;
+using TensorSharp.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+public class CpuDecodeProfileBench
+{
+    private readonly ITestOutputHelper _out;
+    public CpuDecodeProfileBench(ITestOutputHelper o) => _out = o;
+
+    [Fact]
+    public void CpuDecodeProfile_Bench()
+    {
+        if (Environment.GetEnvironmentVariable("TS_CPU_BENCH") != "1")
+        { _out.WriteLine("set TS_CPU_BENCH=1 to run; skipping"); return; }
+
+        string path = Environment.GetEnvironmentVariable("TS_CPU_MODEL")
+            ?? @"C:\Works\models\gemma_mtp\qat\gemma-4-12B-it-qat-UD-Q4_K_XL.gguf";
+        if (!File.Exists(path)) { _out.WriteLine($"missing model {path}; skipping"); return; }
+
+        int maxNew = int.TryParse(Environment.GetEnvironmentVariable("TS_CPU_NEW"), out int n) ? n : 32;
+        int ctx = int.TryParse(Environment.GetEnvironmentVariable("TS_CPU_CTX"), out int c) ? c : 0;
+        string prompt = Environment.GetEnvironmentVariable("TS_CPU_PROMPT") ?? "请详细介绍最终幻想7";
+
+        _out.WriteLine($"cores={Environment.ProcessorCount} model={Path.GetFileName(path)}");
+        using var model = ModelBase.Create(path, BackendType.Cpu);
+        int[] tokens = model.Tokenizer.Encode(prompt, addSpecial: true).ToArray();
+        if (ctx > tokens.Length)
+        {
+            // Pad the prompt with a repeated synthetic context to simulate a long
+            // running generation (large KV cache) so we can observe how decode
+            // utilisation changes with context length.
+            var padded = new List<int>(tokens);
+            int filler = tokens.Length > 1 ? tokens[1] : tokens[0];
+            while (padded.Count < ctx) padded.Add(filler);
+            tokens = padded.ToArray();
+        }
+        _out.WriteLine($"prompt tokens={tokens.Length} maxNew={maxNew}");
+
+        // Prefill (not counted in decode timing).
+        model.ResetKVCache();
+        float[] logits = model.ForwardRefill(tokens);
+        int t = Argmax(logits);
+        var outTok = new List<int> { t };
+
+        // Warm one decode step.
+        logits = model.Forward(new[] { t }); t = Argmax(logits); outTok.Add(t);
+
+        ManagedQuantizedOps.ResetMatmulProfile();
+        var proc = Process.GetCurrentProcess();
+        proc.Refresh();
+        var cpu0 = proc.TotalProcessorTime;
+        var sw = Stopwatch.StartNew();
+        for (int i = 2; i < maxNew; i++)
+        {
+            logits = model.Forward(new[] { t });
+            t = Argmax(logits);
+            outTok.Add(t);
+        }
+        sw.Stop();
+        proc.Refresh();
+        double wall = sw.Elapsed.TotalSeconds;
+        double cpu = (proc.TotalProcessorTime - cpu0).TotalSeconds;
+        int decoded = maxNew - 2;
+        double avgCores = cpu / wall;
+
+        _out.WriteLine($"decoded {decoded} tok in {wall:F2}s = {decoded / wall:F2} tok/s");
+        _out.WriteLine($"avg cores = {avgCores:F2} / {Environment.ProcessorCount}  (util {100.0 * avgCores / Environment.ProcessorCount:F0}%)");
+
+        if (ManagedQuantizedOps.MatmulProfileEnabled)
+        {
+            var (mm, gib, calls) = ManagedQuantizedOps.ReadMatmulProfile();
+            _out.WriteLine($"matmul: {mm:F0} ms total ({100.0 * mm / (wall * 1000):F0}% of wall), {calls} calls, {gib:F1} GiB weights read");
+            _out.WriteLine($"matmul bandwidth = {gib / (mm / 1000.0):F1} GiB/s; rest (serial+attn+overhead) = {wall * 1000 - mm:F0} ms ({100.0 * (wall * 1000 - mm) / (wall * 1000):F0}%)");
+        }
+        _out.WriteLine($"sample out: {Trim(model.Tokenizer.Decode(outTok))}");
+        double checksum = 0; for (int i = 0; i < logits.Length; i++) checksum += logits[i] * (double)((i & 1023) + 1);
+        _out.WriteLine($"tokens=[{string.Join(",", outTok.GetRange(0, Math.Min(12, outTok.Count)))}] logitsChecksum={checksum:R}");
+    }
+
+    private static int Argmax(float[] v)
+    {
+        int bi = 0; float bv = v[0];
+        for (int i = 1; i < v.Length; i++) if (v[i] > bv) { bv = v[i]; bi = i; }
+        return bi;
+    }
+    private static string Trim(string s) => s.Length > 160 ? s.Substring(0, 160) + "…" : s;
+}

--- a/InferenceWeb.Tests/ManagedQuantizedOpsTests.cs
+++ b/InferenceWeb.Tests/ManagedQuantizedOpsTests.cs
@@ -276,6 +276,53 @@ public class ManagedQuantizedOpsTests
         AssertClose(expected, actual, 0.2f);
     }
 
+    [Theory]
+    [InlineData(256, 5, 1)]
+    [InlineData(256, 5, 3)]
+    [InlineData(1024, 33, 4)]
+    public void TryAddmmQuantizedToFloat32_Q40Path_MatchesDequantReference(int inDim, int outDim, int rows)
+    {
+        // Validates the SIMD (AVX2/AVX-512) Q4_0 x Q8_0 dot against the
+        // dequantize-then-dot reference over the SAME weight bytes.
+        var rng = new Random(1234);
+        byte[] weights = BuildRandomQ40(rng, outDim, inDim);
+        float[] input = Enumerable.Range(0, rows * inDim)
+            .Select(i => 0.05f * MathF.Sin(i * 0.021f))
+            .ToArray();
+        float[] actual = new float[rows * outDim];
+
+        Assert.True(ManagedQuantizedOps.TryAddmmQuantizedToFloat32(
+            (int)GgmlTensorType.Q4_0, weights, 0, inDim, outDim,
+            input, 0, inDim, rows, actual, 0, outDim));
+
+        float[] expected = DequantizedMatmul(weights, GgmlTensorType.Q4_0, outDim, inDim, input, rows);
+
+        float maxRef = 0f;
+        for (int i = 0; i < expected.Length; i++) maxRef = MathF.Max(maxRef, MathF.Abs(expected[i]));
+        float tol = 0.02f * maxRef + 1e-3f;   // Q8_0 activation quant noise
+        AssertClose(expected, actual, tol);
+    }
+
+    private static byte[] BuildRandomQ40(Random rng, int outDim, int inDim)
+    {
+        const int blockSize = 32;
+        const int blockBytes = 18; // 2 (f16 scale) + 16 packed nibbles
+        Assert.Equal(0, inDim % blockSize);
+        int blocksPerRow = inDim / blockSize;
+        byte[] raw = new byte[(long)outDim * blocksPerRow * blockBytes];
+        int o = 0;
+        for (int r = 0; r < outDim; r++)
+        {
+            for (int b = 0; b < blocksPerRow; b++)
+            {
+                WriteHalf(raw, o, 0.03f + 0.02f * (float)rng.NextDouble());
+                o += 2;
+                for (int i = 0; i < 16; i++) raw[o++] = (byte)rng.Next(0, 256);
+            }
+        }
+        return raw;
+    }
+
     [Fact]
     public void Benchmark_Q80DirectMatmul_VsDequantizedBlockDot()
     {

--- a/InferenceWeb.Tests/TensorApiTests.cs
+++ b/InferenceWeb.Tests/TensorApiTests.cs
@@ -59,4 +59,32 @@ public class TensorApiTests
         alias.Dispose();
         alias.Dispose();
     }
+
+    [Fact]
+    public void Float16ElementAccessRoundTrips()
+    {
+        using Tensor tensor = new Tensor(_allocator, DType.Float16, 2, 2);
+
+        tensor.SetElementAsFloat(2.5f, 0, 0);
+        tensor.SetElementAsFloat(-3f, 1, 1);
+
+        Assert.Equal(2.5f, tensor.GetElementAsFloat(0, 0));
+        Assert.Equal(-3f, tensor.GetElementAsFloat(1, 1));
+    }
+
+    [Fact]
+    public void FillSupportsFloat16Tensors()
+    {
+        using Tensor tensor = new Tensor(_allocator, DType.Float16, 3, 4);
+
+        Ops.Fill(tensor, 0f);
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 4; j++)
+                Assert.Equal(0f, tensor.GetElementAsFloat(i, j));
+
+        Ops.Fill(tensor, 1.5f);
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 4; j++)
+                Assert.Equal(1.5f, tensor.GetElementAsFloat(i, j));
+    }
 }

--- a/TensorSharp.Backends.Cuda/CudaCpuFallback.cs
+++ b/TensorSharp.Backends.Cuda/CudaCpuFallback.cs
@@ -155,6 +155,7 @@ namespace TensorSharp.Cuda
                 case DType.Float64:
                 case DType.Int32:
                 case DType.UInt8:
+                case DType.Float16:
                     destination.Storage.SetElementAsFloat(destinationOffset, source.Storage.GetElementAsFloat(sourceOffset));
                     break;
                 default:

--- a/TensorSharp.Backends.Cuda/CudaKernels.cs
+++ b/TensorSharp.Backends.Cuda/CudaKernels.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using TensorSharp.Cuda.Interop;
 
@@ -152,15 +153,46 @@ namespace TensorSharp.Cuda
         {
             string path = LocatePtxPath();
             if (path == null)
+            {
+                WarnKernelsUnavailable(
+                    "the compiled PTX (tensorsharp_kernels.ptx) could not be located next to the application " +
+                    "or under a 'cuda_kernels' folder in its output directory");
                 return null;
+            }
 
             try
             {
                 return new CudaKernels(CudaModule.LoadFromFile(path));
             }
+            catch (Exception ex)
+            {
+                WarnKernelsUnavailable($"loading the PTX module from '{path}' failed: {ex.Message}");
+                return null;
+            }
+        }
+
+        private static int kernelWarningEmitted;
+
+        private static void WarnKernelsUnavailable(string reason)
+        {
+            // Without the PTX kernels every PTX-backed op (fill, attention, RoPE, ...)
+            // silently falls back to the slow CPU path, and Float16 caches in
+            // particular used to surface this only as a deep NotSupportedException.
+            // Emit a single, actionable warning so the degraded mode is visible.
+            if (System.Threading.Interlocked.Exchange(ref kernelWarningEmitted, 1) != 0)
+                return;
+
+            try
+            {
+                Console.Error.WriteLine(
+                    "WARNING: TensorSharp CUDA kernels are unavailable because " + reason + ". " +
+                    "The Cuda backend will run PTX-backed ops on a slow CPU fallback. " +
+                    "Build TensorSharp.Backends.Cuda with nvcc on the PATH and ensure " +
+                    "cuda_kernels/tensorsharp_kernels.ptx is copied next to your application.");
+            }
             catch
             {
-                return null;
+                // Diagnostics must never break model initialization.
             }
         }
 
@@ -1470,22 +1502,30 @@ namespace TensorSharp.Cuda
 
         private static string LocatePtxPath()
         {
-            string baseDirectory = AppContext.BaseDirectory;
-            string[] candidates =
+            // Probe the application base directory first, then the directory the
+            // CUDA backend assembly itself was loaded from. When TensorSharp is
+            // consumed from another solution these are usually the same folder,
+            // but they can differ for plugin hosts, single-file publishes, or
+            // shadow-copied assemblies, so checking both avoids the silent CPU
+            // fallback reported when the consuming app lives outside this repo.
+            foreach (string baseDirectory in EnumeratePtxBaseDirectories())
             {
-                Path.Combine(baseDirectory, "cuda_kernels", "tensorsharp_kernels.ptx"),
-                Path.Combine(baseDirectory, "tensorsharp_kernels.ptx"),
-                Path.Combine(baseDirectory, "..", "..", "..", "native", "ptx", "tensorsharp_kernels.ptx"),
-            };
+                string[] candidates =
+                {
+                    Path.Combine(baseDirectory, "cuda_kernels", "tensorsharp_kernels.ptx"),
+                    Path.Combine(baseDirectory, "tensorsharp_kernels.ptx"),
+                    Path.Combine(baseDirectory, "..", "..", "..", "native", "ptx", "tensorsharp_kernels.ptx"),
+                };
 
-            foreach (string candidate in candidates)
-            {
-                string fullPath = Path.GetFullPath(candidate);
-                if (File.Exists(fullPath))
-                    return fullPath;
+                foreach (string candidate in candidates)
+                {
+                    string fullPath = Path.GetFullPath(candidate);
+                    if (File.Exists(fullPath))
+                        return fullPath;
+                }
             }
 
-            DirectoryInfo dir = new DirectoryInfo(baseDirectory);
+            DirectoryInfo dir = new DirectoryInfo(AppContext.BaseDirectory);
             while (dir != null)
             {
                 string sourceTreePath = Path.Combine(dir.FullName, "TensorSharp.Backends.Cuda", "native", "ptx", "tensorsharp_kernels.ptx");
@@ -1500,6 +1540,34 @@ namespace TensorSharp.Cuda
             }
 
             return null;
+        }
+
+        private static IEnumerable<string> EnumeratePtxBaseDirectories()
+        {
+            yield return AppContext.BaseDirectory;
+
+            string assemblyLocation = null;
+            try
+            {
+                assemblyLocation = typeof(CudaKernels).Assembly.Location;
+            }
+            catch
+            {
+                assemblyLocation = null;
+            }
+
+            if (!string.IsNullOrEmpty(assemblyLocation))
+            {
+                string assemblyDir = Path.GetDirectoryName(assemblyLocation);
+                if (!string.IsNullOrEmpty(assemblyDir) &&
+                    !string.Equals(
+                        Path.GetFullPath(assemblyDir),
+                        Path.GetFullPath(AppContext.BaseDirectory),
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return assemblyDir;
+                }
+            }
         }
     }
 }

--- a/TensorSharp.Backends.Cuda/CudaStorage.cs
+++ b/TensorSharp.Backends.Cuda/CudaStorage.cs
@@ -224,6 +224,7 @@ namespace TensorSharp.Cuda
                 DType.Float64 => (float)((double*)hostBuffer.ToPointer())[index],
                 DType.Int32 => ((int*)hostBuffer.ToPointer())[index],
                 DType.UInt8 => ((byte*)hostBuffer.ToPointer())[index],
+                DType.Float16 => (float)BitConverter.UInt16BitsToHalf(((ushort*)hostBuffer.ToPointer())[index]),
                 _ => throw new NotSupportedException("Element type " + ElementType + " not supported"),
             };
         }
@@ -260,6 +261,9 @@ namespace TensorSharp.Cuda
                     break;
                 case DType.UInt8:
                     ((byte*)hostBuffer.ToPointer())[index] = (byte)value;
+                    break;
+                case DType.Float16:
+                    ((ushort*)hostBuffer.ToPointer())[index] = BitConverter.HalfToUInt16Bits((Half)value);
                     break;
                 default:
                     throw new NotSupportedException("Element type " + ElementType + " not supported");

--- a/TensorSharp.Backends.Cuda/CudaStorage.cs
+++ b/TensorSharp.Backends.Cuda/CudaStorage.cs
@@ -263,7 +263,7 @@ namespace TensorSharp.Cuda
                     ((byte*)hostBuffer.ToPointer())[index] = (byte)value;
                     break;
                 case DType.Float16:
-                    ((ushort*)hostBuffer.ToPointer())[index] = BitConverter.HalfToUInt16Bits((Half)value);
+                    ((ushort*)hostBuffer.ToPointer())[index] = BitConverter.HalfToUInt16Bits((System.Half)value);
                     break;
                 default:
                     throw new NotSupportedException("Element type " + ElementType + " not supported");

--- a/TensorSharp.Core/Cpu/CpuStorage.cs
+++ b/TensorSharp.Core/Cpu/CpuStorage.cs
@@ -136,7 +136,7 @@ namespace TensorSharp.Cpu
                 }
                 else if (ElementType == DType.Float16)
                 {
-                    ((ushort*)buffer.ToPointer())[index] = BitConverter.HalfToUInt16Bits((Half)value);
+                    ((ushort*)buffer.ToPointer())[index] = BitConverter.HalfToUInt16Bits((System.Half)value);
                 }
                 else
                 {

--- a/TensorSharp.Core/Cpu/CpuStorage.cs
+++ b/TensorSharp.Core/Cpu/CpuStorage.cs
@@ -81,6 +81,10 @@ namespace TensorSharp.Cpu
                 {
                     return ((byte*)buffer.ToPointer())[index];
                 }
+                else if (ElementType == DType.Float16)
+                {
+                    return (float)BitConverter.UInt16BitsToHalf(((ushort*)buffer.ToPointer())[index]);
+                }
                 else
                 {
                     throw new NotSupportedException("Element type " + ElementType + " not supported");
@@ -129,6 +133,10 @@ namespace TensorSharp.Cpu
                 else if (ElementType == DType.UInt8)
                 {
                     ((byte*)buffer.ToPointer())[index] = (byte)value;
+                }
+                else if (ElementType == DType.Float16)
+                {
+                    ((ushort*)buffer.ToPointer())[index] = BitConverter.HalfToUInt16Bits((Half)value);
                 }
                 else
                 {

--- a/TensorSharp.Models/ManagedQuantizedOps.cs
+++ b/TensorSharp.Models/ManagedQuantizedOps.cs
@@ -21,6 +21,18 @@ namespace TensorSharp.Models
 {
     internal static class ManagedQuantizedOps
     {
+        // Diagnostic: env-gated wall-time + byte accounting for the managed
+        // quantized matmul (the dominant decode cost). Enabled by
+        // TS_CPU_MATMUL_PROFILE=1; read/reset via the public helpers below.
+        internal static readonly bool MatmulProfileEnabled =
+            string.Equals(Environment.GetEnvironmentVariable("TS_CPU_MATMUL_PROFILE"), "1", StringComparison.Ordinal);
+        private static long s_matmulTicks;
+        private static long s_matmulBytes;
+        private static long s_matmulCalls;
+        internal static void ResetMatmulProfile() { s_matmulTicks = 0; s_matmulBytes = 0; s_matmulCalls = 0; }
+        internal static (double ms, double gib, long calls) ReadMatmulProfile() =>
+            (s_matmulTicks * 1000.0 / System.Diagnostics.Stopwatch.Frequency, s_matmulBytes / (1024.0 * 1024 * 1024), s_matmulCalls);
+
         private const int QK4_0 = 32;
         private const int QK4_1 = 32;
         private const int QK5_0 = 32;
@@ -281,6 +293,8 @@ namespace TensorSharp.Models
                         }
                     }
 
+                    long profStart = MatmulProfileEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+
                     bool useParallel = outDim >= 128 && (long)rowCount * outDim >= 512 && Environment.ProcessorCount > 1;
                     if (useParallel)
                     {
@@ -289,6 +303,13 @@ namespace TensorSharp.Models
                     else
                     {
                         ComputeColumnRange(0, outDim);
+                    }
+
+                    if (MatmulProfileEnabled)
+                    {
+                        System.Threading.Interlocked.Add(ref s_matmulTicks, System.Diagnostics.Stopwatch.GetTimestamp() - profStart);
+                        System.Threading.Interlocked.Add(ref s_matmulBytes, (long)outDim * weightRowBytes);
+                        System.Threading.Interlocked.Increment(ref s_matmulCalls);
                     }
                 }
             }
@@ -967,8 +988,21 @@ namespace TensorSharp.Models
             return maxAbs;
         }
 
+        // A/B knob: TENSORSHARP_CPU_NO_SIMD_Q40=1 forces the scalar Q4_0 dot
+        // (to measure the SIMD speedup / fall back if a SIMD bug is suspected).
+        private static readonly bool s_scalarQ40 =
+            string.Equals(Environment.GetEnvironmentVariable("TENSORSHARP_CPU_NO_SIMD_Q40"), "1", StringComparison.Ordinal);
+
         private static unsafe float VecDotQ4_0Q8_0(byte* q4, byte* q8, int blockCount)
         {
+            if (!s_scalarQ40)
+            {
+                if (Avx512F.IsSupported && Avx512BW.IsSupported)
+                    return VecDotQ4_0Q8_0Avx512(q4, q8, blockCount);
+                if (Avx2.IsSupported)
+                    return VecDotQ4_0Q8_0Avx2(q4, q8, blockCount);
+            }
+
             float sum = 0.0f;
             for (int block = 0; block < blockCount; block++)
             {
@@ -991,6 +1025,89 @@ namespace TensorSharp.Models
             }
 
             return sum;
+        }
+
+        // Unpack a Q4_0 block's 16 packed nibble bytes into 32 signed bytes in the
+        // ggml dequant order [low0..low15, high0..high15] (matching the Q8_0
+        // activation layout qx[0..31]), with the -8 zero-point offset already
+        // applied so the result is the signed weight value.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector256<sbyte> UnpackQ40Nibbles(byte* qs, Vector256<sbyte> offset8)
+        {
+            Vector128<byte> packed = Unsafe.ReadUnaligned<Vector128<byte>>(qs);
+            Vector128<byte> mask = Vector128.Create((byte)0x0F);
+            Vector128<byte> low = Sse2.And(packed, mask);
+            Vector128<byte> high = Sse2.And(Sse2.ShiftRightLogical(packed.AsUInt16(), 4).AsByte(), mask);
+            return Avx2.Subtract(Vector256.Create(low, high).AsSByte(), offset8);
+        }
+
+        private static unsafe float VecDotQ4_0Q8_0Avx512(byte* q4, byte* q8, int blockCount)
+        {
+            // Two independent FMA accumulators break the loop-carried dependency
+            // on `acc` so the int8 widen/madd pipeline isn't stalled on FMA
+            // latency; this lifts the Q4_0 matmul closer to the memory wall.
+            Vector512<float> acc0 = Vector512<float>.Zero;
+            Vector512<float> acc1 = Vector512<float>.Zero;
+            Vector512<short> ones = Vector512.Create((short)1);
+            Vector256<sbyte> offset8 = Vector256.Create((sbyte)8);
+
+            int block = 0;
+            int pairEnd = blockCount & ~1;
+            for (; block < pairEnd; block += 2)
+            {
+                acc0 = AccumQ40BlockAvx512(q4, q8, block, ones, offset8, acc0);
+                acc1 = AccumQ40BlockAvx512(q4, q8, block + 1, ones, offset8, acc1);
+            }
+            if (block < blockCount)
+                acc0 = AccumQ40BlockAvx512(q4, q8, block, ones, offset8, acc0);
+
+            return HorizontalSum(acc0 + acc1);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector512<float> AccumQ40BlockAvx512(
+            byte* q4, byte* q8, int block, Vector512<short> ones, Vector256<sbyte> offset8, Vector512<float> acc)
+        {
+            byte* wb = q4 + block * Q4_0BlockBytes;
+            byte* xb = q8 + block * Q8_0BlockBytes;
+            float scale = HalfToSingle(ReadUInt16(wb)) * HalfToSingle(ReadUInt16(xb));
+
+            Vector256<sbyte> qwBytes = UnpackQ40Nibbles(wb + 2, offset8);
+            Vector256<sbyte> qxBytes = Unsafe.ReadUnaligned<Vector256<sbyte>>(xb + 2);
+            Vector512<short> qw = Avx512BW.ConvertToVector512Int16(qwBytes);
+            Vector512<short> qx = Avx512BW.ConvertToVector512Int16(qxBytes);
+            Vector512<short> products = Avx512BW.MultiplyLow(qw, qx);
+            Vector512<int> pairSums = Avx512BW.MultiplyAddAdjacent(products, ones);
+            Vector512<float> dotParts = Avx512F.ConvertToVector512Single(pairSums);
+            return Avx512F.FusedMultiplyAdd(Vector512.Create(scale), dotParts, acc);
+        }
+
+        private static unsafe float VecDotQ4_0Q8_0Avx2(byte* q4, byte* q8, int blockCount)
+        {
+            Vector256<float> acc = Vector256<float>.Zero;
+            Vector256<short> ones = Vector256.Create((short)1);
+            Vector256<sbyte> offset8 = Vector256.Create((sbyte)8);
+
+            for (int block = 0; block < blockCount; block++)
+            {
+                byte* wb = q4 + block * Q4_0BlockBytes;
+                byte* xb = q8 + block * Q8_0BlockBytes;
+                float scale = HalfToSingle(ReadUInt16(wb)) * HalfToSingle(ReadUInt16(xb));
+
+                Vector256<sbyte> qw = UnpackQ40Nibbles(wb + 2, offset8);
+                Vector256<sbyte> qx = Unsafe.ReadUnaligned<Vector256<sbyte>>(xb + 2);
+                // signed*signed dot via maddubs(|w|, sign(w)*x): see VecDotQ8_0Q8_0Avx2.
+                Vector256<sbyte> absW = Avx2.Sign(qw, qw);
+                Vector256<sbyte> signedX = Avx2.Sign(qx, qw);
+                Vector256<short> prod = Avx2.MultiplyAddAdjacent(absW.AsByte(), signedX);
+                Vector256<int> pairSums = Avx2.MultiplyAddAdjacent(prod, ones);
+                Vector256<float> dotParts = Avx.ConvertToVector256Single(pairSums);
+                acc = Fma.IsSupported
+                    ? Fma.MultiplyAdd(Vector256.Create(scale), dotParts, acc)
+                    : Avx.Add(acc, Avx.Multiply(Vector256.Create(scale), dotParts));
+            }
+
+            return HorizontalSum(acc);
         }
 
         private static unsafe float VecDotQ4_1Q8_1(byte* q4, byte* q8, int blockCount)

--- a/TensorSharp.Models/Models/Gemma4/Gemma4Model.cs
+++ b/TensorSharp.Models/Models/Gemma4/Gemma4Model.cs
@@ -5421,14 +5421,18 @@ namespace TensorSharp.Models
             int groupSize = numHeads / numKVHeads;
             int attendLen = totalSeqLen - attendStart;
 
-            float* scores = stackalloc float[attendLen];
-
-            for (int h = 0; h < numHeads; h++)
+            // Each query head is independent; at long context this serial loop is
+            // the single biggest decode cost on the managed CPU backend, so fan it
+            // out across cores. Pointers are passed as nint (lambdas can't capture
+            // pointer locals) and each head stackallocs its own score scratch.
+            nint qN = (nint)qPtr, kN = (nint)kPtr, vN = (nint)vPtr, rN = (nint)rPtr;
+            void Head(int h)
             {
-                float* qHead = qPtr + h * keyDim;
+                float* qHead = (float*)qN + h * keyDim;
                 int kvHead = h / groupSize;
-                float* kHead = kPtr + kvHead * maxSeqLen * keyDim;
-                float* vHead = vPtr + kvHead * maxSeqLen * valDim;
+                float* kHead = (float*)kN + kvHead * maxSeqLen * keyDim;
+                float* vHead = (float*)vN + kvHead * maxSeqLen * valDim;
+                float* scores = stackalloc float[attendLen];
 
                 float maxScore = float.NegativeInfinity;
                 for (int t = 0; t < attendLen; t++)
@@ -5449,12 +5453,26 @@ namespace TensorSharp.Models
                 for (int t = 0; t < attendLen; t++)
                     scores[t] *= invSum;
 
-                float* rHead = rPtr + h * valDim;
+                float* rHead = (float*)rN + h * valDim;
                 VecZero(rHead, valDim);
                 for (int t = 0; t < attendLen; t++)
                     VecScaleAdd(rHead, vHead + (attendStart + t) * valDim, scores[t], valDim);
             }
+
+            if (ShouldParallelizeHeads(numHeads, attendLen))
+                System.Threading.Tasks.Parallel.For(0, numHeads, Head);
+            else
+                for (int h = 0; h < numHeads; h++) Head(h);
         }
+
+        // Decode attention parallelises across query heads only when there is
+        // enough work to amortise the fork/join (long context); short-context
+        // decode is dominated by the matmuls and stays serial. Set
+        // TS_CPU_NO_PAR_ATTN=1 to force the serial path (A/B / correctness).
+        private static readonly bool s_noParallelHeads =
+            string.Equals(Environment.GetEnvironmentVariable("TS_CPU_NO_PAR_ATTN"), "1", StringComparison.Ordinal);
+        private static bool ShouldParallelizeHeads(int numHeads, int attendLen) =>
+            !s_noParallelHeads && numHeads > 1 && attendLen >= 128 && Environment.ProcessorCount > 1;
 
         private unsafe void AttentionDecodeWithWindowF16(Tensor q, Tensor kCache, Tensor vCache,
             Tensor result, int numHeads, int numKVHeads, int keyDim, int valDim,
@@ -5468,14 +5486,14 @@ namespace TensorSharp.Models
             int groupSize = numHeads / numKVHeads;
             int attendLen = totalSeqLen - attendStart;
 
-            float* scores = stackalloc float[attendLen];
-
-            for (int h = 0; h < numHeads; h++)
+            nint qN = (nint)qPtr, kN = (nint)kPtr, vN = (nint)vPtr, rN = (nint)rPtr;
+            void Head(int h)
             {
-                float* qHead = qPtr + h * keyDim;
+                float* qHead = (float*)qN + h * keyDim;
                 int kvHead = h / groupSize;
-                ushort* kHead = kPtr + kvHead * maxSeqLen * keyDim;
-                ushort* vHead = vPtr + kvHead * maxSeqLen * valDim;
+                ushort* kHead = (ushort*)kN + kvHead * maxSeqLen * keyDim;
+                ushort* vHead = (ushort*)vN + kvHead * maxSeqLen * valDim;
+                float* scores = stackalloc float[attendLen];
 
                 float maxScore = float.NegativeInfinity;
                 for (int t = 0; t < attendLen; t++)
@@ -5496,11 +5514,16 @@ namespace TensorSharp.Models
                 for (int t = 0; t < attendLen; t++)
                     scores[t] *= invSum;
 
-                float* rHead = rPtr + h * valDim;
+                float* rHead = (float*)rN + h * valDim;
                 VecZero(rHead, valDim);
                 for (int t = 0; t < attendLen; t++)
                     TensorComputePrimitives.ScaleAddF16(rHead, vHead + (attendStart + t) * valDim, scores[t], valDim);
             }
+
+            if (ShouldParallelizeHeads(numHeads, attendLen))
+                System.Threading.Tasks.Parallel.For(0, numHeads, Head);
+            else
+                for (int h = 0; h < numHeads; h++) Head(h);
         }
 
         private unsafe void AttentionDecodeCircular(Tensor q, Tensor kCache, Tensor vCache,
@@ -5520,18 +5543,18 @@ namespace TensorSharp.Models
             float* rPtr = GetFloatPtr(result);
             int groupSize = numHeads / numKVHeads;
 
-            float* scores = stackalloc float[attendLen];
-
             int startLogicalPos = currentPos + 1 - attendLen;
             if (startLogicalPos < 0) startLogicalPos = 0;
             int actualAttendLen = currentPos + 1 - startLogicalPos;
 
-            for (int h = 0; h < numHeads; h++)
+            nint qN = (nint)qPtr, kN = (nint)kPtr, vN = (nint)vPtr, rN = (nint)rPtr;
+            void Head(int h)
             {
-                float* qHead = qPtr + h * keyDim;
+                float* qHead = (float*)qN + h * keyDim;
                 int kvHead = h / groupSize;
-                float* kHead = kPtr + kvHead * cacheSize * keyDim;
-                float* vHead = vPtr + kvHead * cacheSize * valDim;
+                float* kHead = (float*)kN + kvHead * cacheSize * keyDim;
+                float* vHead = (float*)vN + kvHead * cacheSize * valDim;
+                float* scores = stackalloc float[actualAttendLen];
 
                 float maxScore = float.NegativeInfinity;
                 for (int t = 0; t < actualAttendLen; t++)
@@ -5554,7 +5577,7 @@ namespace TensorSharp.Models
                 for (int t = 0; t < actualAttendLen; t++)
                     scores[t] *= invSum;
 
-                float* rHead = rPtr + h * valDim;
+                float* rHead = (float*)rN + h * valDim;
                 VecZero(rHead, valDim);
                 for (int t = 0; t < actualAttendLen; t++)
                 {
@@ -5563,6 +5586,11 @@ namespace TensorSharp.Models
                     VecScaleAdd(rHead, vHead + cacheIdx * valDim, scores[t], valDim);
                 }
             }
+
+            if (ShouldParallelizeHeads(numHeads, actualAttendLen))
+                System.Threading.Tasks.Parallel.For(0, numHeads, Head);
+            else
+                for (int h = 0; h < numHeads; h++) Head(h);
         }
 
         private unsafe void AttentionDecodeCircularF16(Tensor q, Tensor kCache, Tensor vCache,
@@ -5575,18 +5603,18 @@ namespace TensorSharp.Models
             float* rPtr = GetFloatPtr(result);
             int groupSize = numHeads / numKVHeads;
 
-            float* scores = stackalloc float[attendLen];
-
             int startLogicalPos = currentPos + 1 - attendLen;
             if (startLogicalPos < 0) startLogicalPos = 0;
             int actualAttendLen = currentPos + 1 - startLogicalPos;
 
-            for (int h = 0; h < numHeads; h++)
+            nint qN = (nint)qPtr, kN = (nint)kPtr, vN = (nint)vPtr, rN = (nint)rPtr;
+            void Head(int h)
             {
-                float* qHead = qPtr + h * keyDim;
+                float* qHead = (float*)qN + h * keyDim;
                 int kvHead = h / groupSize;
-                ushort* kHead = kPtr + kvHead * cacheSize * keyDim;
-                ushort* vHead = vPtr + kvHead * cacheSize * valDim;
+                ushort* kHead = (ushort*)kN + kvHead * cacheSize * keyDim;
+                ushort* vHead = (ushort*)vN + kvHead * cacheSize * valDim;
+                float* scores = stackalloc float[actualAttendLen];
 
                 float maxScore = float.NegativeInfinity;
                 for (int t = 0; t < actualAttendLen; t++)
@@ -5609,7 +5637,7 @@ namespace TensorSharp.Models
                 for (int t = 0; t < actualAttendLen; t++)
                     scores[t] *= invSum;
 
-                float* rHead = rPtr + h * valDim;
+                float* rHead = (float*)rN + h * valDim;
                 VecZero(rHead, valDim);
                 for (int t = 0; t < actualAttendLen; t++)
                 {
@@ -5618,6 +5646,11 @@ namespace TensorSharp.Models
                     TensorComputePrimitives.ScaleAddF16(rHead, vHead + cacheIdx * valDim, scores[t], valDim);
                 }
             }
+
+            if (ShouldParallelizeHeads(numHeads, actualAttendLen))
+                System.Threading.Tasks.Parallel.For(0, numHeads, Head);
+            else
+                for (int h = 0; h < numHeads; h++) Head(h);
         }
 
         /// <summary>


### PR DESCRIPTION
When the CUDA PTX kernels can't be loaded (e.g. the consuming app lives
outside the TensorSharp source tree and the .ptx wasn't copied next to
it), every PTX-backed op silently falls back to the CPU path. Filling a
Float16 KV cache then threw 'CUDA CPU fallback does not support Float16
tensors' deep inside model initialization (issue #54).

- Add Float16 element get/set to CpuStorage and CudaStorage via
  System.Half/BitConverter, matching the existing conversion pattern.
- Allow Float16 in CudaCpuFallback.CopyElement so the round-trip fill
  fallback completes instead of throwing.
- Surface a single, actionable stderr warning when the PTX kernels are
  unavailable so the degraded CPU-fallback mode is visible.
- Probe the CUDA backend assembly directory (in addition to the app base
  directory) when locating the PTX, so consumers outside the repo tree
  still find the kernels.
- Add CPU tests for Float16 element access and Ops.Fill.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W8iPC8E2wUXrtqnqDzzCmu