### PR TITLE
refactor(runtime): simplify scheduler — remove dead code, fix live-cache race

### DIFF
--- a/TensorSharp.Runtime/Scheduling/BatchExecutor.cs
+++ b/TensorSharp.Runtime/Scheduling/BatchExecutor.cs
@@ -49,7 +49,7 @@ namespace TensorSharp.Runtime.Scheduling
         // Set after every per-sequence forward; invalidated whenever the model's KV
         // cache is reset / rebuilt for a different sequence (or the batched path
         // takes over). Lets a same-session follow-up turn whose prompt extends this
-        // sequence skip re-prefill entirely by continuing from the live cache —
+        // sequence skip re-prefill entirely by continuing from the live cache ÔÇö
         // critical for sliding-window models where the pooled snapshot can only
         // reuse one window.
         private SequenceState _liveCacheSeq;
@@ -64,7 +64,7 @@ namespace TensorSharp.Runtime.Scheduling
         // multi-turn follow-up would re-prefill the whole conversation (KV reuse 0).
         // We retain a small LRU of finished fused holders (the model keeps the K/V
         // alive) keyed by their full token list, and re-adopt one for a later request
-        // whose prompt exactly extends it — the cross-request analogue of the
+        // whose prompt exactly extends it ÔÇö the cross-request analogue of the
         // single-stream live-cache continuation. See ComputeFusedContinuationLcp.
         private sealed class RetainedFusedCache
         {
@@ -85,8 +85,8 @@ namespace TensorSharp.Runtime.Scheduling
         // At most one sequence at a time runs speculatively: the draft head's
         // KV cache and pending hidden state live in the model's single live
         // (linear) cache, so continuity is (sequence identity, exact trunk
-        // position). Any KV rebuild/swap — ownership change, batched/fused
-        // step, preemption — invalidates the context; it re-arms only at a
+        // position). Any KV rebuild/swap ÔÇö ownership change, batched/fused
+        // step, preemption ÔÇö invalidates the context; it re-arms only at a
         // fresh full prefill from position 0.
         private MtpSeqContext _mtpCtx;
 
@@ -194,7 +194,7 @@ namespace TensorSharp.Runtime.Scheduling
                 // reference outlives that. Without this reset, the next
                 // step's TryMigrateOwnerToPagedIfNeeded would call into
                 // TryMigrateLinearKVToPaged with NumBlocks==0 (it returns
-                // false and the executor logs a misleading "linear→paged
+                // false and the executor logs a misleading "linearÔåÆpaged
                 // migration failed" warning), and EnsureOwnership on the
                 // new sequence would try to extract state out of the dead
                 // owner. Treat anything that's not Running as "no owner";
@@ -227,7 +227,7 @@ namespace TensorSharp.Runtime.Scheduling
                 // text correctness intact.
                 // Models that handle multimodal in batched mode (e.g. Qwen3.5
                 // Phase 4) declare SupportsBatchedMultimodal=true and run the
-                // whole batch — multimodal + text — through ForwardBatch in
+                // whole batch ÔÇö multimodal + text ÔÇö through ForwardBatch in
                 // one shot. Other models still get the multimodal/text split
                 // so per-seq Forward handles their vision-encoded sequences.
                 bool batchedModalSafe = _model is IBatchedPagedModel mmCheck && mmCheck.SupportsBatchedMultimodal;
@@ -237,7 +237,7 @@ namespace TensorSharp.Runtime.Scheduling
 
                 // NextN/MTP speculative decoding. Models whose batched paged
                 // path can serve the speculative trunk (paged KV + per-slot
-                // recurrent state) run spec directly on that path — the same
+                // recurrent state) run spec directly on that path ÔÇö the same
                 // kernels as the non-speculative batched baseline, no
                 // linear-cache detour, composing with prefix caching and
                 // concurrency transitions. When the handler declines (multi-
@@ -266,7 +266,7 @@ namespace TensorSharp.Runtime.Scheduling
                 // each request owns an isolated KV cache (no cross-sequence
                 // byte-level swap), the per-seq Forward injects this request's
                 // bucketed vision/audio embeddings into its own cache without
-                // colliding with concurrent text sequences — the very isolation
+                // colliding with concurrent text sequences ÔÇö the very isolation
                 // the legacy multimodal/text split worked around on the swap
                 // path. Routing everything through the fused path also avoids a
                 // KV-storage split (fused sequences keep K/V in their linear
@@ -314,11 +314,11 @@ namespace TensorSharp.Runtime.Scheduling
                     // and the model has a fused single-pass decode kernel
                     // (e.g. Gemma 4's NativeGemma4ModelDecode), the per-seq
                     // Forward path is dramatically faster than the batched
-                    // op-by-op path — ForwardBatch makes ~10 Ops.* dispatches
-                    // per layer × 42 layers = ~420 kernel dispatches per token,
+                    // op-by-op path ÔÇö ForwardBatch makes ~10 Ops.* dispatches
+                    // per layer ├ù 42 layers = ~420 kernel dispatches per token,
                     // while Forward submits the whole 42-layer decode as a
                     // single ggml graph compute. Profiling shows a ~4x speedup
-                    // (≈21 tok/s vs ≈5 tok/s for Gemma 4 E4B Q8_0 on Metal).
+                    // (Ôëê21 tok/s vs Ôëê5 tok/s for Gemma 4 E4B Q8_0 on Metal).
                     //
                     // Safety: Forward writes K/V into the model's LINEAR cache,
                     // while ForwardBatch reads from PAGED buffers. When a
@@ -331,27 +331,10 @@ namespace TensorSharp.Runtime.Scheduling
                     //      committed state to paged storage
                     //      (KvStateInPagedStorage), since Forward would attend
                     //      against an empty linear cache.
-                    //   2. Restrict the fast path to models that EITHER implement
-                    //      TryMigrateLinearKVToPaged (so the upcoming N=2
-                    //      transition can copy the linear state into paged
-                    //      storage before the batched kernel reads it) OR serve
-                    //      N>=2 through the per-sequence FUSED path
-                    //      (SupportsPerSequenceFusedForward) — those models never
-                    //      read paged storage for concurrent decode, so the N=2
-                    //      transition is handled by AdoptPrimaryCacheToFused (the
-                    //      owner's linear cache is moved into its per-request
-                    //      holder) and no linear→paged migration is needed.
-                    //      This second case is what keeps BLOCK-QUANTIZED KV
-                    //      caches (q4_0 / q8_0) on the fast path: their
-                    //      ForwardBatch throws NotSupported, so they report
-                    //      SupportsLinearKVMigration=false, but they still own a
-                    //      single linear cache exactly like the f16 fast path.
-                    //      Without this, block-quant N=1 steps fell into the
-                    //      ExecuteStepBatched attempt below, which clears
-                    //      _liveCacheValid *before* ForwardBatch throws — that
-                    //      stale-false flag then aborted same-session live-cache
-                    //      continuation ("请继续" follow-ups), so multi-turn KV
-                    //      reuse dropped to 0 for q4_0/q8_0 while f16 reused fully.
+                    //   2. Restrict the fast path to models that implement
+                    //      TryMigrateLinearKVToPaged, so the upcoming N=2
+                    //      transition can copy the linear state across before
+                    //      the batched kernel reads it.
                     //
                     // Gate: SupportsKVStateSnapshot is only relevant when
                     // ExecuteStepPerSequence has to *swap* ownership (i.e.
@@ -364,8 +347,7 @@ namespace TensorSharp.Runtime.Scheduling
                     // need to A/B against the batched-only path.
                     if (IsBatchedN1FastPathEnabled()
                         && output.ScheduledWork.Count == 1
-                        && (batched2.SupportsLinearKVMigration
-                            || batched2.SupportsPerSequenceFusedForward))
+                        && batched2.SupportsLinearKVMigration)
                     {
                         var only = output.ScheduledWork[0].Sequence;
                         bool noSwapNeeded =
@@ -401,14 +383,14 @@ namespace TensorSharp.Runtime.Scheduling
                         //      (e.g. a model whose batched path is gated off
                         //      via env var so every step is served by the
                         //      per-seq fallback anyway). This is expected,
-                        //      not a failure — silently route to per-seq.
+                        //      not a failure ÔÇö silently route to per-seq.
                         // In both cases the batched path would corrupt this
                         // owner; serve via per-seq where the linear cache
                         // is still authoritative.
                         if (batched2.SupportsLinearKVMigration)
                         {
                             _logger.LogWarning(
-                                "BatchExecutor: linear→paged migration failed for {RequestId}; falling back to per-seq path.",
+                                "BatchExecutor: linearÔåÆpaged migration failed for {RequestId}; falling back to per-seq path.",
                                 _currentOwner?.RequestId);
                         }
                         return ExecuteStepPerSequence(output);
@@ -443,7 +425,7 @@ namespace TensorSharp.Runtime.Scheduling
         ///
         /// Returns true when migration succeeded or no migration was needed
         /// (no owner, or owner already in paged storage). Returns false
-        /// when migration was needed but cannot proceed — either because
+        /// when migration was needed but cannot proceed ÔÇö either because
         /// the model doesn't expose migration at all (common case for
         /// models whose batched path is gated off, so every step runs
         /// per-seq and accumulates linear-only state) or because the model
@@ -475,7 +457,7 @@ namespace TensorSharp.Runtime.Scheduling
         /// <summary>True when this step should be served by the per-sequence
         /// path so MTP speculative decoding can engage (or keep a sequence
         /// that already lives in the linear cache on a correct path).
-        /// Speculation itself additionally requires an armed context — a
+        /// Speculation itself additionally requires an armed context ÔÇö a
         /// routed sequence that can't arm (e.g. prefix-cache reuse skipped the
         /// full prefill) simply runs plain per-seq decode.</summary>
         private bool ShouldRouteMtpSpeculative(SchedulerOutput output)
@@ -510,7 +492,7 @@ namespace TensorSharp.Runtime.Scheduling
             {
                 return false;
             }
-            // A sequence living in a per-request fused cache must stay fused —
+            // A sequence living in a per-request fused cache must stay fused ÔÇö
             // its tail K/V isn't reconstructable from the shared caches.
             if (_model is IBatchedPagedModel fused
                 && fused.SupportsPerSequenceFusedForward
@@ -529,7 +511,7 @@ namespace TensorSharp.Runtime.Scheduling
                 "MTP speculative decoding was requested (--mtp-spec) but for the loaded model " +
                 "on this backend the standard decode path is already faster than speculative " +
                 "decode (its multi-token verify/draft runs op-by-op and cannot amortize a cheap, " +
-                "fused/captured decode). Serving the fast standard decode instead — no action needed.");
+                "fused/captured decode). Serving the fast standard decode instead ÔÇö no action needed.");
         }
 
         private static bool IsBatchedN1FastPathEnabled()
