### PR TITLE
Confine /api/chat attachment paths to the upload directory

### DIFF
--- a/InferenceWeb.Tests/ChatAttachmentPathGuardTests.cs
+++ b/InferenceWeb.Tests/ChatAttachmentPathGuardTests.cs
@@ -1,0 +1,97 @@
+using TensorSharp.Runtime;
+using TensorSharp.Server.RequestParsers;
+
+namespace InferenceWeb.Tests;
+
+/// <summary>
+/// Web UI /api/chat attachment paths (imagePaths/audioPaths/textFilePaths)
+/// arrive as client-supplied absolute paths that the multimodal injector later
+/// opens, so every one must resolve inside the upload directory. These check
+/// that paths outside it — including a sibling directory that shares the root's
+/// name — are rejected.
+/// </summary>
+public class ChatAttachmentPathGuardTests : IDisposable
+{
+    private readonly string _baseDir;
+    private readonly string _uploadRoot;
+
+    public ChatAttachmentPathGuardTests()
+    {
+        _baseDir = Path.Combine(Path.GetTempPath(), "ts-chat-path-guard-" + Guid.NewGuid().ToString("N"));
+        _uploadRoot = Path.Combine(_baseDir, "uploads");
+        Directory.CreateDirectory(_uploadRoot);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static List<ChatMessage> MessageWithImage(string path) =>
+        new() { new ChatMessage { Role = "user", Content = "hi", ImagePaths = new List<string> { path } } };
+
+    [Fact]
+    public void PathInsideUploadRoot_IsAccepted()
+    {
+        string inside = Path.Combine(_uploadRoot, "img.png");
+        Assert.Null(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage(inside), _uploadRoot));
+    }
+
+    [Fact]
+    public void AbsolutePathOutsideUploadRoot_IsRejected()
+    {
+        string secret = Path.Combine(_baseDir, "secret.png");
+        File.WriteAllText(secret, "top secret");
+
+        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage(secret), _uploadRoot));
+    }
+
+    [Fact]
+    public void TraversalOutOfUploadRoot_IsRejected()
+    {
+        string traversal = Path.Combine(_uploadRoot, "..", "secret.png");
+        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage(traversal), _uploadRoot));
+    }
+
+    [Fact]
+    public void SiblingDirectorySharingPrefix_IsRejected()
+    {
+        string sibling = Path.Combine(_baseDir, "uploads-evil");
+        Directory.CreateDirectory(sibling);
+        string path = Path.Combine(sibling, "img.png");
+
+        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage(path), _uploadRoot));
+    }
+
+    [Fact]
+    public void AudioAndTextFilePaths_AreValidatedToo()
+    {
+        string outside = Path.Combine(_baseDir, "outside.wav");
+        var audio = new List<ChatMessage>
+        {
+            new ChatMessage { Role = "user", Content = "hi", AudioPaths = new List<string> { outside } }
+        };
+        var text = new List<ChatMessage>
+        {
+            new ChatMessage { Role = "user", Content = "hi", TextFilePaths = new List<string> { outside } }
+        };
+
+        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(audio, _uploadRoot));
+        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(text, _uploadRoot));
+    }
+
+    [Fact]
+    public void NullOrEmptyPathEntry_IsRejected()
+    {
+        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage(null), _uploadRoot));
+        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage("  "), _uploadRoot));
+    }
+
+    [Fact]
+    public void MessagesWithoutAttachments_AreAccepted()
+    {
+        var plain = new List<ChatMessage> { new ChatMessage { Role = "user", Content = "hi" } };
+        Assert.Null(ChatMessageParser.ValidateAttachmentPaths(plain, _uploadRoot));
+        Assert.Null(ChatMessageParser.ValidateAttachmentPaths(null, _uploadRoot));
+    }
+}

--- a/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
+++ b/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
@@ -1134,6 +1134,16 @@ namespace TensorSharp.Server.ProtocolAdapters
 
             var messages = ChatMessageParser.ParseWebUi(messagesEl);
 
+            string attachmentError = ChatMessageParser.ValidateAttachmentPaths(messages, _options.UploadDirectory);
+            if (attachmentError != null)
+            {
+                webUiLogger.LogWarning(LogEventIds.HttpRequestRejected,
+                    "/api/chat rejected: attachment path outside upload directory");
+                ctx.Response.StatusCode = 400;
+                await ctx.Response.WriteAsJsonAsync(new { error = attachmentError });
+                return;
+            }
+
             SseWriter.ApplyHeaders(ctx.Response);
 
             using var ticket = _queue.Enqueue(ctx.RequestAborted);

--- a/TensorSharp.Server/RequestParsers/ChatMessageParser.cs
+++ b/TensorSharp.Server/RequestParsers/ChatMessageParser.cs
@@ -66,6 +66,56 @@ namespace TensorSharp.Server.RequestParsers
         }
 
         /// <summary>
+        /// Validate that every client-supplied attachment path resolves inside
+        /// the upload directory. Returns an error message, or null when all
+        /// paths are acceptable.
+        /// </summary>
+        public static string ValidateAttachmentPaths(List<ChatMessage> messages, string uploadRoot)
+        {
+            if (messages == null)
+                return null;
+
+            string root = Path.GetFullPath(uploadRoot);
+
+            foreach (var msg in messages)
+            {
+                string error = ValidatePathList(msg?.ImagePaths, root)
+                    ?? ValidatePathList(msg?.AudioPaths, root)
+                    ?? ValidatePathList(msg?.TextFilePaths, root);
+                if (error != null)
+                    return error;
+            }
+            return null;
+        }
+
+        private static string ValidatePathList(List<string> paths, string root)
+        {
+            if (paths == null)
+                return null;
+
+            foreach (var path in paths)
+            {
+                if (string.IsNullOrWhiteSpace(path) || !IsInsideDirectory(root, path))
+                    return "Attachment path must reference a previously uploaded file.";
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// True when <paramref name="path"/> resolves inside <paramref name="root"/>.
+        /// Traversal and a sibling directory that merely shares the root's name
+        /// both resolve outside and are rejected. <paramref name="root"/> must
+        /// already be a full path.
+        /// </summary>
+        private static bool IsInsideDirectory(string root, string path)
+        {
+            string relative = Path.GetRelativePath(root, path);
+            return relative != ".."
+                && !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                && !Path.IsPathRooted(relative);
+        }
+
+        /// <summary>
         /// Parse Ollama's messages array. Ollama embeds images per-message as a
         /// base64 array under <c>"images"</c>; we materialise each one as a PNG
         /// in the upload directory and reference them by absolute path.


### PR DESCRIPTION
The Web UI references uploaded files by absolute path, and `ChatMessageParser.ParseWebUi` passed `imagePaths` / `audioPaths` / `textFilePaths` through to the multimodal injector verbatim. The injector opens those paths, so an unauthenticated caller could name any path the server process can read (bounded only by "must decode as image/audio", plus a path-existence oracle) — an arbitrary local file read.

Every attachment path is now validated to resolve inside the upload directory before inference; a path outside it is rejected with 400. Containment is checked with `Path.GetRelativePath` (which resolves `..` and is case-correct per platform), so both directory traversal and a sibling directory that merely shares the root's name are rejected.

The Ollama and OpenAI adapters materialize attachments from base64 into the upload directory themselves, so the Web UI path was the only surface taking client-supplied absolute paths.

**Verification:** `ChatAttachmentPathGuardTests` (7 tests) — inside-root accepted; absolute-outside, traversal, sibling-prefix, and null/empty rejected; audio and text paths validated alongside images. Full suite green.
