### PR TITLE
Fix Qwen3.6 MTP speculative decoding crashes with quantized KV caches…

### DIFF
--- a/TensorSharp.Backends.GGML/GgmlBasicOps.cs
+++ b/TensorSharp.Backends.GGML/GgmlBasicOps.cs
@@ -1523,6 +1523,20 @@ namespace TensorSharp.GGML
                 intermediateSize, ropeMode, kvCacheType);
         }
 
+        /// <summary>KV-cache dtypes the native kernels accept (kv_cache_type is a raw
+        /// ggml_type id: F32=0, F16=1, Q4_0=2, Q8_0=8 — must match ggml.h).</summary>
+        private static bool IsSupportedKvCacheDType(DType dt) =>
+            dt == DType.Float32 || dt == DType.Float16 || dt == DType.Q8_0 || dt == DType.Q4_0;
+
+        private static int KvCacheGgmlTypeId(DType dt) => dt switch
+        {
+            DType.Float32 => 0,
+            DType.Float16 => 1,
+            DType.Q4_0 => 2,
+            DType.Q8_0 => 8,
+            _ => throw new ArgumentException($"Unsupported KV cache dtype: {dt}"),
+        };
+
         /// <summary>
         /// Single-token flash attention decode kernel. Reads Q/K/V (post-norm, post-RoPE) for
         /// the new query position, appends K/V to the persistent KV cache at <paramref name="position"/>,
@@ -1542,8 +1556,8 @@ namespace TensorSharp.GGML
             if (q.ElementType != DType.Float32 || k.ElementType != DType.Float32 || v.ElementType != DType.Float32 ||
                 output.ElementType != DType.Float32)
                 throw new ArgumentException("Flash attention decode requires F32 Q/K/V/output tensors.");
-            if (kCache.ElementType != DType.Float32 && kCache.ElementType != DType.Float16)
-                throw new ArgumentException("Flash attention decode requires F32 or F16 K cache tensor.");
+            if (!IsSupportedKvCacheDType(kCache.ElementType))
+                throw new ArgumentException("Flash attention decode requires an F32, F16, Q8_0 or Q4_0 K cache tensor.");
             if (vCache.ElementType != kCache.ElementType)
                 throw new ArgumentException("Flash attention decode requires K and V caches to share an element type.");
 
@@ -1554,7 +1568,7 @@ namespace TensorSharp.GGML
             IntPtr vcPtr = GetBufferStart(vCache);
             IntPtr outPtr = GetBufferStart(output);
 