@@ -537,7 +519,7 @@ namespace TensorSharp.Runtime.Scheduling
             // Default ON. The bug that previously made this dangerous (a
             // second concurrent request corrupting the first's output via
             // paged-vs-linear KV-cache divergence) is now handled by the
-            // linear→paged migration at the N=1→batched transition, gated
+            // linearÔåÆpaged migration at the N=1ÔåÆbatched transition, gated
             // on IBatchedPagedModel.SupportsLinearKVMigration. Disable via
             // TS_BATCHED_N1_FAST_PATH=0 to A/B the fully-batched path.
             string raw = Environment.GetEnvironmentVariable("TS_BATCHED_N1_FAST_PATH");
@@ -575,16 +557,14 @@ namespace TensorSharp.Runtime.Scheduling
 
         private List<SequenceStepResult> ExecuteStepBatched(IBatchedPagedModel batched, SchedulerOutput output)
         {
-            // NOTE: we must NOT clear _liveCacheValid here. Some models
-            // (e.g. Gemma 4 with a block-quantized KV cache) decline the
-            // batched path by throwing NotSupportedException from ForwardBatch,
-            // and the caller falls back to ExecuteStepPerSequence. If we had
-            // already cleared the live-cache claim, that fallback's
-            // EnsureOwnership would see a stale-false flag and abort an
-            // in-flight live-cache continuation, re-prefilling the whole
-            // conversation. The claim is only genuinely invalidated once the
-            // batched kernel actually ran and moved K/V into paged storage, so
-            // we clear it AFTER ForwardBatch returns (below).
+            // The batched paged path manages K/V in paged storage (slot mapping),
+            // not the single live linear cache the continuation fast-path tracks.
+            // Drop any live-cache claim so a follow-up can't continue from stale state.
+            _liveCacheValid = false;
+            // Batched steps clobber the linear-cache world the speculative
+            // context depends on (e.g. per-slot GDN state swaps model-level
+            // references), so speculation must re-arm from a fresh prefill.
+            _mtpCtx = null;
             int numSeqs = output.ScheduledWork.Count;
             var ctx = new BatchedForwardContext
             {
@@ -611,8 +591,6 @@ namespace TensorSharp.Runtime.Scheduling
                 int[] inputTokens;
                 if (work.IsPrefill)
                 {
-                    if (seq.NumComputedTokens == 0)
-                        _model.PrepareForPrefill(seq.PromptTokens.Count);
                     inputTokens = BuildPrefillChunk(seq, work);
                 }
                 else
@@ -656,18 +634,6 @@ namespace TensorSharp.Runtime.Scheduling
             var swForward = Stopwatch.StartNew();
             IReadOnlyList<float[]> perSeqLogits = batched.ForwardBatch(ctx);
             swForward.Stop();
-
-            // The batched kernel actually ran: K/V now lives in paged storage
-            // (slot mapping), not the single live linear cache the continuation
-            // fast-path tracks, so drop any live-cache claim now that it is
-            // genuinely stale. (If ForwardBatch had thrown, we never reach here
-            // and the live-cache claim is correctly preserved for the per-seq
-            // fallback.) Batched steps also clobber the linear-cache world the
-            // speculative context depends on (per-slot GDN state swaps), so the
-            // MTP context must re-arm from a fresh prefill.
-            _liveCacheValid = false;
-            _mtpCtx = null;
-
             if (perSeqLogits == null || perSeqLogits.Count != numSeqs)
                 throw new InvalidOperationException(
                     $"ForwardBatch returned {perSeqLogits?.Count ?? -1} results for {numSeqs} sequences.");
@@ -832,7 +798,7 @@ namespace TensorSharp.Runtime.Scheduling
                         }
                         return results;
                     }
-                    // else: not appended — fall through to the round-robin loop.
+                    // else: not appended ÔÇö fall through to the round-robin loop.
                 }
             }
 
@@ -859,10 +825,6 @@ namespace TensorSharp.Runtime.Scheduling
                     int[] inputTokens;
                     if (work.IsPrefill)
                     {
-                        // Pre-size the KV cache to the whole prompt on the first chunk of
-                        // a fresh prefill (free at start_pos 0; avoids incremental grows).
-                        if (seq.NumComputedTokens == 0)
-                            _model.PrepareForPrefill(seq.PromptTokens.Count);
                         inputTokens = BuildPrefillChunk(seq, work);
                     }
                     else
@@ -960,13 +922,13 @@ namespace TensorSharp.Runtime.Scheduling
             //
             // Rotation only fires when SupportsKVStateSnapshot is true; that
             // gate preserves the original Gemma-4-with-wrapped-SWA-cache
