### PR TITLE
DSV4: decode index-gather sparse attention + larger prefill chunks

### DIFF
--- a/TensorSharp.GGML.Native/ggml_ops_deepseek4.cpp
+++ b/TensorSharp.GGML.Native/ggml_ops_deepseek4.cpp
@@ -218,6 +218,8 @@ struct graph_inputs
     ggml_tensor * pos[MAX_GPUS + 1] = {};       // I32 [nt]
     ggml_tensor * raw_idxs[MAX_GPUS + 1] = {};  // I64 [nt]
     ggml_tensor * raw_mask[MAX_GPUS + 1] = {};  // F16 [ring, nt]
+    // decode index-gather mode: F16 [ring + top_k, 1] (top-k tail all zeros)
+    ggml_tensor * gather_mask[MAX_GPUS + 1] = {};
     ggml_tensor * out_ids = nullptr;            // I32 [1] (last device)
     plan_inputs csa[MAX_GPUS + 1];
     plan_inputs hca[MAX_GPUS + 1];
@@ -319,6 +321,8 @@ struct dsv4_model
 
     // scratch for logits
     std::vector<float> logits;
+
+    bool gather_env = true; // TS_DSV4_GATHER=0 disables decode index-gather
 
     ~dsv4_model()
     {
@@ -687,6 +691,9 @@ static dsv4_model * dsv4_load(const char * gguf_path, int n_gpu_req, int n_ctx, 
 
         const char * gc = getenv("TS_DSV4_GRAPH_CACHE");
         if (gc && atoi(gc) > 0) m->graph_cache_cap = atoi(gc);
+
+        const char * ge = getenv("TS_DSV4_GATHER");
+        m->gather_env = !(ge && atoi(ge) == 0);
     }
 
     // --- read gguf metadata (all shards) ---
@@ -1059,6 +1066,18 @@ static dsv4_model * dsv4_load(const char * gguf_path, int n_gpu_req, int n_ctx, 
 
     m->logits.resize(hp.n_vocab);
     return m.release();
+}
+
+// Decode-time index-gather sparse attention: past the indexer-skip horizon
+// (pos_end > top_k * ratio) the decode token sees n_visible >= top_k
+// compressed rows, so every top-k index is a valid row and CSA attention can
+// read a compact [raw ring | gathered top-k] K with an all-visible tail mask
+// instead of masked-dense over every compressed row. Attention cost then
+// stops growing with context; only the indexer scores/top-k stay O(n).
+static bool dsv4_use_gather(const dsv4_model & m, int64_t nt, int64_t pos_end)
+{
+    return m.fused && m.gather_env && nt == 1 &&
+           pos_end > (int64_t) m.hp.indexer_top_k * CSA_RATIO;
 }
 
 static comp_plan build_comp_plan(
@@ -1737,7 +1756,22 @@ struct graph_builder
         ggml_tensor * out = nullptr;
         const float kq_scale = 1.0f / sqrtf((float) head);
 
-        if (ratio == CSA_RATIO)
+        if (ratio == CSA_RATIO && res.inp.gather_mask[dev])
+        {
+            // Decode index-gather: compact [raw ring | top-k rows] K. Every
+            // top-k index is a valid compressed row here (see
+            // dsv4_use_gather), so the gathered tail needs no masking and the
+            // softmax over the gathered subset equals the masked-dense
+            // result. The gather runs after this layer's compressor commit
+            // (same stream, graph order), so a just-completed block is
+            // selectable exactly like in the masked-dense path.
+            ggml_tensor * top_k = build_lid_top_k(il, qr, cur, inp_pos, dev);
+            ggml_tensor * k_sel = fused_node(TSG_DSV4_FUSED_KGATHER, GGML_TYPE_F16,
+                    head, 1, m.ring_raw + top_k->ne[0], 1,
+                    { L.raw_k, L.csa_k, top_k }, dev, (int) m.ring_raw);
+            out = attn_mha(q, k_sel, res.inp.gather_mask[dev], L.attn_sinks, kq_scale);
+        }
+        else if (ratio == CSA_RATIO)
         {
             ggml_tensor * csa_k = ggml_view_2d(ctx, L.csa_k, head, res.plan_csa.n_kv, L.csa_k->nb[1], 0);
             csa_k = ggml_reshape_3d(ctx, csa_k, head, 1, res.plan_csa.n_kv);
@@ -1999,6 +2033,11 @@ struct graph_builder
             inp.raw_idxs[d] = new_input_i64(nt, nb, d);
             snprintf(nb, sizeof(nb), "inp_raw_mask.%d", d);
             inp.raw_mask[d] = new_input_mask(m.ring_raw, GGML_TYPE_F16, nb, d);
+            if (dsv4_use_gather(m, nt, std::max(m.pos_end_hint, p0 + nt)))
+            {
+                snprintf(nb, sizeof(nb), "inp_gather_mask.%d", d);
+                inp.gather_mask[d] = new_input_mask(m.ring_raw + hp.indexer_top_k, GGML_TYPE_F16, nb, d);
+            }
             make_plan_inputs(inp.csa[d], res.plan_csa, GGML_TYPE_F16, "csa", d);
             make_plan_inputs(inp.hca[d], res.plan_hca, GGML_TYPE_F16, "hca", d);
             make_plan_inputs(inp.lid[d], res.plan_lid, GGML_TYPE_F16, "lid", d);
@@ -2258,6 +2297,16 @@ static bool dsv4_forward_ubatch(dsv4_model & m, const int32_t * tokens, int64_t 
         plan_mask(res.plan_hca, mk_hca);
         plan_mask(res.plan_lid, mk_lid);
 
+        // gather-mode attention mask: [raw ring mask | top-k rows, all visible]
+        std::vector<ggml_fp16_t> gmask;
+        bool any_gather = false;
+        for (int d = 0; d <= m.n_gpu && !any_gather; d++) any_gather = res.inp.gather_mask[d] != nullptr;
+        if (any_gather)
+        {
+            gmask.assign(mask.begin(), mask.end());
+            gmask.resize((size_t) (m.ring_raw + hp.indexer_top_k) * nt, ZERO16);
+        }
+
         auto set_f16 = [](ggml_tensor * t, const std::vector<ggml_fp16_t> & v)
         {
             if (!t || !t->buffer || v.empty()) return;
@@ -2307,6 +2356,7 @@ static bool dsv4_forward_ubatch(dsv4_model & m, const int32_t * tokens, int64_t 
             for (int64_t i = 0; i < nt; i++) ridx[i] = (p0 + i) % m.ring_raw;
             set_i64(res.inp.raw_idxs[d], ridx);
             set_f16(res.inp.raw_mask[d], mask);
+            set_f16(res.inp.gather_mask[d], gmask);
             fill_plan(res.inp.csa[d], res.plan_csa, mk_csa);
             fill_plan(res.inp.hca[d], res.plan_hca, mk_hca);
             fill_plan(res.inp.lid[d], res.plan_lid, mk_lid);

--- a/TensorSharp.GGML.Native/ggml_ops_dsv4_fused.cu
+++ b/TensorSharp.GGML.Native/ggml_ops_dsv4_fused.cu
@@ -481,6 +481,27 @@ static __global__ void tsg_dsv4_topk_mask_f16(
     }
 }
 
+// Compact sparse-attention K for decode: dst row r < ring_rows copies the raw
+// SWA ring row r, row ring_rows+j gathers compressed cache row topk[j]. K
+// doubles as V, so one gather serves the whole attention read. Rows are
+// contiguous F16; copy as int (half2 pairs).
+static __global__ void tsg_dsv4_kgather_f16(
+        const half * __restrict__ ring,    // [head, ring_rows]
+        const half * __restrict__ comp,    // [head, n_comp_rows]
+        const int32_t * __restrict__ topk, // [n_rows - ring_rows]
+        half * __restrict__ dst,           // [head, n_rows]
+        const int head,
+        const int ring_rows) {
+    const int r = blockIdx.x;
+    const half * src = r < ring_rows ? ring + (int64_t) r * head
+                                     : comp + (int64_t) topk[r - ring_rows] * head;
+    const int * s = (const int *) src;
+    int * o = (int *) (dst + (int64_t) r * head);
+    for (int i = threadIdx.x; i < head/2; i += blockDim.x) {
+        o[i] = s[i];
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Launcher
 // ---------------------------------------------------------------------------
@@ -667,6 +688,21 @@ static void tsg_dsv4_fused_launch(const tsg_dsv4_fused_desc * d, ggml_tensor * d
             tsg_dsv4_topk_mask_f16<<<nt, 256, 0, stream>>>(
                 (const half *) base->data, (const int32_t *) topk->data,
                 (half *) dst->data, W, k, d->i0 /*offset*/);
+        } break;
+
+        case TSG_DSV4_FUSED_KGATHER:
+        {
+            const ggml_tensor * ring = dst->src[0];
+            const ggml_tensor * comp = dst->src[1];
+            const ggml_tensor * topk = dst->src[2];
+
+            const int head      = (int) dst->ne[0];
+            const int n_rows    = (int) dst->ne[2];
+            const int ring_rows = d->i0;
+
+            tsg_dsv4_kgather_f16<<<n_rows, 256, 0, stream>>>(
+                (const half *) ring->data, (const half *) comp->data,
+                (const int32_t *) topk->data, (half *) dst->data, head, ring_rows);
         } break;
 
         default:

--- a/TensorSharp.GGML.Native/ggml_ops_dsv4_fused.h
+++ b/TensorSharp.GGML.Native/ggml_ops_dsv4_fused.h
@@ -37,6 +37,7 @@ enum tsg_dsv4_fused_kind : int32_t
     TSG_DSV4_FUSED_HC_GATES      = 8,
     TSG_DSV4_FUSED_TOPK_MASK     = 9,
     TSG_DSV4_FUSED_TOPK_SELECT   = 10,
+    TSG_DSV4_FUSED_KGATHER       = 11,
 };
 
 #define TSG_DSV4_FUSED_MAGIC 0x5453445356344655ull  // "TSDSV4FU"

--- a/TensorSharp.GGML.Native/ggml_ops_dsv4_fused_cpu.cpp
+++ b/TensorSharp.GGML.Native/ggml_ops_dsv4_fused_cpu.cpp
@@ -398,6 +398,27 @@ static void tsg_dsv4_cpu_topk_mask(ggml_tensor * dst, const tsg_dsv4_fused_desc 
     }
 }
 
+static void tsg_dsv4_cpu_kgather(ggml_tensor * dst, const tsg_dsv4_fused_desc * d)
+{
+    const ggml_tensor * ring = dst->src[0];
+    const ggml_tensor * comp = dst->src[1];
+    const ggml_tensor * topk = dst->src[2];
+
+    const int64_t head      = dst->ne[0];
+    const int64_t n_rows    = dst->ne[2];
+    const int64_t ring_rows = d->i0;
+
+    const int32_t * tk = (const int32_t *) topk->data;
+
+    for (int64_t r = 0; r < n_rows; ++r)
+    {
+        const ggml_fp16_t * src = r < ring_rows
+            ? (const ggml_fp16_t *) ring->data + r * head
+            : (const ggml_fp16_t *) comp->data + (int64_t) tk[r - ring_rows] * head;
+        memcpy((ggml_fp16_t *) dst->data + r * head, src, head * sizeof(ggml_fp16_t));
+    }
+}
+
 void tsg_dsv4_fused_cpu(ggml_tensor * dst, int ith, int nth, void * userdata)
 {
     GGML_UNUSED(nth);
@@ -417,6 +438,7 @@ void tsg_dsv4_fused_cpu(ggml_tensor * dst, int ith, int nth, void * userdata)
         case TSG_DSV4_FUSED_SWIGLU_CLAMP:  tsg_dsv4_cpu_swiglu_clamp(dst, d); break;
         case TSG_DSV4_FUSED_HC_GATES:      tsg_dsv4_cpu_hc_gates(dst, d); break;
         case TSG_DSV4_FUSED_TOPK_MASK:     tsg_dsv4_cpu_topk_mask(dst, d); break;
+        case TSG_DSV4_FUSED_KGATHER:       tsg_dsv4_cpu_kgather(dst, d); break;
         default: GGML_ABORT("tsg_dsv4_fused_cpu: unknown kind %d", d->kind);
     }
 }

--- a/TensorSharp.Models/Models/DeepSeek4/DeepSeek4Model.cs
+++ b/TensorSharp.Models/Models/DeepSeek4/DeepSeek4Model.cs
@@ -46,7 +46,13 @@ namespace TensorSharp.Models
                 maxContext = Math.Min(maxContext, 65536);
             _maxContextLength = maxContext;
 
-            int nUbatch = ParseEnvInt("TS_DSV4_UBATCH", 512);
+            // GPU prefill chunks amortize the MoE expert-GEMM tile padding (256
+            // experts x top-6 leaves ~nt/42 rows per expert, so per-chunk MoE
+            // cost is nearly flat in nt): 1024 measured ~11-21% faster overall
+            // prefill than 512 and also halves what a non-multiple tail chunk
+            // costs relative to the whole prompt. The CPU executor stays at 512
+            // (activation memory bound, no tile padding to amortize).
+            int nUbatch = ParseEnvInt("TS_DSV4_UBATCH", _backend == BackendType.Cpu ? 512 : 1024);
 
             if (_backend == BackendType.Cpu)
             {


### PR DESCRIPTION
Two DeepSeek V4 Flash performance improvements, following up on the future-work items from #109.

## 1. Decode index-gather sparse attention

Past the indexer-skip horizon (`pos > top_k*ratio = 2048`) the decode token always sees `n_visible >= top_k` compressed rows, so every lightning-indexer top-k index is a valid CSA cache row. A new fused `KGATHER` kernel copies `[raw SWA ring | top-512 gathered rows]` into a compact F16 K buffer (K doubles as V), and decode attention runs over a constant ~1.8K rows with an all-visible tail mask instead of masked-dense over every compressed row (8K+ rows at 32K context). The softmax over the gathered subset is mathematically identical to the masked-dense result, so this is an exact optimization. `TS_DSV4_GATHER=0` restores the masked-dense path.

Decode is now essentially **flat in context depth**.

## 2. Default GPU prefill ubatch 512 -> 1024

The MoE expert GEMM (256 experts, top-6) leaves ~nt/42 rows per expert, so MMQ's per-expert tile padding makes per-chunk MoE cost nearly flat in chunk size — this is also why a non-512-multiple prompt's small tail chunk cost almost as much as a full chunk. Larger chunks amortize the padding; 1024 measured best of {256..2048} at both 2.5K and 16K prompt lengths. Uniform chunk splitting was measured and adds nothing over greedy chunking at ubatch 1024. The CPU executor keeps 512.

## Benchmarks (4x A40, DeepSeek-V4-Flash-UD-IQ4_XS 284B, 4-GPU layer split)

| test | before | after | llama.cpp (same box, build 9d9a6d2) |
|---|---|---|---|
| prefill 16384 | 838 tok/s | **963** | 558 |
| prefill 32768 | — | **883** | 508 |
| decode short | 37.0 | **37.0** | 35.3 |
| decode @16K | 30.9 | **33.6** | 32.2 |
| decode @32K | 28.5 | **33.8** | 29.9 |

## Testing

- Needle recall exact at 2.5K / 16K / 32K context, gather on and off
- Greedy outputs token-identical until FP-reassociation near-ties (same behavior as the fused-compressor path); needle answers unchanged
- Multi-turn CLI: arithmetic + cross-turn recall correct
- Full regression on the 4xA40 box: gemma-4-E4B and gemma-4-26B (text + image), Qwen3.5-9B, Qwen3.5-35B (text + image), gpt-oss-20b — all correct
- CPU reference implementation added for the new fused op

🤖 Generated with [Claude Code](https://claude.com/claude-code)