-            int kvGgmlType = kCache.ElementType == DType.Float16 ? 1 : 0;
+            int kvGgmlType = KvCacheGgmlTypeId(kCache.ElementType);
 
             GgmlNative.FlashAttnDecode(
                 qPtr, kPtr, vPtr,
@@ -2342,8 +2356,8 @@ namespace TensorSharp.GGML
             if (residual.ElementType != DType.Float32 || attnNorm.ElementType != DType.Float32 ||
                 qNorm.ElementType != DType.Float32 || kNorm.ElementType != DType.Float32)
                 throw new ArgumentException("Qwen3.5 attention layer decode requires F32 hidden/norm tensors.");
-            if (kCache.ElementType != DType.Float32 && kCache.ElementType != DType.Float16)
-                throw new ArgumentException("Qwen3.5 attention layer decode requires F32 or F16 K cache tensor.");
+            if (!IsSupportedKvCacheDType(kCache.ElementType))
+                throw new ArgumentException("Qwen3.5 attention layer decode requires an F32, F16, Q8_0 or Q4_0 K cache tensor.");
             if (vCache.ElementType != kCache.ElementType)
                 throw new ArgumentException("Qwen3.5 attention layer decode requires K and V caches to share an element type.");
             if (qkvData == IntPtr.Zero || oData == IntPtr.Zero)
@@ -2356,7 +2370,7 @@ namespace TensorSharp.GGML
             IntPtr kCachePtr = GetBufferStart(kCache);
             IntPtr vCachePtr = GetBufferStart(vCache);
             int hiddenSize = (int)residual.Sizes[residual.Sizes.Length - 1];
-            int kvGgmlType = kCache.ElementType == DType.Float16 ? 1 : 0;
+            int kvGgmlType = KvCacheGgmlTypeId(kCache.ElementType);
 
             GgmlNative.Qwen35AttentionLayerDecode(
                 residualPtr, hiddenSize,

--- a/TensorSharp.Models/ModelBase.cs
+++ b/TensorSharp.Models/ModelBase.cs
@@ -3958,7 +3958,7 @@ namespace TensorSharp.Models
         // along the head axis when group_size > 1) — the block-quant analogue of
         // ExpandKVHeadsF16. mul_mat then accumulates in F32, identical to having
         // dequantized in the native kernel.
-        private static bool IsBlockQuantCacheDType(DType dt) =>
+        protected static bool IsBlockQuantCacheDType(DType dt) =>
             dt == DType.Q4_0 || dt == DType.Q8_0;
 
         // ggml type id for a block-quantized KV-cache dtype (must match ggml.h /
@@ -4049,6 +4049,12 @@ namespace TensorSharp.Models
             if (kCache.ElementType == DType.Float16 && vCache.ElementType == DType.Float16)
             {
                 CopyToCacheDecodeF16(kCache, kTensor, vCache, vTensor, numKVHeads, headDim, startPos);
+                return;
+            }
+
+            if (IsBlockQuantCacheDType(kCache.ElementType) && vCache.ElementType == kCache.ElementType)
+            {
+                CopyToCacheDecodeBlockQuant(kCache, kTensor, vCache, vTensor, numKVHeads, headDim, startPos);
                 return;
             }
 
@@ -4188,6 +4194,41 @@ namespace TensorSharp.Models
             return true;
         }
 
+        /// <summary>
+        /// Single-position decode append into a block-quantized (Q4_0 / Q8_0) linear
+        /// cache: each head's new K/V row (headDim elements, a whole number of
+        /// 32-element blocks) is quantized in place at its row offset. Decode analogue
+        /// of <see cref="CopyToCacheBlockQuant"/>; bytes match ggml's block layout so
+        /// the fused native kernels dequantize them identically on later reads.
+        /// </summary>
+        private unsafe void CopyToCacheDecodeBlockQuant(Tensor kCache, Tensor kTensor,
+            Tensor vCache, Tensor vTensor, int numKVHeads, int headDim, int startPos)
+        {
+            int ggmlType = GgmlTypeForCacheDType(kCache.ElementType);
+            long rowBytes = ManagedQuantizedOps.RowSize(ggmlType, headDim);
+            int maxSeqLen = (int)kCache.Sizes[1];
+
+            kCache.Storage.EnsureHostReadable();
+            vCache.Storage.EnsureHostReadable();
+            float* kSrc = GetFloatPtr(kTensor);
+            float* vSrc = GetFloatPtr(vTensor);
+            byte* kBase = (byte*)TensorComputePrimitives.GetStoragePointer(kCache);
+            byte* vBase = (byte*)TensorComputePrimitives.GetStoragePointer(vCache);
+
+            for (int h = 0; h < numKVHeads; h++)
+            {
+                long cacheOffset = (long)h * maxSeqLen * rowBytes + (long)startPos * rowBytes;
+                int srcOffset = h * headDim;
+                ManagedQuantizedOps.QuantizeRowFromFloat32(ggmlType, kSrc + srcOffset,
+                    (IntPtr)(kBase + cacheOffset), headDim);
+                ManagedQuantizedOps.QuantizeRowFromFloat32(ggmlType, vSrc + srcOffset,
+                    (IntPtr)(vBase + cacheOffset), headDim);
+            }
+
+            InvalidateTensorDeviceCache(kCache);
+            InvalidateTensorDeviceCache(vCache);
+        }
+
         private unsafe void CopyToCacheDecodeF16(Tensor kCache, Tensor kTensor,
             Tensor vCache, Tensor vTensor, int numKVHeads, int headDim, int startPos)
         {
@@ -4216,6 +4257,24 @@ namespace TensorSharp.Models
             {
                 AttentionDecodePureCSF16(q, kCache, vCache, result,
                     numHeads, numKVHeads, headDim, totalSeqLen, scale);
+                return;
+            }
+
+            if (IsBlockQuantCacheDType(kCache.ElementType) && vCache.ElementType == kCache.ElementType)
+            {
+                // Block-quantized (Q4_0 / Q8_0) caches cannot be walked as flat float
+                // buffers. Dequantize the active [0, totalSeqLen) window into compact
+                // F32 tensors (no GQA broadcast; the grouped kernel below reads per
+                // KV head) and re-enter on the F32 path — the compact copy's
+                // Sizes[1] == totalSeqLen doubles as its row stride. This is the
+                // deep-fallback path (fused native attention handles quantized
+                // caches on-device), so correctness beats the extra dequant cost.
+                using (Tensor kF32 = ExpandKVHeadsBlockQuant(kCache, 1, totalSeqLen))
+                using (Tensor vF32 = ExpandKVHeadsBlockQuant(vCache, 1, totalSeqLen))
+                {
+                    AttentionDecodePureCS(q, kF32, vF32, result,
+                        numHeads, numKVHeads, headDim, totalSeqLen, scale);
+                }
                 return;
             }
 

--- a/TensorSharp.Models/Models/Qwen35/Qwen35Model.BatchedForward.cs
+++ b/TensorSharp.Models/Models/Qwen35/Qwen35Model.BatchedForward.cs
@@ -474,9 +474,15 @@ namespace TensorSharp.Models
 
                     // Fused QKV projection. The fused weight emits
                     // [numTokens, qFullDim + 2*kvDim] where the first qFullDim cols
-                    // are Q+gate interleaved per head.
+                    // are Q+gate interleaved per head. UD-style GGUFs mix quant
+                    // types across Q/K/V, so the loader fuses them into an F32
+                    // tensor (_attnQkvF32) and DISPOSES the separate projections —
+                    // gating on the quantized handle alone would route those models
+                    // into the separate-projection branch below, whose weights no
+                    // longer exist (LinearForwardCached returns null and the
+                    // batched MTP trunk crashes in DeinterleaveQGate).
                     Tensor qFull, kTensor, vTensor;
-                    if (_attnQkvQW[layer] != null)
+                    if (_attnQkvQW[layer] != null || _attnQkvF32[layer] != null)
                     {
                         using Tensor fusedQkv = LinearForwardCached(normed, _attnQkvQW[layer], _attnQkvF32[layer]);
                         normed.Dispose();

--- a/TensorSharp.Models/Models/Qwen35/Qwen35Model.GatedDeltaNet.cs
+++ b/TensorSharp.Models/Models/Qwen35/Qwen35Model.GatedDeltaNet.cs
@@ -1034,6 +1034,31 @@ namespace TensorSharp.Models
             return ((IntPtr)GetFloatPtr(f32), 0, ne0, ne1, f32.ElementCount() * 4L);
         }
 
+        /// <summary>
+        /// KV-cache dtypes the fused whole-model / per-layer native graphs accept.
+        /// F32/F16 everywhere; block-quantized (Q8_0 / Q4_0) only on ggml_cuda,
+        /// where every op the graphs touch the cache with has a quantized-KV
+        /// kernel at this model's head size (ggml_set_rows and ggml_cpy write
+        /// F32-&gt;Q8_0/Q4_0 rows, ggml_flash_attn_ext reads quantized K/V incl.
+        /// head_dim 256). Metal's set_rows faults and Vulkan's quantized-KV
+        /// flash attention is unvalidated here, so those backends decline and
+        /// take the per-op path, whose host helpers handle block-quant caches.
+        /// </summary>
+        private bool IsFusedGraphKvCacheDType(DType dt) =>
+            dt == DType.Float32 || dt == DType.Float16
+            || (IsBlockQuantCacheDType(dt) && _backend == BackendType.GgmlCuda);
+
+        /// <summary>ggml_type id passed as the native kernels' kv_cache_type
+        /// argument (must match ggml.h: F32=0, F16=1, Q4_0=2, Q8_0=8).</summary>
+        private static int FusedGraphKvCacheTypeId(DType dt) => dt switch
+        {
+            DType.Float32 => 0,
+            DType.Float16 => 1,
+            DType.Q4_0 => 2,
+            DType.Q8_0 => 8,
+            _ => throw new NotSupportedException($"Unsupported KV cache dtype for fused graphs: {dt}"),
+        };
+
         internal unsafe bool TryFullModelDecode(Tensor hidden, int position, float[] logitsOut)
         {
             if (logitsOut == null || logitsOut.Length < Config.VocabSize)
@@ -1091,7 +1116,8 @@ namespace TensorSharp.Models
                             && HasW(_attnOutputQW[l], _attnOutputF32[l])
                             && _attnQNormW[l] != null && _attnKNormW[l] != null
                             && _kvCacheK[l] != null && _kvCacheV[l] != null
-                            && (_kvCacheK[l].ElementType == DType.Float32 || _kvCacheK[l].ElementType == DType.Float16);
+                            && IsFusedGraphKvCacheDType(_kvCacheK[l].ElementType)
+                            && _kvCacheV[l].ElementType == _kvCacheK[l].ElementType;
                     if (ok && _isRecurrent[l])
                         ok = HasW(_attnQkvRecQW[l], _attnQkvRecF32[l]) && HasW(_attnGateRecQW[l], _attnGateRecF32[l])
                             && HasW(_ssmBetaQW[l], _ssmBetaF32[l]) && HasW(_ssmAlphaQW[l], _ssmAlphaF32[l])
@@ -1122,7 +1148,7 @@ namespace TensorSharp.Models
                 if (!_isRecurrent[l])
                 {
                     cacheSize = (int)_kvCacheK[l].Sizes[1];
-                    kvCacheType = _kvCacheK[l].ElementType == DType.Float16 ? 1 : 0;
+                    kvCacheType = FusedGraphKvCacheTypeId(_kvCacheK[l].ElementType);
                     break;
                 }
             }
@@ -1385,7 +1411,7 @@ namespace TensorSharp.Models
                 if (!_isRecurrent[l])
                 {
                     cacheSize = (int)_kvCacheK[l].Sizes[1];
-                    kvCacheType = _kvCacheK[l].ElementType == DType.Float16 ? 1 : 0;
+                    kvCacheType = FusedGraphKvCacheTypeId(_kvCacheK[l].ElementType);
                     break;
                 }
             }
@@ -1417,7 +1443,8 @@ namespace TensorSharp.Models
                             && HasW(_attnOutputQW[l], _attnOutputF32[l])
                             && _attnQNormW[l] != null && _attnKNormW[l] != null
                             && _kvCacheK[l] != null && _kvCacheV[l] != null
-                            && (_kvCacheK[l].ElementType == DType.Float32 || _kvCacheK[l].ElementType == DType.Float16);
+                            && IsFusedGraphKvCacheDType(_kvCacheK[l].ElementType)
+                            && _kvCacheV[l].ElementType == _kvCacheK[l].ElementType;
                     if (ok && _isRecurrent[l])
                         ok = HasW(_attnQkvRecQW[l], _attnQkvRecF32[l]) && HasW(_attnGateRecQW[l], _attnGateRecF32[l])
                             && HasW(_ssmBetaQW[l], _ssmBetaF32[l]) && HasW(_ssmAlphaQW[l], _ssmAlphaF32[l])
@@ -1684,8 +1711,11 @@ namespace TensorSharp.Models
                 return false;
             if (_kvCacheK[mtp] == null || _kvCacheV[mtp] == null)
                 return false;
+            if (!IsFusedGraphKvCacheDType(_kvCacheK[mtp].ElementType)
+                || _kvCacheV[mtp].ElementType != _kvCacheK[mtp].ElementType)
+                return false;
             int cacheSize = (int)_kvCacheK[mtp].Sizes[1];
-            int kvCacheType = _kvCacheK[mtp].ElementType == DType.Float16 ? 1 : 0;
+            int kvCacheType = FusedGraphKvCacheTypeId(_kvCacheK[mtp].ElementType);
             if (cacheSize <= 0 || startPos + seqLen > cacheSize)
                 return false;
 

--- a/TensorSharp.Models/Models/Qwen35/Qwen35Model.cs
+++ b/TensorSharp.Models/Models/Qwen35/Qwen35Model.cs
@@ -3420,7 +3420,7 @@ namespace TensorSharp.Models
             if (q.ElementType != DType.Float32 || k.ElementType != DType.Float32 || v.ElementType != DType.Float32 ||
                 output.ElementType != DType.Float32)
                 return false;
-            if (kCache.ElementType != DType.Float32 && kCache.ElementType != DType.Float16)
+            if (!IsFusedGraphKvCacheDType(kCache.ElementType))
                 return false;
             if (vCache.ElementType != kCache.ElementType)
                 return false;
@@ -3493,7 +3493,7 @@ namespace TensorSharp.Models
             if (qkv == null || oOut == null || attnNorm == null || qNorm == null || kNorm == null
                 || kCache == null || vCache == null)
                 return false;
-            if (kCache.ElementType != DType.Float32 && kCache.ElementType != DType.Float16)
+            if (!IsFusedGraphKvCacheDType(kCache.ElementType))
                 return false;
             if (vCache.ElementType != kCache.ElementType)
                 return false;
@@ -3506,7 +3506,7 @@ namespace TensorSharp.Models
             const int ropeMode = 2; // NeoX, matches the legacy ApplyRoPEPrefill
             float ropeFreqScale = 1.0f / Config.RopeScale;
 
-            int kvCacheTypeId = (kCache.ElementType == DType.Float16) ? 1 : 0;
+            int kvCacheTypeId = FusedGraphKvCacheTypeId(kCache.ElementType);
 
             try
             {
@@ -3556,7 +3556,7 @@ namespace TensorSharp.Models
             if (qkv == null || oOut == null || attnNorm == null || qNorm == null || kNorm == null
                 || kCache == null || vCache == null)
                 return false;
-            if (kCache.ElementType != DType.Float32 && kCache.ElementType != DType.Float16)
+            if (!IsFusedGraphKvCacheDType(kCache.ElementType))
                 return false;
             if (vCache.ElementType != kCache.ElementType)
                 return false;


### PR DESCRIPTION
… and UD GGUFs (#108)

Three distinct crashes reported against Qwen3.6-27B-UD-Q4_K_XL with --mtp-spec are fixed:

1. Block-quantized KV caches (--kv-cache-dtype q8_0/q4_0) crashed the whole qwen35 stack at WarmUpKernels with "Requires a Float32 tensor, but found Q8_0": every fused native path (TryFullModelDecode / TryFullModelVerify / TryFusedMtpBlock / TryFlashAttnDecode / per-layer fused attention) gated KV to F32/F16, silently dropping ALL forwards to the per-op loop, whose decode-side cache helpers only handled F32/F16. Fixed on both sides: - The fused gates now accept Q8_0/Q4_0 on ggml_cuda and pass the real ggml_type id (F32=0, F16=1, Q4_0=2, Q8_0=8) as kv_cache_type. The native kernels were already type-generic (ggml_set_rows / ggml_cpy write F32->quant rows; ggml_flash_attn_ext reads quantized K/V incl. head_dim 256), so quantized caches now run the same single-graph decode/verify as F16 - measured at f16 parity (16.4 vs 16.0 tok/s decode on a RTX 3080 Laptop 16GB, 27B-UD-IQ2_XXS) instead of crashing. - The per-op fallback (used by non-CUDA backends and any fused decline) gets a block-quant decode append (CopyToCacheDecodeBlockQuant, ggml-compatible QuantizeRowFromFloat32 per head-row) and a block-quant read branch in AttentionDecodePureCS (dequantize the active window, re-enter the F32 kernel).

2. UD-style GGUFs (mixed quant types across Q/K/V, e.g. Unsloth Q4_K_XL / IQ2_XXS) crashed the batched MTP trunk with ArgumentNullException in DeinterleaveQGate: the loader fuses their QKV into one F32 tensor and DISPOSES the separate projections, but ForwardBatch only checked the quantized fused handle before taking the separate-projection branch, so LinearForwardCached returned null. The gate now also accepts the F32-fused weight.

3. With both fixed, MTP speculative decoding was verified end-to-end on the exact reported model (Qwen3.6-27B-UD-Q4_K_XL) with kv f16 AND q8_0, on all three trunk modes (fused-verify linear, per-op linear, batched): correct output, 83-100% draft acceptance, and the Qwen36MtpTests greedy-equivalence e2e passes token-for-token on ggml_cuda (48/48).