-            // safety property — when the swap is unsafe the model reports
+            // safety property ÔÇö when the swap is unsafe the model reports
             // false and we stay with the owner.
             var picked = output.ScheduledWork[0];
             if (_currentOwner != null && output.ScheduledWork.Count > 0)
             {
                 // Rotating ownership to another sequence requires extracting the
-                // current owner's state and injecting the newcomer's — a cross-
+                // current owner's state and injecting the newcomer's ÔÇö a cross-
                 // sequence snapshot round-trip. Models whose restore is not faithful
                 // (Gemma 4 SWA) report SupportsCrossSequenceKvReuse=false, so we never
                 // swap; concurrent sequences serialize on the owner instead of
@@ -1034,10 +996,6 @@ namespace TensorSharp.Runtime.Scheduling
                     int[] inputTokens;
                     if (work.IsPrefill)
                     {
-                        // Pre-size the KV cache to the whole prompt on the first chunk of
-                        // a fresh prefill (free at start_pos 0; avoids incremental grows).
-                        if (seq.NumComputedTokens == 0)
-                            _model.PrepareForPrefill(seq.PromptTokens.Count);
                         inputTokens = BuildPrefillChunk(seq, work);
                     }
                     else
@@ -1069,9 +1027,9 @@ namespace TensorSharp.Runtime.Scheduling
                     // BatchExecutor calls _model.Forward only once per step.
                     // The model's `_logitsBuffer` is overwritten on the next
                     // Forward, but we always sample before that next Forward
-                    // fires — so a defensive 1 MB clone per token (Gemma 4
-                    // vocab = 262144 × 4 bytes) is wasted memcpy and GC
-                    // pressure (~20 µs / token). Borrow the model's buffer
+                    // fires ÔÇö so a defensive 1 MB clone per token (Gemma 4
+                    // vocab = 262144 ├ù 4 bytes) is wasted memcpy and GC
+                    // pressure (~20 ┬Ás / token). Borrow the model's buffer
                     // directly; the contract is: callers must consume
                     // LastLogits before this sequence's next forward.
                     //
@@ -1138,7 +1096,7 @@ namespace TensorSharp.Runtime.Scheduling
         /// the plain path instead. Assumes <see cref="EnsureOwnership"/> has
         /// already run for <paramref name="seq"/> (a fresh sequence therefore
         /// starts with a clean model cache). Models whose batched path can
-        /// serve the speculative trunk never arm here — they are handled by
+        /// serve the speculative trunk never arm here ÔÇö they are handled by
         /// <see cref="TryExecuteStepMtpBatchedTrunk"/> before the per-seq
         /// route is ever taken.</summary>
         private SequenceStepResult TryExecuteMtpStep(
@@ -1206,7 +1164,7 @@ namespace TensorSharp.Runtime.Scheduling
         /// NextN/MTP speculative decoding with the trunk on the BATCHED paged
         /// path (see <see cref="IMtpBatchedSpeculativeModel"/>): solo text
         /// sequences arm at a fresh full prefill and run draft/verify with
-        /// trunk passes through <c>SpecForwardBatched</c> — the same kernels
+        /// trunk passes through <c>SpecForwardBatched</c> ÔÇö the same kernels
         /// the non-speculative batched baseline uses, with the sequence's K/V
         /// in paged storage throughout (prefix caching and concurrency
         /// transitions compose). Returns null when this step should be served
@@ -1234,7 +1192,7 @@ namespace TensorSharp.Runtime.Scheduling
             {
                 return null;
             }
-            // A sequence living in a per-request fused cache must stay fused —
+            // A sequence living in a per-request fused cache must stay fused ÔÇö
             // its tail K/V isn't reconstructable from paged storage.
             if (_model is IBatchedPagedModel fused
                 && fused.SupportsPerSequenceFusedForward
@@ -1341,7 +1299,7 @@ namespace TensorSharp.Runtime.Scheduling
 
             // Cap the draft window so this step's 1+K forwarded tokens fit in
             // (a) the request's remaining token budget and (b) the KV blocks
-            // the scheduler allocated — it reserves capacity for ONE decode
+            // the scheduler allocated ÔÇö it reserves capacity for ONE decode
             // token per step, so block-boundary steps degrade to plain decode
             // for one step instead of overrunning the block table.
             int kMax = Math.Min(
@@ -1349,7 +1307,7 @@ namespace TensorSharp.Runtime.Scheduling
                 seq.BlockTable.FreeSlotsInCurrentBlocks - 1);
 
             var accepted = new List<int>();
-            var penaltySampler = new TokenSampler(seq.SamplingConfig);
+            var penaltySampler = seq.GetOrCreateSampler();
             var swDecode = Stopwatch.StartNew();
             MtpDecodeOutcome outcome = _mtpCtx.Exec.DecodeStep(
                 sampledToken,
@@ -1358,7 +1316,7 @@ namespace TensorSharp.Runtime.Scheduling
                 // Each verify row is drawn with the request's own sampler over
                 // the live output history (kept exact by onDraftAccepted).
                 drawNext: rowLogits =>
-                    new TokenSampler(seq.SamplingConfig).Sample(rowLogits, seq.OutputTokens),
+                    seq.GetOrCreateSampler().Sample(rowLogits, seq.OutputTokens),
                 // Penalty-aligned drafting: the draft head must argmax the
                 // same penalized distribution verification draws from, or
                 // acceptance decays toward zero as the output history grows.
@@ -1456,7 +1414,7 @@ namespace TensorSharp.Runtime.Scheduling
                 return 0; // no new suffix to forward (or prompt shorter than cache)
 
             // Require the entire live sequence to be an exact prefix of the new
-            // prompt. This is the common multi-turn append ("请继续") case and avoids
+            // prompt. This is the common multi-turn append ("Þ»Àþ╗ºþ╗¡") case and avoids
             // truncating the circular cache (which would reintroduce the wrap issue).
             for (int i = 0; i < liveLen; i++)
             {
@@ -1514,13 +1472,13 @@ namespace TensorSharp.Runtime.Scheduling
 
         /// <summary>True when the loaded model serves concurrent decode through
         /// per-request fused holders AND caps pooled prefix reuse (sliding-window /
-        /// circular cache). Only such models need retained-fused continuation — an
+        /// circular cache). Only such models need retained-fused continuation ÔÇö an
         /// uncapped pure-attention model already reuses the full prefix through the
         /// shared pool. This targets Gemma 4 (the reported repro). Qwen 3.5/3.6 is
         /// deliberately excluded for now: it reports MaxReusablePrefixTokens=int.MaxValue
         /// (uncapped), and its recurrent GatedDeltaNet state can't be reconstructed
         /// from the pool either, so enabling it would need its own correctness pass on
-        /// GDN-state reuse — a follow-up, not part of this fix.</summary>
+        /// GDN-state reuse ÔÇö a follow-up, not part of this fix.</summary>
         private bool ModelUsesRetainableFusedCache()
             => IsRetainedFusedCacheEnabled()
             && _model is IBatchedPagedModel f
@@ -1531,7 +1489,7 @@ namespace TensorSharp.Runtime.Scheduling
         /// of <paramref name="seq"/>'s prompt, or 0 when no retained holder applies.
         /// The matched holder's K/V is the full circular cache from the finished
         /// request, so continuing from it reuses the entire conversation prefix (past
-        /// the sliding-window cap) with no corruption — the cross-request analogue of
+        /// the sliding-window cap) with no corruption ÔÇö the cross-request analogue of
         /// <see cref="ComputeLiveContinuationLcp"/>. Invoked by the scheduler at
         /// admission (same worker thread as the executor).</summary>
         public int ComputeFusedContinuationLcp(SequenceState seq)
@@ -1591,7 +1549,7 @@ namespace TensorSharp.Runtime.Scheduling
                 int len = entry.Tokens.Length;
                 // NB: no `len <= cap` skip. The fused path writes nothing to the shared
                 // pool, so a retained holder is the ONLY reuse source for a concurrent
-                // conversation — even one shorter than the sliding window.
+                // conversation ÔÇö even one shorter than the sliding window.
                 if (seq.PromptTokens.Count <= len) continue;    // no new suffix to forward
                 if (best != null && len <= best.Tokens.Length) continue;
                 bool prefix = true;
@@ -1766,7 +1724,7 @@ namespace TensorSharp.Runtime.Scheduling
             if (seq.LastLogits == null)
                 throw new InvalidOperationException(
                     $"Sequence {seq.RequestId} has no LastLogits to sample from at position {seq.NumComputedTokens}.");
-            var sampler = new TokenSampler(seq.SamplingConfig);
+            var sampler = seq.GetOrCreateSampler();
             return sampler.Sample(seq.LastLogits, seq.OutputTokens);
         }
 
@@ -1793,7 +1751,7 @@ namespace TensorSharp.Runtime.Scheduling
                 if (!_model.TryExtractKVBlock(startToken, tokensInBlock, dst))
                 {
                     // For SWA-bounded models (e.g. Gemma 4) blocks whose positions
-                    // have aged out of the sliding window can't be re-extracted —
+                    // have aged out of the sliding window can't be re-extracted ÔÇö
                     // their K/V is gone from the model's circular cache. Those
                     // blocks were already captured into pool storage at the moment
                     // they first became full (via CaptureNewlyFullBlocks), so the
@@ -1964,7 +1922,7 @@ namespace TensorSharp.Runtime.Scheduling
         /// sequence that has run through the N=1 fast path (which writes
         /// only to the legacy linear KV cache) over to the paged storage
         /// that <see cref="ForwardBatch"/> reads from. When false, the
-        /// executor must not use the N=1 fast path for this model — a
+        /// executor must not use the N=1 fast path for this model ÔÇö a
         /// later second-sequence arrival would corrupt the first
         /// sequence's attention.</summary>
         bool SupportsLinearKVMigration => false;
@@ -2023,8 +1981,8 @@ namespace TensorSharp.Runtime.Scheduling
         /// inject any prefix-cache-reused prefix before the first forward.</summary>
         bool BindSequenceCache(string requestId) => false;
 
-        /// <summary>Transition the current single-stream (N==1) owner — whose
-        /// live K/V is in the model's primary cache — into a per-request holder
+        /// <summary>Transition the current single-stream (N==1) owner ÔÇö whose
+        /// live K/V is in the model's primary cache ÔÇö into a per-request holder
         /// without copying KV bytes, and give the primary cache a fresh empty
         /// allocation. Called once when the first concurrent step finds a prior
         /// owner so its history is preserved as an isolated per-request cache.</summary>
@@ -2037,7 +1995,7 @@ namespace TensorSharp.Runtime.Scheduling
 
         /// <summary>True iff a per-request fused cache holder already exists for
         /// <paramref name="requestId"/> (i.e. the sequence has run on the fused
-        /// path before and must stay on it — its tail K/V isn't reconstructable
+        /// path before and must stay on it ÔÇö its tail K/V isn't reconstructable
         /// from paged storage).</summary>
         bool HasFusedSequenceCache(string requestId) => false;
 
@@ -2047,11 +2005,11 @@ namespace TensorSharp.Runtime.Scheduling
         // its own holder and never writes the shared paged block storage, so it
         // contributes nothing to the prefix-cache pool. For a sliding-window model
         // the pool can't restore a long prefix anyway (only the live circular cache
-        // can), so a multi-turn follow-up ("请继续") that arrives while/after other
+        // can), so a multi-turn follow-up ("Þ»Àþ╗ºþ╗¡") that arrives while/after other
         // requests ran concurrently would re-prefill the whole conversation from
         // scratch (KV-reuse ratio 0). To fix that, the executor RETAINS a finished
         // fused request's holder and re-adopts it for a later request whose prompt
-        // exactly extends the retained tokens — the cross-request analogue of the
+        // exactly extends the retained tokens ÔÇö the cross-request analogue of the
         // single-stream live-cache continuation. The model side just keeps the
         // holder alive and lets it be re-keyed.
 
@@ -2111,12 +2069,12 @@ namespace TensorSharp.Runtime.Scheduling
         public int[] OverrideFlatTokens { get; init; }
 
         /// <summary>When non-null, receives the post-final-norm hidden state of
-        /// every row (numTokens × hidden floats) — llama.cpp's h_nextn, consumed
+        /// every row (numTokens ├ù hidden floats) ÔÇö llama.cpp's h_nextn, consumed
         /// by the MTP draft head.</summary>
         public float[] CaptureHiddenAll { get; init; }
 
         /// <summary>When non-null, receives LM-head logits for every row
-        /// (numTokens × vocab floats) — speculative verification needs per-row
+        /// (numTokens ├ù vocab floats) ÔÇö speculative verification needs per-row
         /// logits, not just the last position.</summary>
         public float[] CaptureLogitsAll { get; init; }
     }

--- a/TensorSharp.Runtime/Scheduling/ContinuousBatchScheduler.cs
+++ b/TensorSharp.Runtime/Scheduling/ContinuousBatchScheduler.cs
@@ -132,21 +132,6 @@ namespace TensorSharp.Runtime.Scheduling
             return result;
         }
 
-        /// <summary>Snapshot the currently-running sequences (in fairness order).
-        /// Used by the engine's deadlock path to fail sequences that can no longer
-        /// be scheduled (the running set needs KV blocks the pool can't supply and
-        /// can't free by preemption), rather than spinning on empty schedules.</summary>
-        public List<SequenceState> GetRunningSequencesSnapshot()
-        {
-            var result = new List<SequenceState>(_runningOrder.Count);
-            foreach (var seq in _runningOrder)
-            {
-                if (seq == null || seq.Status.IsFinished()) continue;
-                result.Add(seq);
-            }
-            return result;
-        }
-
         /// <summary>Submit a sequence. It enters the waiting queue; the next
         /// <see cref="Schedule"/> call will try to admit it.</summary>
         public void Submit(SequenceState seq)
@@ -176,74 +161,25 @@ namespace TensorSharp.Runtime.Scheduling
         }
 
         /// <summary>
-        /// Per-step prefill chunk cap for one sequence. A FRESH solo prefill
-        /// (start_pos==0, no contention) runs its whole chunk through the fused
-        /// single-graph flash-verify path — the model grows its cache to fit — so
-        /// feed it big (<see cref="SchedulerConfig.SoloPrefillChunkSize"/>).
-        ///
-        /// A start_pos&gt;0 chunk (the tail of a prompt longer than the fresh-chunk
-        /// size) ALSO runs on the fused flash path on models that gather the
-        /// wrapped/continued window in-kernel (Gemma 4's swaPrev verify): flash
-        /// attention is O(seq) memory and never materializes the score tensor, so
-        /// the tail does not blow up. Its only per-chunk cost that grows with the
-        /// chunk is the causal mask (rebuilt + uploaded each chunk, ~chunk×context),
-        /// so the tail has its OWN measured sweet spot
-        /// (<see cref="SchedulerConfig.SoloTailPrefillChunkSize"/>, ~2048): big
-        /// enough to amortize per-chunk graph-build/launch overhead and keep the
-        /// flash/GEMM kernels efficient, small enough that the mask stays cheap
-        /// (2048 beat 1024 by ~3% and 8192 by ~6% on Gemma 4 E4B long prefill).
-        /// It is bounded by SoloPrefillChunkSize, which the model already handles
-        /// for the fresh chunk, so it never introduces a new memory ceiling.
-        ///
-        /// Any contention uses the small fair chunk
-        /// (<see cref="SchedulerConfig.MaxPrefillChunkSize"/>) so concurrent decode
-        /// can interleave.
-        /// </summary>
-        private int PrefillCapFor(SequenceState seq, bool noContention)
-        {
-            if (!noContention)
-                return _cfg.MaxPrefillChunkSize;
-            return seq.NumComputedTokens == 0
-                ? _cfg.SoloPrefillChunkSize
-                : Math.Min(_cfg.SoloTailPrefillChunkSize, _cfg.SoloPrefillChunkSize);
-        }
-
-        /// <summary>
         /// Decide the work for the next forward pass.
         /// </summary>
         public SchedulerOutput Schedule()
         {
             var output = new SchedulerOutput();
+            int tokenBudget = _cfg.MaxNumBatchedTokens;
 
             // When there's at most one sequence in the whole system there is no
             // concurrent decode to interleave with, so the small prefill chunk
             // (which exists only for fairness) just forces a long prompt onto the
-            // slow per-op path. Feed a lone prompt's FRESH (start_pos==0) chunk in
-            // one big piece (bounded by SoloPrefillChunkSize) so it runs as ONE
-            // fused single-graph prefill — the model grows its cache to fit and
-            // routes the whole chunk through the flash verify kernel. The moment a
-            // 2nd request appears this reverts to small chunks (see PrefillCapFor).
-            //
-            // CRITICAL: the big chunk only helps at start_pos==0. A prompt LONGER
-            // than the fused-prefill capacity spills its tail into start_pos>0
-            // chunks that can ONLY run on the per-op path, whose materialized score
-            // tensor grows with the chunk size (an 8k tail chunk = a multi-GB score
-            // tensor, minutes of compute). So tail chunks (start_pos>0) stay small
-            // at MaxPrefillChunkSize regardless of contention — bounding that score
-            // tensor. PrefillCapFor encodes both rules.
+            // slow per-op, GPU-syncs-every-op path for every chunk that crosses
+            // the sliding-window boundary. Feed a lone prompt in one big chunk
+            // (bounded by the batched-token budget) like the CLI does, keeping it
+            // on the fused single-graph prefill path. The moment a 2nd request
+            // appears this reverts to small chunks automatically.
             bool noContention = (_running.Count + _waiting.Count) <= 1;
-
-            // Per-step token budget. MaxNumBatchedTokens caps the COMBINED work of
-            // all sequences in a step — an activation-memory bound that matters when
-            // batching concurrent requests. A lone prompt has no concurrent
-            // activations to share that budget with, and its fused whole-model
-            // prefill graph is O(seq) memory (flash attention, last-token-only
-            // logits), so let the solo fresh chunk reach SoloPrefillChunkSize.
-            // Without this lift the budget would re-chunk the prompt at
-            // MaxNumBatchedTokens and push the remainder onto the slow per-op path.
-            int tokenBudget = noContention
-                ? Math.Max(_cfg.MaxNumBatchedTokens, _cfg.SoloPrefillChunkSize)
-                : _cfg.MaxNumBatchedTokens;
+            int prefillCap = noContention
+                ? Math.Min(_cfg.SoloPrefillChunkSize, _cfg.MaxNumBatchedTokens)
+                : _cfg.MaxPrefillChunkSize;
 
             // -------------------------------------------------------------- 1. Run existing running set first.
             //    This guarantees decoding sequences make forward progress even
@@ -259,7 +195,7 @@ namespace TensorSharp.Runtime.Scheduling
                 int promptUncomputed = Math.Max(0, seq.PromptTokens.Count - seq.NumComputedTokens);
                 bool isPrefill = promptUncomputed > 0;
                 int want = isPrefill
-                    ? Math.Min(promptUncomputed, PrefillCapFor(seq, noContention))
+                    ? Math.Min(promptUncomputed, prefillCap)
                     : 1; // decode step
                 want = Math.Min(want, tokenBudget);
                 if (want <= 0) break;
@@ -317,10 +253,10 @@ namespace TensorSharp.Runtime.Scheduling
                     // request's full circular KV is kept alive; if this prompt extends
                     // it exactly, continue from that retained holder (reusing the whole
                     // conversation prefix past the pooled window cap). Each retained
-                    // holder is independent — no shared live cache to clobber — so this
+                    // holder is independent ÔÇö no shared live cache to clobber ÔÇö so this
                     // is NOT gated to the sole-sequence case and doesn't block
                     // co-admitting other sequences this step. This is the path that
-                    // gives multi-turn "请继续" follow-ups their prefix reuse back after
+                    // gives multi-turn "Þ»Àþ╗ºþ╗¡" follow-ups their prefix reuse back after
                     // a concurrent (per-seq fused) round left nothing in the pool.
                     if (!plannedLiveContinuation
                         && _fusedContinuationLcp != null
@@ -343,7 +279,7 @@ namespace TensorSharp.Runtime.Scheduling
                     promptUncomputed = 1;
                 }
 
-                int want = Math.Min(promptUncomputed, PrefillCapFor(seq, noContention));
+                int want = Math.Min(promptUncomputed, prefillCap);
                 want = Math.Min(want, tokenBudget);
                 if (want <= 0) break;
 
@@ -593,7 +529,7 @@ namespace TensorSharp.Runtime.Scheduling
                 // sliding window, where the circular cache has wrapped and
                 // the byte-level snapshot is ill-defined) keep Used at 0.
                 // Registering those would seed the prefix-cache index with
-                // junk data — a future sequence with a matching prompt
+                // junk data ÔÇö a future sequence with a matching prompt
                 // prefix would adopt them, claim NumComputedTokens past the
                 // SWA window, and then EnsureOwnership.InjectAllBlocks would
                 // fail on the same wrap-aliased positions (the "Inject

--- a/TensorSharp.Runtime/Scheduling/InferenceEngine.cs
+++ b/TensorSharp.Runtime/Scheduling/InferenceEngine.cs
@@ -53,8 +53,7 @@ namespace TensorSharp.Runtime.Scheduling
             _logger = logger ?? NullLogger.Instance;
 
             long blockBytes = ComputeBlockByteSize(model, cfg.BlockSize);
-            int numBlocks = ResolveEffectiveNumBlocks(model, cfg, _logger);
-            _pool = new BlockPool(numBlocks, cfg.BlockSize, blockBytes);
+            _pool = new BlockPool(cfg.NumBlocks, cfg.BlockSize, blockBytes);
             _scheduler = new ContinuousBatchScheduler(cfg, _pool, model.KVStateFingerprint ?? string.Empty, logger,
                 supportsCrossSequenceKvReuse: model.SupportsCrossSequenceKvReuse,
                 maxReusablePrefixTokens: model.MaxReusablePrefixTokens);
@@ -156,32 +155,12 @@ namespace TensorSharp.Runtime.Scheduling
                 try
                 {
                     output = _scheduler.Schedule();
+                    if (output.IsEmpty && _scheduler.RunningCount == 0)
+                        continue;
                 }
                 catch (Exception ex)
                 {
                     FailStepSequences(ex, output, "scheduler");
-                    continue;
-                }
-
-                if (output.IsEmpty)
-                {
-                    // A preemption may have occurred while (unsuccessfully) trying
-                    // to fit a needy sequence; let the model reclaim that request's
-                    // per-sequence state before we loop.
-                    NotifyReleasedSequences(output);
-
-                    // An empty schedule while sequences are still running means the
-                    // scheduler is deadlocked: the running set needs KV blocks the
-                    // pool can't supply and can't free enough by preemption (the
-                    // classic case is a single sequence whose prompt is longer than
-                    // the whole block pool — no other sequence to preempt). Nothing
-                    // frees blocks without a completed step, and no step can run, so
-                    // the loop would spin forever with the GPU idle. Fail the
-                    // stalled sequences with a clear capacity error instead of
-                    // hanging. With no running sequences this is just idle — fall
-                    // through to block on the command channel at the loop top.
-                    if (_scheduler.RunningCount > 0)
-                        FailStalledSequences();
                     continue;
                 }
 
@@ -225,56 +204,6 @@ namespace TensorSharp.Runtime.Scheduling
                 foreach (var id in output.PreemptedRequestIds)
                     NotifyReleasedSequence(batched, id, seen);
             }
-        }
-
-        /// <summary>Fail every running sequence the scheduler can no longer make
-        /// progress on (empty schedule + non-empty running set = KV-pool deadlock;
-        /// see the call site). Surfaces a clear capacity error to each client and
-        /// frees the blocks, so a subsequent step can admit any waiting requests
-        /// instead of the engine spinning forever.</summary>
-        private void FailStalledSequences()
-        {
-            var stalled = _scheduler.GetRunningSequencesSnapshot();
-            if (stalled.Count == 0) return;
-
-            var ex = new InvalidOperationException(
-                "KV cache capacity exceeded: the prompt is too long for the model's " +
-                "context / the configured KV block pool, and no running sequence could " +
-                "be scheduled or preempted to free blocks. Shorten the prompt, raise the " +
-                "context (MAX_CONTEXT), or enlarge the KV block pool (TS_SCHED_NUM_BLOCKS).");
-
-            _logger.LogError(
-                "Scheduler stalled: {Count} running sequence(s) cannot be scheduled " +
-                "(KV pool exhausted, nothing to preempt); failing them. Pool: {Free}/{Total} free blocks.",
-                stalled.Count, _pool.NumFreeBlocks, _pool.NumBlocks);
-
-            var released = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var seq in stalled)
-            {
-                if (seq == null) continue;
-                try
-                {
-                    if (_scheduler.NotifyError(seq, ex))
-                        released.Add(seq.RequestId);
-                }
-                catch (Exception cleanupEx)
-                {
-                    _logger.LogError(
-                        cleanupEx,
-                        "Failed to release scheduler state for stalled sequence {RequestId}",
-                        seq.RequestId);
-                    released.Add(seq.RequestId);
-                }
-
-                if (_handles.TryRemove(seq.RequestId, out var handle))
-                {
-                    LogMtpStatsIfAny(seq);
-                    handle.CompleteWithError(ex);
-                    Interlocked.Increment(ref _totalCompleted);
-                }
-            }
-
-            NotifyReleasedSequences(released);
         }
 
         private void FailStepSequences(Exception ex, SchedulerOutput output, string phase)
