### PR TITLE
Fix ggml master build break, mixed-quant UD GGUFs, and a ~27x Vulkan slowdown on small-BAR AMD GPUs

### DIFF
--- a/TensorSharp.Backends.GGML/GgmlGgufTensorDequant.cs
+++ b/TensorSharp.Backends.GGML/GgmlGgufTensorDequant.cs
@@ -88,4 +88,14 @@ public static class GgmlGgufTensorDequant
     {
         GgmlNative.DequantizeGgufTensorToFloat32Native(ggmlType, src, dst, numElements);
     }
+
+    /// <summary>
+    /// Quantizes FP32 rows in unmanaged memory into a GGML quantized row layout.
+    /// Returns bytes written, or 0 when the target type needs an importance matrix
+    /// (IQ1/IQ2 families cannot be produced without one).
+    /// </summary>
+    public static long QuantizeFloat32RowsOrZero(int ggmlType, IntPtr src, IntPtr dst, long nrows, long nPerRow)
+    {
+        return GgmlNative.QuantizeFloat32RowsOrZero(ggmlType, src, dst, nrows, nPerRow);
+    }
 }

--- a/TensorSharp.Backends.GGML/GgmlNative.cs
+++ b/TensorSharp.Backends.GGML/GgmlNative.cs
@@ -966,17 +966,8 @@ internal enum GgmlIndexReductionOp
         {
             try
             {
-                if (!string.Equals(Environment.GetEnvironmentVariable("TS_GGML_TP_CUDA_GRAPHS"), "0",
-                                   StringComparison.Ordinal))
-                    return;
-
-                string degreeText = Environment.GetEnvironmentVariable("TENSORSHARP_TP_DEGREE");
-                if (!int.TryParse(degreeText, System.Globalization.NumberStyles.Integer,
-                                  System.Globalization.CultureInfo.InvariantCulture, out int degree)
-                    || degree <= 1)
-                    return;
-
-                SetNativeEnvironmentVariable("GGML_CUDA_DISABLE_GRAPHS", "1", overwrite: false);
+                ApplySmallBarVulkanWorkaround();
+                ApplyTensorParallelCudaGraphTunable();
             }
             catch (DllNotFoundException)
             {
@@ -987,6 +978,79 @@ internal enum GgmlIndexReductionOp
             {
                 // Older GgmlOps without the setter; the native-side backstop in
                 // TSGgml_TensorParallelInit still applies where it can.
+            }
+        }
+
+        private static void ApplyTensorParallelCudaGraphTunable()
+        {
+            if (!string.Equals(Environment.GetEnvironmentVariable("TS_GGML_TP_CUDA_GRAPHS"), "0",
+                               StringComparison.Ordinal))
+                return;
+
+            string degreeText = Environment.GetEnvironmentVariable("TENSORSHARP_TP_DEGREE");
+            if (!int.TryParse(degreeText, System.Globalization.NumberStyles.Integer,
+                              System.Globalization.CultureInfo.InvariantCulture, out int degree)
+                || degree <= 1)
+                return;
+
+            SetNativeEnvironmentVariable("GGML_CUDA_DISABLE_GRAPHS", "1", overwrite: false);
+        }
+
+        /// <summary>
+        /// ggml-vulkan's default device-buffer preference is
+        /// DEVICE_LOCAL|HOST_VISIBLE|HOST_COHERENT — the Resizable-BAR memory
+        /// type. On a discrete AMD GPU without ReBAR only the 256 MB BAR heap
+        /// carries those flags, and RADV over-commits that heap instead of
+        /// failing the allocation, so the fallback to plain DEVICE_LOCAL never
+        /// fires: every weight buffer is silently backed by GTT and the GPU
+        /// re-reads the whole model across PCIe on every token (measured
+        /// 1.3 → 35.9 tok/s on Qwen3.8-27B Q4_K_XL, RX 7900 XTX, RADV).
+        /// Detect the small-BAR case via amdgpu sysfs and pre-set
+        /// GGML_VK_DISABLE_HOST_VISIBLE_VIDMEM before the Vulkan device is
+        /// created — ggml-vulkan latches the variable at device init, so this
+        /// must run before the first backend call. A user-set value of the
+        /// variable (any value, including empty) is always respected.
+        /// </summary>
+        private static void ApplySmallBarVulkanWorkaround()
+        {
+            if (!OperatingSystem.IsLinux())
+                return;
+            if (Environment.GetEnvironmentVariable("GGML_VK_DISABLE_HOST_VISIBLE_VIDMEM") != null)
+                return;
+
+            try
+            {
+                foreach (string dev in System.IO.Directory.GetDirectories("/sys/class/drm"))
+                {
+                    string vramPath = System.IO.Path.Combine(dev, "device", "mem_info_vram_total");
+                    string visPath = System.IO.Path.Combine(dev, "device", "mem_info_vis_vram_total");
+                    if (!System.IO.File.Exists(vramPath) || !System.IO.File.Exists(visPath))
+                        continue;
+                    if (!long.TryParse(System.IO.File.ReadAllText(vramPath).Trim(), out long vramTotal) ||
+                        !long.TryParse(System.IO.File.ReadAllText(visPath).Trim(), out long visTotal))
+                        continue;
+
+                    const long OneGiB = 1L << 30;
+                    if (vramTotal >= 4 * OneGiB && visTotal <= OneGiB && visTotal < vramTotal / 4)
+                    {
+                        if (SetNativeEnvironmentVariable("GGML_VK_DISABLE_HOST_VISIBLE_VIDMEM", "1", overwrite: false))
+                        {
+                            Console.Error.WriteLine(
+                                $"ggml-vulkan small-BAR workaround: {System.IO.Path.GetFileName(dev)} exposes " +
+                                $"{visTotal >> 20} MB CPU-visible VRAM of {vramTotal >> 30} GB total (Resizable BAR off); " +
+                                "set GGML_VK_DISABLE_HOST_VISIBLE_VIDMEM=1 so model weights stay in VRAM. " +
+                                "Enabling Resizable BAR in the BIOS removes the need for this.");
+                        }
+                        return;
+                    }
+                }
+            }
+            catch (System.IO.IOException)
+            {
+                // sysfs unavailable/odd permissions: leave ggml-vulkan defaults alone.
+            }
+            catch (UnauthorizedAccessException)
+            {
             }
         }
 

--- a/TensorSharp.Backends.GGML/GgmlNative.cs
+++ b/TensorSharp.Backends.GGML/GgmlNative.cs
@@ -3135,6 +3135,17 @@ internal enum GgmlIndexReductionOp
             IntPtr up, IntPtr down, int rank, float scale, int nThreads);
 
         [DllImport(DllName, CallingConvention = CallingConventionType)]
