### PR TITLE
Fix out-bool marshalling of mlx_array_is_row_contiguous

### DIFF
--- a/TensorSharp.Backends.MLX/MlxNative.cs
+++ b/TensorSharp.Backends.MLX/MlxNative.cs
@@ -9349,7 +9349,7 @@ if (tile_b + TileSize <= InRows && tile_m + TileSize <= OutDim) {
         private static extern nuint mlx_array_size_native(MlxArray array);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "_mlx_array_is_row_contiguous")]
-        private static extern int mlx_array_is_row_contiguous_native(out bool result, MlxArray array);
+        private static extern int mlx_array_is_row_contiguous_native([MarshalAs(UnmanagedType.I1)] out bool result, MlxArray array);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "mlx_astype")]
         private static extern int mlx_astype(out MlxArray result, MlxArray array, int dtype, MlxStream stream);


### PR DESCRIPTION
`mlx_array_is_row_contiguous_native` declared its result as a plain `out bool`, which the runtime marshals as a 4-byte Win32 `BOOL`. The mlx-c side (`_mlx_array_is_row_contiguous(bool* res, ...)`) writes a 1-byte C `bool`, leaving the other 3 bytes of the marshaller's native slot uninitialized. Since the managed side reads all 4 bytes, a native `false` can nondeterministically come back as `true`.

The failure mode is silent: `IsRowContiguous` reporting `true` for a non-contiguous array makes the caller skip the `mlx_contiguous` copy and run downstream ops on strided data, i.e. wrong results rather than a crash.

Every other `out bool` extern in `MlxNative.cs` (e.g. `mlx_metal_is_available`, `mlx_device_is_available`) already carries `[MarshalAs(UnmanagedType.I1)]`; this brings the one stray declaration in line. One-line change, no behavior change on the correctly-marshalled paths.

## Verification

I don't have Apple hardware, so I couldn't run this on the MLX backend. What this rests on instead:

- The native signature is confirmed at the pinned mlx-c commit (`fba4470`): `int _mlx_array_is_row_contiguous(bool* res, const mlx_array arr)` — a 1-byte C `bool*`, while the default .NET `out bool` marshalling uses a 4-byte `BOOL`.
- The change makes this declaration identical in form to the other `out bool` externs in the same file (`mlx_metal_is_available`, `mlx_device_is_available`), which are known-working.
- `TensorSharp.Backends.MLX` builds cleanly with the change.

A smoke test on a Mac (any model load runs through `IsRowContiguous`) would be a welcome double-check from someone with the hardware.