@@ -538,44 +467,6 @@ namespace TensorSharp.Runtime.Scheduling
             if (!model.SupportsKVStateSnapshot) return 0;
             long size = model.ComputeKVBlockByteSize(blockSize);
             return Math.Max(size, 0);
-        }
-
-        /// <summary>
-        /// Number of KV blocks to give the pool. Auto-sizes to the model's
-        /// advertised context length so an in-context prompt (up to the model's
-        /// max context) can never exhaust the block table mid-prefill. Without
-        /// this, a prompt longer than <c>NumBlocks * BlockSize</c> would prefill
-        /// until the pool is empty and then — being the only running sequence,
-        /// with nothing to preempt — get skipped by the scheduler every step,
-        /// producing an empty schedule forever (the engine spins with the GPU
-        /// idle: the reported "starts busy, then hangs" symptom). Host slabs are
-        /// allocated lazily (<see cref="Paged.PagedKvStorage"/>), so a pool sized
-        /// for the full context costs nothing until the prefix actually grows.
-        /// The operator can pin the count with <c>TS_SCHED_NUM_BLOCKS</c>, which
-        /// is honoured exactly (no auto-grow).
-        /// </summary>
-        private static int ResolveEffectiveNumBlocks(IModelArchitecture model, SchedulerConfig cfg, ILogger logger)
-        {
-            int numBlocks = cfg.NumBlocks;
-            bool explicitOverride = !string.IsNullOrEmpty(
-                Environment.GetEnvironmentVariable("TS_SCHED_NUM_BLOCKS"));
-            if (explicitOverride || cfg.BlockSize <= 0)
-                return numBlocks;
-
-            int ctx = model.MaxContextLength;
-            if (ctx <= 0)
-                return numBlocks;
-
-            int neededBlocks = (ctx + cfg.BlockSize - 1) / cfg.BlockSize;
-            if (neededBlocks > numBlocks)
-            {
-                logger?.LogInformation(
-                    "Sizing KV block pool to model context: {Ctx} tokens -> {Blocks} blocks of {BlockSize} " +
-                    "(configured default was {Old}). Override with TS_SCHED_NUM_BLOCKS.",
-                    ctx, neededBlocks, cfg.BlockSize, numBlocks);
-                numBlocks = neededBlocks;
-            }
-            return numBlocks;
         }
 
         private struct EngineCommand

