### PR TITLE
Marshal native-bound strings as UTF-8 instead of CharSet.Ansi

### DIFF
--- a/TensorSharp.Backends.GGML/GgmlDeepSeek4Native.cs
+++ b/TensorSharp.Backends.GGML/GgmlDeepSeek4Native.cs
@@ -24,13 +24,18 @@ namespace TensorSharp.GGML
             GgmlNative.EnsureImportResolverRegistered();
         }
 
-        [DllImport(DllName, CallingConvention = Conv, CharSet = CharSet.Ansi)]
-        private static extern IntPtr TSGgml_Dsv4LoadModel(string ggufPath, int nGpu, int nCtx, int nUbatch, int nThreads,
-            int nCpuMoe, string backendName);
+        // Paths must cross as UTF-8: ggml_fopen decodes them as UTF-8 on Windows,
+        // while CharSet.Ansi would marshal the active code page.
+        [DllImport(DllName, CallingConvention = Conv)]
+        private static extern IntPtr TSGgml_Dsv4LoadModel([MarshalAs(UnmanagedType.LPUTF8Str)] string ggufPath,
+            int nGpu, int nCtx, int nUbatch, int nThreads,
+            int nCpuMoe, [MarshalAs(UnmanagedType.LPUTF8Str)] string backendName);
 
-        [DllImport(DllName, CallingConvention = Conv, CharSet = CharSet.Ansi)]
-        private static extern IntPtr TSGgml_Dsv4LoadModelDspark(string ggufPath, int nGpu, int nCtx, int nUbatch,
-            int nThreads, string dsparkPath, int nCpuMoe, string backendName);
+        [DllImport(DllName, CallingConvention = Conv)]
+        private static extern IntPtr TSGgml_Dsv4LoadModelDspark([MarshalAs(UnmanagedType.LPUTF8Str)] string ggufPath,
+            int nGpu, int nCtx, int nUbatch,
+            int nThreads, [MarshalAs(UnmanagedType.LPUTF8Str)] string dsparkPath, int nCpuMoe,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string backendName);
 
         [DllImport(DllName, CallingConvention = Conv)]
         private static extern int TSGgml_Dsv4DsparkBlockSize(IntPtr handle);

--- a/TensorSharp.Backends.GGML/GgmlNative.cs
+++ b/TensorSharp.Backends.GGML/GgmlNative.cs
@@ -1070,8 +1070,10 @@ internal enum GgmlIndexReductionOp
         [DllImport(DllName, CallingConvention = CallingConventionType)]
         private static extern int TSGgml_IsMetalAvailable();
 
-        [DllImport(DllName, CallingConvention = CallingConventionType, CharSet = CharSet.Ansi)]
-        private static extern int TSGgml_SetNativeEnvironmentVariable(string name, string value, int overwrite);
+        [DllImport(DllName, CallingConvention = CallingConventionType)]
+        private static extern int TSGgml_SetNativeEnvironmentVariable(
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string value, int overwrite);
 
         [DllImport(DllName, CallingConvention = CallingConventionType)]
         private static extern int TSGgml_CanInitializeBackend(int backendType);


### PR DESCRIPTION
`ggml_fopen` (ggml.c:606) decodes incoming paths as UTF-8 on Windows and converts to `_wfopen`, but the managed side marshalled `ggufPath` with `CharSet.Ansi`, which produces active-code-page bytes. The two sides disagree about the encoding, so a GGUF path containing non-ASCII characters (e.g. a user directory with accented characters) fails to open in the DeepSeek4 loader on Windows. This change marshals every string crossing into GgmlOps as `LPUTF8Str` — the loader paths plus `TSGgml_SetNativeEnvironmentVariable`, whose consumers likewise treat values as raw/UTF-8 bytes. No `CharSet.Ansi` marshalling remains in the codebase.

**Why this is safe for existing setups:** for pure-ASCII strings, UTF-8 bytes are byte-identical to ANSI bytes, and on Linux/macOS the runtime already marshalled `CharSet.Ansi` as UTF-8 — so the only behavior change is the previously-broken case (non-ASCII paths on Windows).

## Verification

I don't have Windows hardware to reproduce the failing case, so the fix rests on the encoding contract being visible on both sides in this repo: `ggml_fopen`'s UTF-8 decode versus the active-code-page bytes `CharSet.Ansi` produces.

Verified on Linux (RX 7900 XTX box) that the changed externs still bind and succeed:

- Backend init runs `TSGgml_SetNativeEnvironmentVariable` through the new marshalling (the Vulkan small-BAR workaround path) and succeeds.
- A direct call with a non-ASCII name/value (`TS_UTF8_SMOKE_ÄÖÜ` = `wert_日本語`) returns success through the new marshalling.
- `TensorSharp.Backends.GGML` builds with 0 errors.

A quick load of any DeepSeek4 GGUF from a non-ASCII directory on Windows would be a welcome double-check from someone with the hardware.
