### PR TITLE
Clamp generation reserve to remaining context

### DIFF
--- a/InferenceWeb.Tests/ClampGenerationReserveTests.cs
+++ b/InferenceWeb.Tests/ClampGenerationReserveTests.cs
@@ -1,0 +1,56 @@
+using TensorSharp.Server;
+
+namespace InferenceWeb.Tests;
+
+/// <summary>
+/// The generation reserve (max new tokens) is clamped to the context room the
+/// prompt leaves, so a large default reserve on a small-context model still
+/// admits a short prompt while a genuine overflow is left to the caller.
+/// </summary>
+public class ClampGenerationReserveTests
+{
+    [Fact]
+    public void OversizedReserve_ShrinksToRoomLeftByPrompt()
+    {
+        // 100-token prompt on a 4096 context with the 20000 default keeps a
+        // generous reserve: the remaining 3996 tokens.
+        Assert.Equal(3996, ChatGenerationPipeline.ClampGenerationReserve(20000, 100, 4096));
+    }
+
+    [Fact]
+    public void ReserveThatAlreadyFits_IsUnchanged()
+    {
+        Assert.Equal(200, ChatGenerationPipeline.ClampGenerationReserve(200, 100, 4096));
+    }
+
+    [Fact]
+    public void ReserveExactlyFillingContext_IsUnchanged()
+    {
+        Assert.Equal(3996, ChatGenerationPipeline.ClampGenerationReserve(3996, 100, 4096));
+    }
+
+    [Fact]
+    public void PromptAloneOverflowsContext_ReserveFloorsAtOne()
+    {
+        Assert.Equal(1, ChatGenerationPipeline.ClampGenerationReserve(20000, 5000, 4096));
+    }
+
+    [Fact]
+    public void PromptEqualToContext_ReserveFloorsAtOne()
+    {
+        Assert.Equal(1, ChatGenerationPipeline.ClampGenerationReserve(20000, 4096, 4096));
+    }
+
+    [Fact]
+    public void UnknownContext_LeavesReserveUntouched()
+    {
+        Assert.Equal(20000, ChatGenerationPipeline.ClampGenerationReserve(20000, 100, 0));
+    }
+
+    [Fact]
+    public void LargeContext_LeavesGenerousReserveUntouched()
+    {
+        // 32k context, 20000 default, short prompt: nothing to clamp.
+        Assert.Equal(20000, ChatGenerationPipeline.ClampGenerationReserve(20000, 500, 32768));
+    }
+}

--- a/TensorSharp.Server/ChatGenerationPipeline.cs
+++ b/TensorSharp.Server/ChatGenerationPipeline.cs
@@ -200,6 +200,7 @@ namespace TensorSharp.Server
 
             var promptSw = Stopwatch.StartNew();
             List<int> inputTokens;
+            int effectiveMaxTokens;
             bool hasMultimodal = RequiresMultimodalPreparation(renderHistory);
             if (hasMultimodal)
             {
@@ -243,8 +244,8 @@ namespace TensorSharp.Server
                     injectorBucketCreated = true;
                     inputTokens = model.MultimodalInjector.ProcessPromptTokens(renderHistory, inputTokens, requestId);
                     inputTokens = TruncatePromptToContext(
-                        session, inputTokens, maxTokens, requestId, preserveAttachedDocuments,
-                        engineContextLimit);
+                        session, inputTokens, maxTokens, out effectiveMaxTokens, requestId,
+                        preserveAttachedDocuments, engineContextLimit);
                 }
             }
             else
@@ -253,7 +254,8 @@ namespace TensorSharp.Server
                     model.Tokenizer, model.Config.ChatTemplate, renderHistory, arch,
                     addGenerationPrompt: true, tools: tools, enableThinking: enableThinking);
                 inputTokens = TruncatePromptToContext(
-                    session, inputTokens, maxTokens, preserveAllInput: preserveAttachedDocuments,
+                    session, inputTokens, maxTokens, out effectiveMaxTokens,
+                    preserveAllInput: preserveAttachedDocuments,
                     executionContextLimit: engineContextLimit);
             }
 