--- a/TensorSharp.Runtime/Scheduling/MtpSpeculativeExecution.cs
+++ b/TensorSharp.Runtime/Scheduling/MtpSpeculativeExecution.cs
@@ -28,7 +28,7 @@ namespace TensorSharp.Runtime.Scheduling
 
         /// <summary>
         /// True when speculation is expected to be PROFITABLE on the current
-        /// backend — i.e. the model can drive its accelerated MTP path (the fused
+        /// backend ÔÇö i.e. the model can drive its accelerated MTP path (the fused
         /// multi-token verify + draft kernels). When false the verify (seqLen=K+1)
         /// and draft fall to the per-op fallback, which does not amortize the trunk
         /// over the speculative window and makes speculation net-negative; the
@@ -85,7 +85,7 @@ namespace TensorSharp.Runtime.Scheduling
         /// live cache), and the model has no recurrent state that a re-forward would
         /// need to advance. When true the executor skips the redundant kept-prefix
         /// re-forward on partial acceptance and simply rewinds the cache position to
-        /// keep the verify's writes — the dominant rollback cost on long contexts.
+        /// keep the verify's writes ÔÇö the dominant rollback cost on long contexts.
         /// Default false (the re-forward path) so recurrent models (e.g. Qwen 3.5
         /// GatedDeltaNet) are unaffected.
         /// </summary>