+        private static extern void ggml_quantize_init(int type);
+
+        [DllImport(DllName, CallingConvention = CallingConventionType)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        private static extern bool ggml_quantize_requires_imatrix(int type);
+
+        [DllImport(DllName, CallingConvention = CallingConventionType)]
+        private static extern UIntPtr ggml_quantize_chunk(int type, IntPtr src, IntPtr dst,
+            long start, long nrows, long nPerRow, IntPtr imatrix);
+
+        [DllImport(DllName, CallingConvention = CallingConventionType)]
         private static extern int TSGgml_QwenVaeRun(in QwenVaeArgs args);
 
         /// <summary>Run a whole VAE encode/decode op-list as ONE device graph (see QwenVaeArgs).
@@ -5080,6 +5091,27 @@ internal enum GgmlIndexReductionOp
             {
                 return TSGgml_ApplyLoraDelta(w, ggmlType, ne0, ne1, (IntPtr)pu, (IntPtr)pd, rank, scale, nThreads);
             }
+        }
+
+        /// <summary>
+        /// Quantize FP32 rows into a GGML quantized row layout via ggml_quantize_chunk.
+        /// Returns bytes written, or 0 when the target type cannot be produced without
+        /// an importance matrix (IQ1/IQ2 families).
+        /// </summary>
+        internal static long QuantizeFloat32RowsOrZero(int ggmlType, IntPtr src, IntPtr dst, long nrows, long nPerRow)
+        {
+            if (src == IntPtr.Zero || dst == IntPtr.Zero || nrows <= 0 || nPerRow <= 0)
+            {
+                throw new ArgumentException("Invalid src/dst pointers or shape for quantization.");
+            }
+
+            if (ggml_quantize_requires_imatrix(ggmlType))
+            {
+                return 0;
+            }
+
+            ggml_quantize_init(ggmlType);
+            return (long)ggml_quantize_chunk(ggmlType, src, dst, 0, nrows, nPerRow, IntPtr.Zero).ToUInt64();
         }
 
         internal static void DequantizeGgufTensorToFloat32Native(int ggmlType, IntPtr src, IntPtr dst, long numElements)

