### PR TITLE
docs(wiki): reflect auto-enabled GGML Vulkan backend and add ggml_vulkan examples

### DIFF
--- a/website/api-reference.html
+++ b/website/api-reference.html
@@ -135,7 +135,7 @@
       <tr><td><code>TS_MLX_* </code></td><td>MLX backend tuning: pipelined decode, mlock GGUF, fused KV write, batched MoE decode, memory caps.</td></tr>
       <tr><td><code>TENSORSHARP_MLX_LIBRARY / _LIBRARY_DIR</code></td><td>Override the search path for <code>libmlxc</code>.</td></tr>
       <tr><td><code>TENSORSHARP_GGML_NO_UPDATE / _GGML_GIT_REF</code></td><td>Skip / pin the ggml source clone on native builds.</td></tr>
-      <tr><td><code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN</code></td><td><code>ON</code> builds the native bridge with the GGML Vulkan backend (= build-script <code>--vulkan</code>).</td></tr>
+      <tr><td><code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN</code></td><td>Force the GGML Vulkan backend on/off at native build time (<code>ON</code>/<code>OFF</code> = build-script <code>--vulkan</code>/<code>--no-vulkan</code>). Auto-enabled when a Vulkan runtime is detected; an explicit choice sticks across rebuilds.</td></tr>
     </tbody>
   </table>
   </div>

--- a/website/api-reference_zh-cn.html
+++ b/website/api-reference_zh-cn.html
@@ -135,7 +135,7 @@
       <tr><td><code>TS_MLX_* </code></td><td>MLX 后端调参：流水线 decode、mlock GGUF、融合 KV 写、批量 MoE decode、内存上限。</td></tr>
       <tr><td><code>TENSORSHARP_MLX_LIBRARY / _LIBRARY_DIR</code></td><td>覆盖 <code>libmlxc</code> 的搜索路径。</td></tr>
       <tr><td><code>TENSORSHARP_GGML_NO_UPDATE / _GGML_GIT_REF</code></td><td>在原生构建时跳过 / 固定 ggml 源码克隆。</td></tr>
-      <tr><td><code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN</code></td><td><code>ON</code> 让原生桥接库带上 GGML Vulkan 后端（= 构建脚本 <code>--vulkan</code>）。</td></tr>
+      <tr><td><code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN</code></td><td>在原生构建时强制开启/关闭 GGML Vulkan 后端（<code>ON</code>/<code>OFF</code> = 构建脚本 <code>--vulkan</code>/<code>--no-vulkan</code>）。检测到 Vulkan 运行时时自动启用；显式选择会在重复构建中保持。</td></tr>
     </tbody>
   </table>
   </div>