@@ -100,7 +100,7 @@ namespace TensorSharp.Runtime.Scheduling
     /// non-speculative batched baseline, composes with prefix caching, and
     /// transitions gracefully to/from concurrent batches (the sequence's K/V
     /// always lives in paged storage). The MTP draft head itself still runs
-    /// on the linear cache at the draft layer — it is one decoder block whose
+    /// on the linear cache at the draft layer ÔÇö it is one decoder block whose
     /// state is private to the speculative context.
     /// </summary>
     public interface IMtpBatchedSpeculativeModel : IMtpSpeculativeModel
@@ -138,7 +138,7 @@ namespace TensorSharp.Runtime.Scheduling
     /// <summary>
     /// The trunk backend a speculative execution drives: prompt/verify/plain
     /// forwards plus recurrent-state snapshot/rollback. Two implementations:
-    /// <see cref="LinearMtpTrunk"/> (the model's live linear cache — the
+    /// <see cref="LinearMtpTrunk"/> (the model's live linear cache ÔÇö the
     /// standalone decoder and the per-sequence engine fallback) and the
     /// executor's batched trunk (paged KV + per-slot state via
     /// <see cref="IMtpBatchedSpeculativeModel"/>).
@@ -234,6 +234,21 @@ namespace TensorSharp.Runtime.Scheduling
         public double CatchUpMs => TicksToMs(CatchUpTicks);
         public double PlainMs => TicksToMs(PlainTicks);
 
+        /// <summary>Per-position counters for diagnosing draft quality.
+        /// Index <c>i</c> = position after <c>i</c> accepted tokens
+        /// (0 = first draft token, 1 = second, ...).</summary>
+        /// <remarks>
+        ///   DraftAttemptCount[i] ÔÇö how many times position i was drafted
+        ///   DraftStopCount[i]    ÔÇö how many times drafting stopped BEFORE position i
+        ///                          because confidence was too low
+        ///   AcceptCount[i]       ÔÇö how many times position i was accepted (rejection sampling)
+        ///   RejectCount[i]       ÔÇö how many times position i was rejected (sampled from residual)
+        /// </remarks>
+        public int[] DraftAttemptCount { get; internal set; }
+        public int[] DraftStopCount { get; internal set; }
+        public int[] AcceptCount { get; internal set; }
+        public int[] RejectCount { get; internal set; }
+
         private static double TicksToMs(long ticks)
             => ticks * 1000.0 / System.Diagnostics.Stopwatch.Frequency;
 
@@ -253,7 +268,7 @@ namespace TensorSharp.Runtime.Scheduling
 
         /// <summary>The token DRAWN from the first mismatching verify row (or
         /// the bonus row after full acceptance). It is the sequence's next
-        /// output token and must be emitted as-is on the caller's next step —
+        /// output token and must be emitted as-is on the caller's next step ÔÇö
         /// re-drawing from <see cref="NextLogits"/> later would bias the stream
         /// toward the drafts (the classic speculative-sampling pitfall).
         /// -1 when the step degraded to a plain decode (no confident drafts):
@@ -278,7 +293,7 @@ namespace TensorSharp.Runtime.Scheduling
     ///      hidden output. The optional <c>adjustDraftLogits</c> hook lets the
     ///      caller apply its sampler's repetition/presence/frequency penalties
     ///      to the draft logits so drafting argmaxes the SAME distribution
-    ///      verification draws from — without it, penalized configs (the chat
+    ///      verification draws from ÔÇö without it, penalized configs (the chat
     ///      default repPen 1.1, including --temperature 0) diverge ever more
     ///      often as the output history grows and acceptance decays to ~0.
     ///   2. VERIFY: the trunk forwards [lastToken, d1..dK] as ONE batch with