@@ -271,7 +273,7 @@ namespace TensorSharp.Server
             var seq = new SequenceState(
                 requestId: requestId,
                 promptTokens: inputTokens,
-                maxNewTokens: maxTokens,
+                maxNewTokens: effectiveMaxTokens,
                 blockSize: enginePoolStats.blockSize,
                 samplingConfig: cfg,
                 userTag: session,
@@ -452,7 +454,7 @@ namespace TensorSharp.Server
                 model.Tokenizer, model.Config.ChatTemplate, renderHistory, arch,
                 addGenerationPrompt: true, tools: null, enableThinking: false);
             inputTokens = TruncatePromptToContext(
-                session, inputTokens, maxTokens, preserveAllInput: preserveAttachedDocuments);
+                session, inputTokens, maxTokens, out _, preserveAllInput: preserveAttachedDocuments);
             int promptTokenCount = inputTokens.Count;
             promptSw.Stop();
 
@@ -590,6 +592,7 @@ namespace TensorSharp.Server
             ChatSession session,
             List<int> inputTokens,
             int maxTokens,
+            out int effectiveMaxTokens,
             string requestId = null,
             bool preserveAllInput = false,
             int executionContextLimit = 0)
@@ -599,11 +602,17 @@ namespace TensorSharp.Server
             if (executionContextLimit > 0 && (maxCtx <= 0 || executionContextLimit < maxCtx))
                 maxCtx = executionContextLimit;
             int inputCount = inputTokens?.Count ?? 0;
-            RejectAttachedDocumentOverflow(inputCount, maxTokens, maxCtx, preserveAllInput);
-            if (maxCtx <= 0 || inputTokens == null || (long)inputCount + maxTokens <= maxCtx)
+
+            // Shrink the reserve to the room the prompt leaves. The clamped
+            // value is what the engine reserves, so it flows back to the caller
+            // for maxNewTokens.
+            effectiveMaxTokens = ClampGenerationReserve(maxTokens, inputCount, maxCtx);
+
+            RejectAttachedDocumentOverflow(inputCount, effectiveMaxTokens, maxCtx, preserveAllInput);
+            if (maxCtx <= 0 || inputTokens == null || (long)inputCount + effectiveMaxTokens <= maxCtx)
                 return inputTokens;
 
-            int available = maxCtx - maxTokens;
+            int available = maxCtx - effectiveMaxTokens;
             if (available < 1)
             {
                 throw new InvalidOperationException(
@@ -623,10 +632,26 @@ namespace TensorSharp.Server
 
             _logger.LogWarning(LogEventIds.PromptTruncated,
                 "prompt.truncated from {OriginalTokens} to {KeptTokens} tokens (contextLimit={ContextLimit}, generationReserve={MaxTokens}, sessionId={SessionId})",
-                inputTokens.Count, kept, maxCtx, maxTokens, session?.Id ?? "(none)");
+                inputTokens.Count, kept, maxCtx, effectiveMaxTokens, session?.Id ?? "(none)");
             model.MultimodalInjector.TrimPreparedPrompt(trimStart, requestId);
             session?.TrackedHistory.Clear();
             return inputTokens.GetRange(trimStart, kept);
+        }
+
+        /// <summary>
+        /// Clamp a generation reserve to the context room the prompt leaves, so
+        /// a large default reserve on a small-context model still admits a short
+        /// prompt. The reserve is only ever shrunk, never below 1, and never
+        /// when the context length is unknown. A prompt that alone overflows the
+        /// context is left for the caller's trim/reject logic.
+        /// </summary>
+        internal static int ClampGenerationReserve(int requestedReserve, int promptTokenCount, int contextLimit)
+        {
+            if (contextLimit <= 0)
+                return requestedReserve;
+
+            int room = Math.Max(1, contextLimit - promptTokenCount);
+            return Math.Min(requestedReserve, room);
         }
 
         internal static void RejectAttachedDocumentOverflow(


### PR DESCRIPTION
The default generation reserve (`--max-tokens`, fallback 20000) was never bounded by the context window. On any model whose effective context is smaller than the reserve — e.g. `MAX_CONTEXT=8192`, or the 4096 metadata fallback — `TruncatePromptToContext` computed a negative available budget and rejected *every* request with "Prompt exceeds the model's context limit", even a three-token prompt. The scheduler's capacity check fails the same way once the reserve reaches it.

The reserve is now clamped to the room the prompt leaves (never below 1, never when the context length is unknown), and the clamped value flows through to the engine's `maxNewTokens` — otherwise the failure would simply relocate to the scheduler. A prompt that alone overflows the context still falls through to the existing trim/reject path.

**Verification:** `ClampGenerationReserveTests` (7 tests) covering oversized-reserve shrink, reserve-already-fits, prompt-alone-overflows (floors at 1), and unknown-context (untouched). Full suite green.