--- a/TensorSharp.GGML.Native/ggml_ops_mamba2.cpp
+++ b/TensorSharp.GGML.Native/ggml_ops_mamba2.cpp
@@ -596,7 +596,7 @@ TSG_EXPORT int TSGgml_NemotronMamba2PrefillF32(
             ggml_tensor* dt = ggml_add(ctx, dt_raw, dt_bias_t);
             dt = ggml_reshape_3d(ctx, dt, n_head, T, 1);
 
-            ggml_tensor* scan = ggml_ssm_scan(ctx, ssm_state_t, x, dt, a_t, b, c, ids_t);
+            ggml_tensor* scan = ggml_ssm_scan(ctx, ssm_state_t, x, dt, a_t, b, c, ids_t, 1);
 
             ggml_tensor* y = ggml_view_4d(
                 ctx, scan,
@@ -953,7 +953,7 @@ TSG_EXPORT int TSGgml_NemotronMamba2DecodeF32(
             ggml_tensor* dt = ggml_add(ctx, dt_raw, dt_bias_t);
             dt = ggml_reshape_3d(ctx, dt, n_head, T, 1);
 
-            ggml_tensor* scan = ggml_ssm_scan(ctx, ssm_state_t, x, dt, a_t, b, c, ids_t);
+            ggml_tensor* scan = ggml_ssm_scan(ctx, ssm_state_t, x, dt, a_t, b, c, ids_t, 1);
 
             ggml_tensor* y = ggml_view_4d(
                 ctx, scan,

--- a/TensorSharp.Models/ModelBase.cs
+++ b/TensorSharp.Models/ModelBase.cs
@@ -2036,6 +2036,7 @@ namespace TensorSharp.Models
             if (numLayers <= 0)
                 numLayers = Config.NumLayers;
             int fused = 0;
+            int requantized = 0;
             for (int l = 0; l < numLayers; l++)
             {
                 string gateName = $"blk.{l}.ffn_gate.weight";
@@ -2044,19 +2045,42 @@ namespace TensorSharp.Models
 
                 if (_quantWeights.TryGetValue(gateName, out var gw) &&
                     _quantWeights.TryGetValue(upName, out var uw) &&
-                    gw.GgmlType == uw.GgmlType && gw.Ne0 == uw.Ne0)
+                    gw.Ne0 == uw.Ne0)
                 {
+                    // Mixed-quant "UD"/dynamic GGUFs (e.g. Qwen3.8 UD quants, where
+                    // ffn_gate is IQ4_XS but ffn_up is Q5_K) store gate and up in
+                    // different types, which a single fused tensor can't represent.
+                    // Requantize the lower-fidelity side into the higher-fidelity
+                    // type first, then fuse as usual.
+                    QuantizedWeight gateSrc = gw, upSrc = uw, requant = null;
+                    if (gw.GgmlType != uw.GgmlType)
+                    {
+                        requant = TryRequantizeForFusion(gw, uw, out bool requantIsGate);
+                        if (requant == null)
+                        {
+                            Console.WriteLine(
+                                $"  WARNING: layer {l} ffn_gate ({(Runtime.GgmlTensorType)(uint)gw.GgmlType}) and ffn_up " +
+                                $"({(Runtime.GgmlTensorType)(uint)uw.GgmlType}) quant types differ and requantization is " +
+                                "unavailable; gate/up left unfused.");
+                            continue;
+                        }
+                        if (requantIsGate) gateSrc = requant; else upSrc = requant;
+                        requantized++;
+                    }
+
                     // Gate-up fusion must always succeed: model FFN code expects
                     // a single fused tensor at guName. If MLX view-fusion fails
                     // (gate/up not contiguous in the GGUF file), fall back to a
                     // copy. Cost is bounded — 2 tensors × per-layer, host memory
                     // released after the MLX device upload.
-                    if (!TryCreateFusedQuantizedWeight(out QuantizedWeight fusedWeight, gw, uw))
-                        fusedWeight = QuantizedWeight.ConcatOrCreateCopy(gw, uw);
+                    if (!TryCreateFusedQuantizedWeight(out QuantizedWeight fusedWeight, gateSrc, upSrc))
+                        fusedWeight = QuantizedWeight.ConcatOrCreateCopy(gateSrc, upSrc);
 
                     _quantWeights[guName] = fusedWeight;
                     _quantWeights.Remove(gateName); gw.Dispose();
                     _quantWeights.Remove(upName); uw.Dispose();
+                    if (requant != null && !ReferenceEquals(requant, fusedWeight))
+                        requant.Dispose();
                     fused++;
                 }
                 else if (_weights.TryGetValue(gateName, out var gf) &&
@@ -2074,7 +2098,115 @@ namespace TensorSharp.Models
                 }
             }
             if (fused > 0)
-                Console.WriteLine($"  Fused projections: {fused} Gate+Up");
+                Console.WriteLine(requantized > 0
+                    ? $"  Fused projections: {fused} Gate+Up ({requantized} mixed-quant layers requantized to a common type)"
+                    : $"  Fused projections: {fused} Gate+Up");
+        }
+
+        /// <summary>
+        /// Produce a copy of the lower-fidelity side of a mixed-type gate/up pair,
+        /// requantized to the other side's type so the pair can be fused. Prefers
+        /// upcasting (smaller row size → larger); tries the opposite direction when
+        /// the preferred target can't be produced without an importance matrix.
+        /// Returns null when neither direction is possible.
+        /// </summary>
+        private unsafe QuantizedWeight TryRequantizeForFusion(QuantizedWeight gw, QuantizedWeight uw, out bool requantIsGate)
+        {
+            requantIsGate = false;
+            if (!gw.HasHostData || !uw.HasHostData || gw.Ne0 != uw.Ne0)
+                return null;
+
+            long gRow = NativeDequant.RowSize(gw.GgmlType, gw.Ne0);
+            long uRow = NativeDequant.RowSize(uw.GgmlType, uw.Ne0);
+            QuantizedWeight lower = gRow <= uRow ? gw : uw;
+            QuantizedWeight higher = gRow <= uRow ? uw : gw;
+
+            QuantizedWeight result = TryRequantizeWeight(lower, higher.GgmlType);
+            if (result != null)
+            {
+                requantIsGate = ReferenceEquals(lower, gw);
+                return result;
+            }
+
+            result = TryRequantizeWeight(higher, lower.GgmlType);
+            if (result != null)
+            {
+                requantIsGate = ReferenceEquals(higher, gw);
+                return result;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Dequantize a weight row-chunk-wise to FP32 and requantize it into
+        /// <paramref name="targetType"/>. Returns null when the conversion is not
+        /// possible (imatrix-only target, or no native quantize available).
+        /// </summary>
+        private unsafe QuantizedWeight TryRequantizeWeight(QuantizedWeight src, int targetType)
+        {
+            try
+            {
+                long ne0 = src.Ne0, ne1 = src.Ne1;
+                long srcRow = NativeDequant.RowSize(src.GgmlType, ne0);
+                long dstRow = NativeDequant.RowSize(targetType, ne0);
+                byte[] dstBuf = new byte[checked(dstRow * ne1)];
+                const int ChunkRows = 512;
+                int numChunks = (int)((ne1 + ChunkRows - 1) / ChunkRows);
+                IntPtr srcBase = src.Data;
+                bool failed = false;
+                GCHandle hDst = GCHandle.Alloc(dstBuf, GCHandleType.Pinned);
+                try
+                {
+                    IntPtr dstBase = hDst.AddrOfPinnedObject();
+                    Parallel.For(0, numChunks,
+                        () => new float[(long)ChunkRows * ne0],
+                        (ci, state, f32) =>
+                        {
+                            if (Volatile.Read(ref failed))
+                            {
+                                state.Stop();
+                                return f32;
+                            }
+                            long r = (long)ci * ChunkRows;
+                            long rows = Math.Min(ChunkRows, ne1 - r);
+                            fixed (float* pF32 = f32)
+                            {
+                                NativeDequant.DequantizeToFloat32Native(src.GgmlType,
+                                    (IntPtr)((byte*)srcBase.ToPointer() + r * srcRow), (IntPtr)pF32, rows * ne0);
+                                long written = GgmlGgufTensorDequant.QuantizeFloat32RowsOrZero(targetType,
+                                    (IntPtr)pF32, (IntPtr)((byte*)dstBase.ToPointer() + r * dstRow), rows, ne0);
+                                if (written != rows * dstRow)
+                                {
+                                    Volatile.Write(ref failed, true);
+                                    state.Stop();
+                                }
+                            }
+                            return f32;
+                        },
+                        _ => { });
+                }
+                finally
+                {
+                    hDst.Free();
+                }
+
+                if (failed)
+                    return null;
+
+                return new QuantizedWeight(dstBuf, targetType, ne0, ne1);
+            }
+            catch (Exception ex) when (IsRequantizeUnavailable(ex))
+            {
+                return null;
+            }
+        }
+
+        private static bool IsRequantizeUnavailable(Exception ex)
+        {
+            if (ex is AggregateException agg)
+                return agg.InnerExceptions.Count > 0 && agg.InnerExceptions.All(IsRequantizeUnavailable);
+            return ex is DllNotFoundException or EntryPointNotFoundException or NotSupportedException;
         }
 
         protected Tensor CreateFloatTensor(float[] data, params long[] sizes)

--- a/TensorSharp.Models/Models/Qwen35/Qwen35Model.GatedDeltaNet.cs
+++ b/TensorSharp.Models/Models/Qwen35/Qwen35Model.GatedDeltaNet.cs
@@ -1214,11 +1214,24 @@ namespace TensorSharp.Models
         internal bool TryFullModelDecodeToken(int tokenId, int position, float[] logitsOut)
             => TryFullModelDecodeCore(null, tokenId, position, logitsOut);
 
+        // One-time stderr note for why the fused whole-model decode graph is not
+        // used (the per-op fallback is silent otherwise, and the two paths differ
+        // by an order of magnitude in tokens/sec).
+        private bool FdBail(string reason)
+        {
+            if (!_fdDiagPrinted)
+            {
+                _fdDiagPrinted = true;
+                Console.Error.WriteLine($"[full-decode] not engaged: {reason}; using per-op decode.");
+            }
+            return false;
+        }
+
         private unsafe bool TryFullModelDecodeCore(
             Tensor hidden, int tokenId, int position, float[] logitsOut)
         {
             if (logitsOut == null || logitsOut.Length < Config.VocabSize)
-                return false;
+                return FdBail("logits buffer missing/too small");
             bool tokenInput = tokenId >= 0;
             // Whole-model single-graph paths read the single-device caches
             // (_kvCacheK, _deltaStateTensor) and the unsharded LM head, none of
@@ -1227,19 +1240,21 @@ namespace TensorSharp.Models
                 return false;
             // Fold final-norm + lm_head into the graph requires both present.
             if ((_lmHeadQW == null && _lmHeadF32 == null) || _finalNormW == null)
-                return false;
+                return FdBail("final-norm or lm_head weight missing");
             // All three GGML GPU backends persist and replay the fixed-topology
             // graph. CUDA/Vulkan use dynamic SET_ROWS KV writes; Metal moves CPY
             // destination views before replay, avoiding its problematic SET_ROWS
             // shape. GDN recurrence and MoE top-K routing remain device-resident.
-            if (!_fullDecodeEnabled || _fdUnsupported || _fdSpecSessionActive
+            if (!_fullDecodeEnabled || _fdSpecSessionActive
                 || (_backend != BackendType.GgmlCuda && _backend != BackendType.GgmlMetal
                     && _backend != BackendType.GgmlVulkan))
+                return false;
+            if (_fdUnsupported)
                 return false;
             if (!tokenInput &&
                 (hidden == null || hidden.DimensionCount != 2 || hidden.Sizes[0] != 1
                     || hidden.ElementType != DType.Float32))
-                return false;
+                return FdBail("hidden tensor shape/dtype not a single f32 row");
 
             // Keep the new token-input contract scoped to Metal for now. CUDA
             // supports only a subset of quantized GET_ROWS types and TP needs the
@@ -1277,11 +1292,11 @@ namespace TensorSharp.Models
             // [S_v, S_v, heads], so asymmetric key/value state widths cannot
             // enter the fused graph (the per-operation path remains available).
             if (_headKDim != _headVDim)
-                return false;
+                return FdBail($"asymmetric GDN state widths (K={_headKDim}, V={_headVDim})");
             int qkvDim = _headKDim * _numKHeads * 2 + _headVDim * _numVHeads;
             int convDim = _convKernel - 1;
             if (convDim <= 0)
-                return false;
+                return FdBail($"conv kernel too small ({_convKernel})");
 
             // --- one-time gate: every layer must have its required weights/state ---
             if (_fdLayers == null)
@@ -1313,7 +1328,11 @@ namespace TensorSharp.Models
                             && _deltaStateTensor[l] != null && _convState[l] != null;
                     if (!ok)
                     {
-                        _fdUnsupported = true; return false;
+                        _fdUnsupported = true;
+                        return FdBail($"layer {l} ({(_isRecurrent[l] ? "recurrent" : "attention")}, moe={isMoeL}) missing a required weight/state" +
+                            (!_isRecurrent[l] && _kvCacheK[l] != null && !IsFusedGraphKvCacheDType(_kvCacheK[l].ElementType)
+                                ? $" (KV cache dtype {_kvCacheK[l].ElementType} unsupported by fused graph on {_backend})"
+                                : ""));
                     }
                 }
                 int gdnCount = 0;
@@ -1342,7 +1361,7 @@ namespace TensorSharp.Models
                 }
             }
             if (cacheSize <= 0 || position >= cacheSize)
-                return false;
+                return FdBail($"KV cache capacity gate (cacheSize={cacheSize}, position={position})");
 
             int structBytes = Marshal.SizeOf<Qwen35LayerDecodeArgs>();
             int convBlock = convDim * qkvDim;


### PR DESCRIPTION
Found while bringing up Qwen3.8-27B (unsloth UD-Q4_K_XL) on `ggml_vulkan`. Four independent commits:

1. **Build fix:** ggml master added a `K` parameter to `ggml_ssm_scan`; pass `K=1` (identical semantics) at both call sites.
2. **Mixed-quant fusion:** UD GGUFs may store `ffn_gate`/`ffn_up` in different quant types (here IQ4_XS/Q5_K). `FuseGateUpWeights` silently skipped the pair, and dense FFN paths crashed on the null fused tensor. Now the lower-fidelity side is requantized to the other's type (parallel, via `ggml_quantize_chunk`) and fused as usual.
3. **Small-BAR workaround:** without Resizable BAR, ggml-vulkan's `DEVICE_LOCAL|HOST_VISIBLE` preference over-commits the 256 MB BAR heap (RADV doesn't fail the allocation), silently backing all weights with GTT — the GPU re-reads the model over PCIe every token. Detect small BAR via amdgpu sysfs before device init and set `GGML_VK_DISABLE_HOST_VISIBLE_VIDMEM=1`, with a one-line log; user-set values are respected. Likely affects all ggml-vulkan apps on non-ReBAR AMD systems.
4. **Diagnostics:** the Qwen35 fused whole-model decode declined silently; each gate now logs a one-time `[full-decode] not engaged: <reason>` line.

**Measured** (RX 7900 XTX, RADV, ReBAR off): Qwen3.8-27B decode 1.3 → **36.1 tok/s**, prefill ~13 → **837 tok/s**; Qwen3.5-9B decode 5.1 → **103.1 tok/s**. For reference, llama.cpp b10434 on the same GPU/GGUF: 32.5 tok/s (ROCm) / 15.8 (Vulkan).

Validated: clean build, both models generate correctly on `ggml_vulkan`, weight residency confirmed via amdgpu sysfs (VRAM after, GTT before).