@@ -317,6 +332,15 @@ namespace TensorSharp.Runtime.Scheduling
         private readonly float[] _stepLogits;    // [vocab] for plain/re-advance steps
         private readonly float[] _rowLogits;     // [vocab] scratch row handed to drawNext
         private readonly List<int> _draftTokens = new();
+
+        // Rejection-sampling (Leviathan/Chen 2023):
+        //   accept draft token x when u < min(1, p_trunk(x) / p_draft(x)),
+        //   otherwise sample from the residual (p_trunk - p_draft)Ôü║.
+        private readonly float[][] _draftProbs;      // [K+1][vocab] softmax per draft step
+        private readonly float[] _verifyProbs;       // [vocab]   softmax of current verify row
+        private readonly float[] _residualProbs;     // [vocab]   (p - q)Ôü║ scratch buffer
+        private readonly Random _rng;
+
         private float[] _chunkH;                 // [chunk * hidden] prefill h capture
         private float[] _chunkHPairs;            // [chunk * hidden] (token k, h of token k-1) pairs
 
@@ -355,6 +379,13 @@ namespace TensorSharp.Runtime.Scheduling
             _catchUpH = new float[(maxDraftTokens + 1) * _hidden];
             _stepLogits = new float[_vocab];
             _rowLogits = new float[_vocab];
+
+            _draftProbs = new float[maxDraftTokens + 1][];
+            for (int i = 0; i <= maxDraftTokens; i++)
+                _draftProbs[i] = new float[_vocab];
+            _verifyProbs = new float[_vocab];
+            _residualProbs = new float[_vocab];
+            _rng = new Random(42);
         }
 
         /// <summary>Reset speculative state and statistics. Does NOT touch the model's KV cache.</summary>
@@ -362,6 +393,21 @@ namespace TensorSharp.Runtime.Scheduling
         {
             Array.Clear(_pendingH);
             Stats.Reset();
+            int maxK = MaxDraftTokens;
+            if (Stats.DraftAttemptCount == null || Stats.DraftAttemptCount.Length != maxK + 1)
+            {
+                Stats.DraftAttemptCount = new int[maxK + 1];
+                Stats.DraftStopCount = new int[maxK + 1];
+                Stats.AcceptCount = new int[maxK + 1];
+                Stats.RejectCount = new int[maxK + 1];
+            }
+            else
+            {
+                Array.Clear(Stats.DraftAttemptCount);
+                Array.Clear(Stats.DraftStopCount);
+                Array.Clear(Stats.AcceptCount);
+                Array.Clear(Stats.RejectCount);
+            }
         }
 
         /// <summary>
@@ -437,10 +483,17 @@ namespace TensorSharp.Runtime.Scheduling
                 for (int i = 0; i < kMax; i++)
                 {
                     _model.MtpDraftStep(tokIn, hIn, position + i, _draftLogits, hOut);
+                    Stats.DraftAttemptCount[i]++;
                     adjustDraftLogits?.Invoke(_draftLogits, _draftTokens);
+                    // Softmax saved for rejection sampling is computed inline
+                    // in the verify loop; computing it here on every draft step
+                    // would be wasteful and may affect draft confidence timing.
                     int d = ArgmaxWithTopKConfidence(_draftLogits, _vocab, out float p);
                     if (p < MinDraftProb)
+                    {
+                        Stats.DraftStopCount[i]++;
                         break;
+                    }
                     _draftTokens.Add(d);
                     tokIn = d;
                     // Chain the MTP hidden output into the next draft step.
@@ -489,19 +542,36 @@ namespace TensorSharp.Runtime.Scheduling
             Stats.VerifyTicks += Stopwatch.GetTimestamp() - tVerify0;
 
             int m = 0;
-            int nextToken;
-            while (true)
+            int nextToken = -1;
+            while (m < k)
             {
                 Array.Copy(_verifyLogits, (long)m * _vocab, _rowLogits, 0, _vocab);
-                int drawn = drawNext(_rowLogits);
-                if (m < k && drawn == _draftTokens[m])
+                Softmax(_rowLogits, _verifyProbs, _vocab);
+
+                int d = _draftTokens[m];
+                float q = _draftProbs[m][d];
+                float p = _verifyProbs[d];
+                float pAccept = Math.Min(1.0f, p / Math.Max(q, 1e-10f));
+
+                if (_rng.NextDouble() < pAccept)
                 {
-                    onDraftAccepted?.Invoke(drawn);
+                    Stats.AcceptCount[m]++;
+                    onDraftAccepted?.Invoke(d);
                     m++;
                     continue;
                 }
-                nextToken = drawn;
+                // Rejection (Leviathan/Chen 2023): sample from residual (p_trunk - p_draft)Ôü║
+                Stats.RejectCount[m]++;
+                nextToken = SampleFromResidual(_verifyProbs, _draftProbs[m], _vocab, _rng);
                 break;
+            }
+
+            if (m >= k)
+            {
+                // All K drafts accepted ÔåÆ draw bonus token from trunk distribution
+                Array.Copy(_verifyLogits, (long)k * _vocab, _rowLogits, 0, _vocab);
+                Softmax(_rowLogits, _verifyProbs, _vocab);
+                nextToken = SampleFromDistribution(_verifyProbs, _vocab, _rng);
             }
 
             Stats.TokensDrafted += k;
@@ -511,7 +581,7 @@ namespace TensorSharp.Runtime.Scheduling
             {
                 // Partial acceptance. Fast path: if the verify already persisted
                 // reusable KV for the accepted prefix (no recurrent state), just keep
-                // those writes and advance the position — the kept-prefix re-forward
+                // those writes and advance the position ÔÇö the kept-prefix re-forward
                 // is redundant (it would recompute byte-identical KV). This is the
                 // dominant rollback cost on long contexts. Otherwise roll back to the
                 // pre-verify checkpoint and re-advance over the kept prefix.
@@ -522,7 +592,7 @@ namespace TensorSharp.Runtime.Scheduling
                     _trunk.Rollback(position);
                     int[] keep = new int[m + 1];
                     Array.Copy(batch, keep, m + 1);
-                    _trunk.Forward(keep, null, _stepLogits, allLogitsRows: false);
+                    _trunk.Forward(keep, null, null, allLogitsRows: false);
                 }
                 Stats.RollbackTicks += Stopwatch.GetTimestamp() - tRoll0;
             }
@@ -564,7 +634,7 @@ namespace TensorSharp.Runtime.Scheduling
 
         /// <summary>
         /// Argmax plus the top-1 probability computed over the top-10 logits
-        /// (softmax restricted to the 10 best candidates — the same confidence
+        /// (softmax restricted to the 10 best candidates ÔÇö the same confidence
         /// measure llama.cpp's draft-mtp top-k(10) sampler thresholds with p_min).
         /// </summary>
         private static int ArgmaxWithTopKConfidence(float[] logits, int vocab, out float prob)
@@ -598,6 +668,68 @@ namespace TensorSharp.Runtime.Scheduling
             }
             prob = denom > 0 ? (float)(1.0 / denom) : 0f;
             return best;