--- a/website/assets/search-index-zh.js
+++ b/website/assets/search-index-zh.js
@@ -25,7 +25,7 @@ window.SEARCH_INDEX_ZH = [
   { t: "MLX 后端", p: "后端", u: "backends.html#mlx", s: "--backend mlx —— 基于 mlx-c 的 Apple Silicon GPU 路径。", k: "apple metal mlx-c 苹果" },
   { t: "直接 CUDA 后端", p: "后端", u: "backends.html#cuda", s: "--backend cuda —— 直接 CUDA Driver API + cuBLAS + PTX 内核（纯 C#）。", k: "nvidia ptx cublas 实验" },
   { t: "纯 C# CPU 后端", p: "后端", u: "backends.html#cpu", s: "--backend cpu —— 可移植、无原生依赖；ggml_cpu 提供原生 CPU 内核。", k: "可移植 调试 无 gpu" },
-  { t: "构建原生 GGML / MLX 库", p: "后端", u: "backends.html#native-build", s: "build-windows.ps1 / build-linux.sh / build-macos.sh、CUDA 架构检测，以及 --vulkan 选择启用（Windows 便携 Vulkan 工具链）。", k: "compile 编译 native cmake cuda arch vulkan glslc TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN" },
+  { t: "构建原生 GGML / MLX 库", p: "后端", u: "backends.html#native-build", s: "build-windows.ps1 / build-linux.sh / build-macos.sh、CUDA 架构检测，以及自动启用的 Vulkan（用 --no-vulkan 退出；Windows 便携 Vulkan 工具链）。", k: "compile 编译 native cmake cuda arch vulkan glslc no-vulkan TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN" },
 
   { t: "支持的模型", p: "模型", u: "models.html#table", s: "Gemma 3/4、Qwen 3 / 3.5 / 3.6、GPT OSS、Nemotron-H、Mistral 3、DiffusionGemma、Qwen-Image-Edit。", k: "architectures 架构 家族 gemma qwen gptoss nemotron mistral 图像 编辑" },
   { t: "模型下载（GGUF）", p: "模型", u: "models.html#downloads", s: "每个受支持架构的 Hugging Face 链接。", k: "huggingface 权重 下载" },

--- a/website/assets/search-index.js
+++ b/website/assets/search-index.js
@@ -25,7 +25,7 @@ window.SEARCH_INDEX = [
   { t: "MLX backend", p: "Backends", u: "backends.html#mlx", s: "--backend mlx — Apple Silicon GPU path built on mlx-c.", k: "apple metal mlx-c" },
   { t: "Direct CUDA backend", p: "Backends", u: "backends.html#cuda", s: "--backend cuda — direct CUDA Driver API + cuBLAS + PTX kernels (pure C#).", k: "nvidia ptx cublas experimental" },
   { t: "Pure C# CPU backend", p: "Backends", u: "backends.html#cpu", s: "--backend cpu — portable, no native dependencies; ggml_cpu for native CPU kernels.", k: "portable debugging no gpu" },
-  { t: "Build the native GGML / MLX libraries", p: "Backends", u: "backends.html#native-build", s: "build-windows.ps1 / build-linux.sh / build-macos.sh, CUDA arch detection, and the --vulkan opt-in (portable Vulkan toolchain on Windows).", k: "compile native cmake cuda arch vulkan glslc TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN" },
+  { t: "Build the native GGML / MLX libraries", p: "Backends", u: "backends.html#native-build", s: "build-windows.ps1 / build-linux.sh / build-macos.sh, CUDA arch detection, and auto-enabled Vulkan (opt out with --no-vulkan; portable Vulkan toolchain on Windows).", k: "compile native cmake cuda arch vulkan glslc no-vulkan TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN" },
 
   { t: "Supported models", p: "Models", u: "models.html#table", s: "Gemma 3/4, Qwen 3 / 3.5 / 3.6, GPT OSS, Nemotron-H, Mistral 3, DiffusionGemma, Qwen-Image-Edit.", k: "architectures families gemma qwen gptoss nemotron mistral image edit" },
   { t: "Model downloads (GGUF)", p: "Models", u: "models.html#downloads", s: "Hugging Face links for every supported architecture.", k: "huggingface weights download" },

--- a/website/backends.html
+++ b/website/backends.html
@@ -25,7 +25,7 @@
     <tbody>
       <tr><td><strong>Apple Silicon (Mac)</strong></td><td>GGML Metal</td><td><code>ggml_metal</code></td><td>Default on macOS. <code>mlx</code> is an alternative Apple-Silicon GPU path.</td></tr>
       <tr><td><strong>Windows / Linux + NVIDIA</strong></td><td>GGML CUDA</td><td><code>ggml_cuda</code></td><td>Most-tested NVIDIA path. <code>cuda</code> is the direct PTX/cuBLAS backend for experimentation.</td></tr>
-      <tr><td><strong>Windows / Linux + AMD / Intel / NVIDIA</strong></td><td>GGML Vulkan</td><td><code>ggml_vulkan</code></td><td>Vendor-neutral GPU path via ggml-vulkan (cooperative-matrix accelerated where the driver supports it). Opt in at native build time with <code>--vulkan</code>.</td></tr>
+      <tr><td><strong>Windows / Linux + AMD / Intel / NVIDIA</strong></td><td>GGML Vulkan</td><td><code>ggml_vulkan</code></td><td>Vendor-neutral GPU path via ggml-vulkan (cooperative-matrix accelerated where the driver supports it). Built automatically when the machine has a Vulkan runtime; opt out with <code>--no-vulkan</code>.</td></tr>
       <tr><td><strong>No GPU / portability / debugging</strong></td><td>Pure C# CPU</td><td><code>cpu</code></td><td>No native dependencies. For faster CPU inference use <code>ggml_cpu</code> (native kernels).</td></tr>
     </tbody>
   </table>
@@ -77,15 +77,15 @@
 # macOS (Metal)
 bash build-macos.sh
 
-# Linux — CPU only / with CUDA / with Vulkan
+# Linux — CPU only, force CUDA on, force Vulkan off
 bash build-linux.sh
 bash build-linux.sh --cuda
-bash build-linux.sh --vulkan</code></pre>
-  <pre data-lang="powershell"><code># Windows — CPU only / with CUDA / with Vulkan
+bash build-linux.sh --no-vulkan</code></pre>
+  <pre data-lang="powershell"><code># Windows — CPU only, force CUDA on, force Vulkan off
 .\build-windows.ps1 --no-cuda
 .\build-windows.ps1 --cuda
-.\build-windows.ps1 --vulkan</code></pre>
-  <p>The GGML Vulkan backend is opt-in (<code>--vulkan</code> or <code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN=ON</code>). On Windows, a <a href="https://vulkan.lunarg.com/" target="_blank" rel="noopener">LunarG Vulkan SDK</a> is used when installed; without one the build auto-provisions a portable toolchain (Vulkan-Headers, a <code>vulkan-1</code> import library generated from the system loader, glslc, SPIRV-Headers) into <code>ExternalProjects/vulkan-toolchain/</code> via <code>eng/fetch-vulkan-toolchain.ps1</code>. On Linux, install the distro Vulkan SDK packages first (e.g. <code>apt install libvulkan-dev glslc spirv-headers</code>). A GPU driver with Vulkan 1.3 support is required at run time.</p>
+.\build-windows.ps1 --no-vulkan</code></pre>
+  <p>The GGML Vulkan backend is <strong>enabled automatically</strong> when the machine has a Vulkan runtime (a loader such as <code>vulkan-1.dll</code> on Windows or <code>libvulkan.so.1</code> on Linux, shipped by every recent GPU driver); opt out with <code>--no-vulkan</code> (or <code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN=OFF</code>), and an explicit choice sticks across rebuilds via the CMake cache. On Windows, a <a href="https://vulkan.lunarg.com/" target="_blank" rel="noopener">LunarG Vulkan SDK</a> is used when installed; without one the build auto-provisions a portable toolchain (Vulkan-Headers, a <code>vulkan-1</code> import library generated from the system loader, glslc, SPIRV-Headers) into <code>ExternalProjects/vulkan-toolchain/</code> via <code>eng/fetch-vulkan-toolchain.ps1</code>. On Linux, distro dev packages are used when present (<code>apt install libvulkan-dev glslc spirv-headers</code>); otherwise the build auto-provisions the missing pieces (Vulkan-Headers, glslc from the shaderc CI prebuilts, SPIRV-Headers) via <code>eng/fetch-vulkan-toolchain.sh</code>. A GPU driver with Vulkan 1.3 support is required at run time.</p>
   <p>On Windows/Linux the script auto-detects the visible NVIDIA GPU compute capability and passes a narrow <code>CMAKE_CUDA_ARCHITECTURES</code> (e.g. <code>86-real</code> on an RTX 3080), which cuts CUDA build time substantially. Override it explicitly:</p>
   <pre data-lang="bash"><code>TENSORSHARP_GGML_NATIVE_CUDA_ARCHITECTURES='86-real;89-real' bash build-linux.sh --cuda
 bash build-linux.sh --cuda --cuda-arch='86-real;89-real'</code></pre>

--- a/website/backends_zh-cn.html
+++ b/website/backends_zh-cn.html
@@ -25,7 +25,7 @@
     <tbody>
       <tr><td><strong>Apple Silicon（Mac）</strong></td><td>GGML Metal</td><td><code>ggml_metal</code></td><td>macOS 默认。<code>mlx</code> 是另一条 Apple Silicon GPU 路径。</td></tr>
       <tr><td><strong>Windows / Linux + NVIDIA</strong></td><td>GGML CUDA</td><td><code>ggml_cuda</code></td><td>测试最充分的 NVIDIA 路径。<code>cuda</code> 是用于实验的直接 PTX/cuBLAS 后端。</td></tr>
-      <tr><td><strong>Windows / Linux + AMD / Intel / NVIDIA</strong></td><td>GGML Vulkan</td><td><code>ggml_vulkan</code></td><td>与厂商无关的 GPU 路径（ggml-vulkan，驱动支持时启用 cooperative-matrix 加速）。需在原生构建时用 <code>--vulkan</code> 选择启用。</td></tr>
+      <tr><td><strong>Windows / Linux + AMD / Intel / NVIDIA</strong></td><td>GGML Vulkan</td><td><code>ggml_vulkan</code></td><td>与厂商无关的 GPU 路径（ggml-vulkan，驱动支持时启用 cooperative-matrix 加速）。当主机存在 Vulkan 运行时时会在原生构建时自动启用；用 <code>--no-vulkan</code> 退出。</td></tr>
       <tr><td><strong>无 GPU / 可移植 / 调试</strong></td><td>纯 C# CPU</td><td><code>cpu</code></td><td>无原生依赖。要更快的 CPU 推理请用 <code>ggml_cpu</code>（原生内核）。</td></tr>
     </tbody>
   </table>
@@ -77,15 +77,15 @@
 # macOS（Metal）
 bash build-macos.sh
 
-# Linux —— 仅 CPU / 启用 CUDA / 启用 Vulkan
+# Linux —— 仅 CPU、强制启用 CUDA、强制关闭 Vulkan
 bash build-linux.sh
 bash build-linux.sh --cuda
-bash build-linux.sh --vulkan</code></pre>
-  <pre data-lang="powershell"><code># Windows —— 仅 CPU / 启用 CUDA / 启用 Vulkan
+bash build-linux.sh --no-vulkan</code></pre>
+  <pre data-lang="powershell"><code># Windows —— 仅 CPU、强制启用 CUDA、强制关闭 Vulkan
 .\build-windows.ps1 --no-cuda
 .\build-windows.ps1 --cuda
-.\build-windows.ps1 --vulkan</code></pre>
-  <p>GGML Vulkan 后端需选择启用（<code>--vulkan</code> 或 <code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN=ON</code>）。Windows 上已安装 <a href="https://vulkan.lunarg.com/" target="_blank" rel="noopener">LunarG Vulkan SDK</a> 时直接使用；未安装时构建会通过 <code>eng/fetch-vulkan-toolchain.ps1</code> 自动把便携工具链（Vulkan-Headers、由系统 loader 生成的 <code>vulkan-1</code> 导入库、glslc、SPIRV-Headers）准备到 <code>ExternalProjects/vulkan-toolchain/</code>。Linux 上请先安装发行版 Vulkan SDK 软件包（例如 <code>apt install libvulkan-dev glslc spirv-headers</code>）。运行时需要支持 Vulkan 1.3 的 GPU 驱动。</p>
+.\build-windows.ps1 --no-vulkan</code></pre>
+  <p>GGML Vulkan 后端<strong>会自动启用</strong>——当主机存在 Vulkan 运行时（Windows 上的 <code>vulkan-1.dll</code> 或 Linux 上的 <code>libvulkan.so.1</code> loader，近期 GPU 驱动均自带）时即启用；用 <code>--no-vulkan</code>（或 <code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN=OFF</code>）退出，且显式选择会经 CMake 缓存在重复构建中保持。Windows 上已安装 <a href="https://vulkan.lunarg.com/" target="_blank" rel="noopener">LunarG Vulkan SDK</a> 时直接使用；未安装时构建会通过 <code>eng/fetch-vulkan-toolchain.ps1</code> 自动把便携工具链（Vulkan-Headers、由系统 loader 生成的 <code>vulkan-1</code> 导入库、glslc、SPIRV-Headers）准备到 <code>ExternalProjects/vulkan-toolchain/</code>。Linux 上有发行版开发包时直接使用（<code>apt install libvulkan-dev glslc spirv-headers</code>）；否则构建会通过 <code>eng/fetch-vulkan-toolchain.sh</code> 自动补齐缺失部分（Vulkan-Headers、来自 shaderc CI 预编译的 glslc、SPIRV-Headers）。运行时需要支持 Vulkan 1.3 的 GPU 驱动。</p>
   <p>在 Windows/Linux 上，脚本会自动检测可见 NVIDIA GPU 的计算能力，并传入一个收窄的 <code>CMAKE_CUDA_ARCHITECTURES</code>（例如 RTX 3080 上的 <code>86-real</code>），从而大幅缩短 CUDA 构建时间。可显式覆盖：</p>
   <pre data-lang="bash"><code>TENSORSHARP_GGML_NATIVE_CUDA_ARCHITECTURES='86-real;89-real' bash build-linux.sh --cuda
 bash build-linux.sh --cuda --cuda-arch='86-real;89-real'</code></pre>

--- a/website/cli.html
+++ b/website/cli.html
@@ -29,6 +29,15 @@
 ./TensorSharp.Cli --model &lt;model.gguf&gt; --input prompt.txt --output result.txt \
     --max-tokens 200 --backend ggml_cuda
 
+# Text inference on any Vulkan GPU (AMD / Intel / NVIDIA)
+./TensorSharp.Cli --model &lt;model.gguf&gt; --input prompt.txt --output result.txt \
+    --max-tokens 200 --backend ggml_vulkan
+
+# Multi-GPU host: list the visible Vulkan devices, then pick one by index
+./TensorSharp.Cli --list-gpus
+./TensorSharp.Cli --model &lt;model.gguf&gt; --input prompt.txt \
+    --backend ggml_vulkan --gpu-device 1
+
 # Interactive turn-by-turn chat (REPL) with KV-cache reuse and slash commands
 ./TensorSharp.Cli --model &lt;model.gguf&gt; --backend ggml_metal --interactive
 ./TensorSharp.Cli --model &lt;model.gguf&gt; --backend ggml_metal -i \

--- a/website/cli_zh-cn.html
+++ b/website/cli_zh-cn.html
@@ -29,6 +29,15 @@
 ./TensorSharp.Cli --model &lt;model.gguf&gt; --input prompt.txt --output result.txt \
     --max-tokens 200 --backend ggml_cuda
 
+# 在任意 Vulkan GPU（AMD / Intel / NVIDIA）上的文本推理
+./TensorSharp.Cli --model &lt;model.gguf&gt; --input prompt.txt --output result.txt \
+    --max-tokens 200 --backend ggml_vulkan
+
+# 多 GPU 主机：先列出可见的 Vulkan 设备，再按索引选择
+./TensorSharp.Cli --list-gpus
+./TensorSharp.Cli --model &lt;model.gguf&gt; --input prompt.txt \
+    --backend ggml_vulkan --gpu-device 1
+
 # 交互式逐轮聊天（REPL），带 KV 缓存复用与斜杠命令
 ./TensorSharp.Cli --model &lt;model.gguf&gt; --backend ggml_metal --interactive
 ./TensorSharp.Cli --model &lt;model.gguf&gt; --backend ggml_metal -i \

--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -32,7 +32,7 @@
       <tr><td><strong>macOS</strong> (Metal)</td><td><code>ggml_metal</code> / <code>mlx</code></td><td>CMake 3.20+ and Xcode command-line tools. MLX additionally builds <code>libmlxc</code>.</td></tr>
       <tr><td><strong>Windows</strong></td><td><code>ggml_cuda</code> / <code>cuda</code></td><td>CMake 3.20+, Visual Studio 2022 C++ build tools, NVIDIA driver + CUDA Toolkit 12.x (with cuBLAS).</td></tr>
       <tr><td><strong>Linux</strong></td><td><code>ggml_cuda</code> / <code>cuda</code></td><td>CMake 3.20+, NVIDIA driver + CUDA Toolkit 12.x (with cuBLAS).</td></tr>
-      <tr><td><strong>Windows / Linux</strong> (any Vulkan GPU)</td><td><code>ggml_vulkan</code></td><td>Opt in with <code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN=ON</code> (or <code>--vulkan</code> on the build scripts). Windows auto-provisions a portable Vulkan toolchain when no SDK is installed; on Linux install e.g. <code>libvulkan-dev glslc spirv-headers</code>. Needs a Vulkan 1.3 driver at run time.</td></tr>
+      <tr><td><strong>Windows / Linux</strong> (any Vulkan GPU)</td><td><code>ggml_vulkan</code></td><td>Enabled automatically when the machine has a Vulkan runtime (loader installed); opt out with <code>--no-vulkan</code> (or <code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN=OFF</code>). Windows auto-provisions a portable Vulkan toolchain when no SDK is installed; on Linux install e.g. <code>libvulkan-dev glslc spirv-headers</code>. Needs a Vulkan 1.3 driver at run time.</td></tr>
       <tr><td>Any (CPU only)</td><td><code>cpu</code> / <code>ggml_cpu</code></td><td>Nothing beyond the .NET SDK.</td></tr>
     </tbody>
   </table>
@@ -68,7 +68,7 @@ dotnet build TensorSharp.Server/TensorSharp.Server.csproj -c Release</code></pre
 # Windows / Linux + NVIDIA
 ./TensorSharp.Cli --model gemma-4-E4B-it-Q8_0.gguf --input prompt.txt --backend ggml_cuda
 
-# Windows / Linux + AMD / Intel / NVIDIA (Vulkan-enabled native build)
+# Windows / Linux + AMD / Intel / NVIDIA (GGML Vulkan; built automatically when a Vulkan runtime is present)
 ./TensorSharp.Cli --model gemma-4-E4B-it-Q8_0.gguf --input prompt.txt --backend ggml_vulkan
 
 # Portable / debugging (no GPU)

--- a/website/getting-started_zh-cn.html
+++ b/website/getting-started_zh-cn.html
@@ -32,7 +32,7 @@
       <tr><td><strong>macOS</strong>（Metal）</td><td><code>ggml_metal</code> / <code>mlx</code></td><td>CMake 3.20+ 与 Xcode 命令行工具。MLX 还会额外构建 <code>libmlxc</code>。</td></tr>
       <tr><td><strong>Windows</strong></td><td><code>ggml_cuda</code> / <code>cuda</code></td><td>CMake 3.20+、Visual Studio 2022 C++ 构建工具、NVIDIA 驱动 + CUDA Toolkit 12.x（含 cuBLAS）。</td></tr>
       <tr><td><strong>Linux</strong></td><td><code>ggml_cuda</code> / <code>cuda</code></td><td>CMake 3.20+、NVIDIA 驱动 + CUDA Toolkit 12.x（含 cuBLAS）。</td></tr>
-      <tr><td><strong>Windows / Linux</strong>（任何 Vulkan GPU）</td><td><code>ggml_vulkan</code></td><td>用 <code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN=ON</code>（或构建脚本的 <code>--vulkan</code>）选择启用。Windows 上未安装 SDK 时会自动准备便携 Vulkan 工具链；Linux 上请安装如 <code>libvulkan-dev glslc spirv-headers</code>。运行时需要 Vulkan 1.3 驱动。</td></tr>
+      <tr><td><strong>Windows / Linux</strong>（任何 Vulkan GPU）</td><td><code>ggml_vulkan</code></td><td>当主机存在 Vulkan 运行时（loader 已安装）时自动启用；用 <code>--no-vulkan</code>（或 <code>TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN=OFF</code>）退出。Windows 上未安装 SDK 时会自动准备便携 Vulkan 工具链；Linux 上请安装如 <code>libvulkan-dev glslc spirv-headers</code>。运行时需要 Vulkan 1.3 驱动。</td></tr>
       <tr><td>任意（仅 CPU）</td><td><code>cpu</code> / <code>ggml_cpu</code></td><td>除 .NET SDK 外无需任何东西。</td></tr>
     </tbody>
   </table>
@@ -68,7 +68,7 @@ dotnet build TensorSharp.Server/TensorSharp.Server.csproj -c Release</code></pre
 # Windows / Linux + NVIDIA
 ./TensorSharp.Cli --model gemma-4-E4B-it-Q8_0.gguf --input prompt.txt --backend ggml_cuda
 
-# Windows / Linux + AMD / Intel / NVIDIA（启用 Vulkan 的原生构建）
+# Windows / Linux + AMD / Intel / NVIDIA（GGML Vulkan；存在 Vulkan 运行时时自动构建启用）
 ./TensorSharp.Cli --model gemma-4-E4B-it-Q8_0.gguf --input prompt.txt --backend ggml_vulkan
 
 # 可移植 / 调试（无 GPU）

--- a/website/server.html
+++ b/website/server.html
@@ -27,6 +27,10 @@
 # Linux + NVIDIA GPU
 ./TensorSharp.Server --model ./models/model.gguf --backend ggml_cuda
 
+# Any Vulkan GPU (AMD / Intel / NVIDIA) — pick the device on multi-GPU hosts
+./TensorSharp.Server --list-gpus
+./TensorSharp.Server --model ./models/model.gguf --backend ggml_vulkan --gpu-device 1
+
 # Multimodal models: host an explicit projector too
 ./TensorSharp.Server --model ./models/model.gguf --mmproj ./models/mmproj.gguf --backend ggml_cuda</code></pre>
   <p>The server starts on <strong><code>http://localhost:5000</code></strong>. Open it in a browser for the chat UI, or point an HTTP client at the <a href="http-api.html">compatibility endpoints</a>.</p>

--- a/website/server_zh-cn.html
+++ b/website/server_zh-cn.html
@@ -27,6 +27,10 @@
 # Linux + NVIDIA GPU
 ./TensorSharp.Server --model ./models/model.gguf --backend ggml_cuda
 
+# 任意 Vulkan GPU（AMD / Intel / NVIDIA）—— 多 GPU 主机上可选择设备
+./TensorSharp.Server --list-gpus
+./TensorSharp.Server --model ./models/model.gguf --backend ggml_vulkan --gpu-device 1
+
 # 多模态模型：同时托管显式投影器
 ./TensorSharp.Server --model ./models/model.gguf --mmproj ./models/mmproj.gguf --backend ggml_cuda</code></pre>
   <p>服务器在 <strong><code>http://localhost:5000</code></strong> 启动。用浏览器打开它即可使用聊天 UI，或将 HTTP 客户端指向<a href="http-api_zh-cn.html">兼容端点</a>。</p>


### PR DESCRIPTION
The wiki still described the GGML Vulkan backend as opt-in at native build
time (--vulkan). It is now enabled automatically whenever the machine has a
Vulkan runtime, with --no-vulkan / TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN=OFF
to opt out. Update the backends, getting-started, api-reference pages and the
search index (EN + zh-cn) to match, and add concrete ggml_vulkan run examples
(including --list-gpus / --gpu-device device selection) to the CLI and server
pages.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0141Z2XzwPUJTTP3bAKrLWSi