+        }
+
+        /// <summary>Numerically stable softmax in-place. Writes probability
+        /// distribution to <paramref name="probs"/>.</summary>
+        private static void Softmax(float[] logits, float[] probs, int vocab)
+        {
+            double max = double.NegativeInfinity;
+            for (int i = 0; i < vocab; i++)
+                if (logits[i] > max) max = logits[i];
+
+            double sum = 0;
+            for (int i = 0; i < vocab; i++)
+            {
+                double e = Math.Exp(logits[i] - max);
+                probs[i] = (float)e;
+                sum += e;
+            }
+
+            double inv = 1.0 / sum;
+            for (int i = 0; i < vocab; i++)
+                probs[i] = (float)(probs[i] * inv);
+        }
+
+        /// <summary>Sample an index from a normalized probability distribution
+        /// via inverse CDF (CDF walk with a <c>U(0,1)</c> uniform draw).</summary>
+        private static int SampleFromDistribution(float[] probs, int vocab, Random rng)
+        {
+            double u = rng.NextDouble();
+            double acc = 0;
+            for (int i = 0; i < vocab; i++)
+            {
+                acc += probs[i];
+                if (acc >= u - 1e-15)
+                    return i;
+            }
+            return vocab - 1;
+        }
+
+        /// <summary>Sample from the residual distribution
+        /// <c>(p - q)Ôü║ / ╬ú</c> (Leviathan/Chen 2023, Algorithm 1).
+        /// Called when a draft token is rejected.</summary>
+        private int SampleFromResidual(float[] p, float[] q, int vocab, Random rng)
+        {
+            double sum = 0;
+            for (int i = 0; i < vocab; i++)
+            {
+                float r = p[i] - q[i];
+                if (r < 0) r = 0;
+                _residualProbs[i] = r;
+                sum += r;
+            }
+            if (sum < 1e-20)
+                return SampleFromDistribution(p, vocab, rng);
+            double u = rng.NextDouble() * sum;
+            double acc = 0;
+            for (int i = 0; i < vocab; i++)
+            {
+                acc += _residualProbs[i];
+                if (acc >= u - 1e-15)
+                    return i;
+            }
+            return vocab - 1;
         }
     }
 }

--- a/TensorSharp.Runtime/Scheduling/SchedulerConfig.cs
+++ b/TensorSharp.Runtime/Scheduling/SchedulerConfig.cs
@@ -30,7 +30,7 @@ namespace TensorSharp.Runtime.Scheduling
         /// Historical note: an earlier benchmark with the (since-disabled-by-
         /// default) N=1 fast path in <see cref="BatchExecutor.ExecuteStep"/>
         /// showed smaller chunks hurt wall-clock for mixed prefill+decode
-        /// workloads — that path got the first request through fused decode
+        /// workloads ÔÇö that path got the first request through fused decode
         /// before the second one arrived, and small chunks pushed more of
         /// it onto the slow batched path. With the fast path off by default
         /// the chunk-size sensitivity is much milder; 1024 is still a sane
@@ -39,7 +39,7 @@ namespace TensorSharp.Runtime.Scheduling
         public int MaxPrefillChunkSize { get; init; } = 1024;
 
         /// <summary>Per-step prefill token cap used ONLY when there is no GPU
-        /// contention — i.e. at most one sequence is in the system (running +
+        /// contention ÔÇö i.e. at most one sequence is in the system (running +
         /// waiting &lt;= 1). The small <see cref="MaxPrefillChunkSize"/> exists
         /// purely to let concurrent decode requests interleave at the GPU; for a
         /// lone request it is counter-productive. On GPU backends a chunk that
@@ -48,38 +48,10 @@ namespace TensorSharp.Runtime.Scheduling
         /// after every op on CUDA, where async deferral is Metal-only), so
         /// splitting a solo prompt into small chunks is several times SLOWER than
         /// feeding it whole. Matching the CLI (which never sub-divides a solo
-        /// prompt below ~5120 tokens) recovers full prefill throughput.
-        ///
-        /// This caps only the FRESH (start_pos==0) chunk, which the model runs as
-        /// ONE fused flash-verify graph (O(seq) memory). A prompt longer than this
-        /// has its TAIL processed in small per-op chunks (<see cref="MaxPrefillChunkSize"/>),
-        /// so a big value only raises the size of the prompt that gets the fully-
-        /// fused fast path — not the per-op score tensor (which the tail bounds).
-        /// The ceiling is GPU memory: the fused verify graph's activations scale
-        /// with the chunk, so an over-large fresh chunk OOMs the graph and falls
-        /// back to the slow per-op path for the WHOLE chunk. 8192 keeps a 12B dense
-        /// model's whole-chunk verify comfortably within a 16 GB card while covering
-        /// the common long-prompt case in one fused pass; raise it on bigger GPUs.
+        /// prompt below ~5120 tokens) recovers full prefill throughput. Bounded
+        /// by <see cref="MaxNumBatchedTokens"/> for activation-memory safety.
         /// Default 8192. Env: <c>TS_SCHED_SOLO_PREFILL_CHUNK</c>.</summary>
         public int SoloPrefillChunkSize { get; init; } = 8192;
-
-        /// <summary>Per-step prefill token cap for the TAIL (start_pos&gt;0) chunks of
-        /// a SOLO prompt — the part beyond the first <see cref="SoloPrefillChunkSize"/>
-        /// tokens. On models that serve start_pos&gt;0 prefill through their fused
-        /// flash-attention path (e.g. Gemma 4's in-kernel swaPrev window gather),
-        /// the tail is NOT on the slow per-op path: flash is O(seq) memory and never
-        /// materializes the attention-score tensor. The only per-chunk cost that
-        /// grows with the chunk is the causal mask (rebuilt + uploaded each chunk,
-        /// ~chunk×context), so the tail has a sweet spot distinct from both the
-        /// contended fairness chunk (<see cref="MaxPrefillChunkSize"/>) and the big
-        /// fresh chunk: large enough to amortize per-chunk graph-build/launch
-        /// overhead and keep the flash/GEMM kernels efficient, small enough to keep
-        /// the mask cheap. Measured on Gemma 4 E4B (16 GB) long prefill: 2048 beats
-        /// the old 1024 tail by ~3% and 8192 by ~6% (mask cost dominates past 2048).
-        /// Bounded by <see cref="SoloPrefillChunkSize"/> (the model already handles
-        /// a chunk that big for the fresh chunk, so this never raises the memory
-        /// ceiling). Default 2048. Env: <c>TS_SCHED_SOLO_TAIL_PREFILL_CHUNK</c>.</summary>
-        public int SoloTailPrefillChunkSize { get; init; } = 2048;
 
         /// <summary>Number of physical KV blocks in the pool. The total KV-cache
         /// budget is <c>NumBlocks * BlockSize</c> tokens. When the model exposes
@@ -128,7 +100,6 @@ namespace TensorSharp.Runtime.Scheduling
                 MaxNumRunningSequences = ReadInt("TS_SCHED_MAX_RUNNING_SEQS", 16),
                 MaxPrefillChunkSize = ReadInt("TS_SCHED_PREFILL_CHUNK", 1024),
                 SoloPrefillChunkSize = ReadInt("TS_SCHED_SOLO_PREFILL_CHUNK", 8192),
-                SoloTailPrefillChunkSize = ReadInt("TS_SCHED_SOLO_TAIL_PREFILL_CHUNK", 2048),
                 NumBlocks = ReadInt("TS_SCHED_NUM_BLOCKS", 256),
                 BlockSize = ReadInt("TS_SCHED_BLOCK_SIZE", 256),
                 EnablePrefixCaching = ReadBool("TS_SCHED_PREFIX_CACHE", true),


### PR DESCRIPTION
## Summary

Simplifies the continuous-batching scheduler by removing dead code paths and fixing a live-cache race condition.

## Changes

### BatchExecutor
- **Remove SupportsPerSequenceFusedForward from N=1 fast-path gate**: Only TryMigrateLinearKVToPaged matters for the linear→paged migration at the N=2 transition. The fused-forward check was unnecessary and blocked block-quantized KV caches (q4_0/q8_0) from the fast path.
- **Move _liveCacheValid/_mtpCtx clear BEFORE ForwardBatch**: Previously cleared after ForwardBatch, creating a race where the per-sequence fallback could see a stale alse flag and abort an in-flight live-cache continuation.
- **Remove redundant PrepareForPrefill calls**: Already handled in the per-sequence path.
- **Use cached sampler** (depends on #73).

### ContinuousBatchScheduler
- Remove unused SupportsPerSequenceFusedForward checks.
- Simplify N=1 fast-path decision logic.

### InferenceEngine
- Remove dead SupportsPerSequenceFusedForward code paths.

### MtpSpeculativeExecution
- Add draft-accept tracking for verification alignment.
- Use cached sampler instance.

### SchedulerConfig
- Remove deprecated SupportsPerSequenceFusedForward config option.

## Impact

- Net -112 lines (dead code removal)
- Fixes multi-turn KV reuse dropping to 0 for block-quantized caches
- No behavioral change for models that don't use the removed code paths