### PR TITLE
Map prompt-context overflow to HTTP 400 instead of 500

### DIFF
--- a/InferenceWeb.Tests/ChatGenerationPipelineDocumentTests.cs
+++ b/InferenceWeb.Tests/ChatGenerationPipelineDocumentTests.cs
@@ -15,7 +15,7 @@ public class ChatGenerationPipelineDocumentTests
     [Fact]
     public void RejectAttachedDocumentOverflow_RejectsInsteadOfSilentlyTruncating()
     {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.Throws<PromptContextOverflowException>(() =>
             ChatGenerationPipeline.RejectAttachedDocumentOverflow(
                 promptTokens: 130_000,
                 maxTokens: 4_096,

--- a/InferenceWeb.Tests/PromptOverflowMiddlewareTests.cs
+++ b/InferenceWeb.Tests/PromptOverflowMiddlewareTests.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using TensorSharp.Server;
+using TensorSharp.Server.Logging;
+
+namespace InferenceWeb.Tests;
+
+/// <summary>
+/// A prompt that does not fit the context window must surface as an HTTP 400
+/// with a protocol-appropriate JSON body. The overflow is thrown during prompt
+/// preparation, before any response body is written, so the middleware can
+/// still set the status.
+/// </summary>
+public class PromptOverflowMiddlewareTests
+{
+    private static DefaultHttpContext ContextFor(string path)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Path = path;
+        ctx.Response.Body = new MemoryStream();
+        return ctx;
+    }
+
+    private static async Task<string> BodyOf(HttpContext ctx)
+    {
+        ctx.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(ctx.Response.Body, Encoding.UTF8);
+        return await reader.ReadToEndAsync();
+    }
+
+    [Fact]
+    public async Task Overflow_OnOpenAiRoute_Becomes400WithOpenAiErrorShape()
+    {
+        var ctx = ContextFor("/v1/chat/completions");
+
+        await PromptOverflowMiddleware.InvokeAsync(ctx,
+            () => throw new PromptContextOverflowException("Prompt (9000 tokens) exceeds the model's context limit (4096 tokens)."));
+
+        Assert.Equal(400, ctx.Response.StatusCode);
+        using var doc = JsonDocument.Parse(await BodyOf(ctx));
+        var error = doc.RootElement.GetProperty("error");
+        Assert.Equal("invalid_request_error", error.GetProperty("type").GetString());
+        Assert.Contains("context limit", error.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task Overflow_OnOllamaRoute_Becomes400WithFlatErrorShape()
+    {
+        var ctx = ContextFor("/api/generate");
+
+        await PromptOverflowMiddleware.InvokeAsync(ctx,
+            () => throw new PromptContextOverflowException("Prompt exceeds the model's context limit."));
+
+        Assert.Equal(400, ctx.Response.StatusCode);
+        using var doc = JsonDocument.Parse(await BodyOf(ctx));
+        Assert.Equal(JsonValueKind.String, doc.RootElement.GetProperty("error").ValueKind);
+    }
+
+    [Fact]
+    public async Task NonOverflowException_IsNotSwallowed()
+    {
+        var ctx = ContextFor("/v1/chat/completions");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            PromptOverflowMiddleware.InvokeAsync(ctx,
+                () => throw new InvalidOperationException("something else")));
+    }
+
+    [Fact]
+    public async Task Overflow_AfterResponseStarted_IsNotConvertedTo400()
+    {
+        // A stream already in flight: the body is committed, so the status
+        // can't be rewritten and the exception must propagate.
+        var ctx = ContextFor("/v1/chat/completions");
+        ctx.Features.Set<Microsoft.AspNetCore.Http.Features.IHttpResponseFeature>(new StartedResponseFeature());
+
+        await Assert.ThrowsAsync<PromptContextOverflowException>(() =>
+            PromptOverflowMiddleware.InvokeAsync(ctx,
+                () => throw new PromptContextOverflowException("too long")));
+    }
+
+    private sealed class StartedResponseFeature : Microsoft.AspNetCore.Http.Features.IHttpResponseFeature
+    {
+        public int StatusCode { get; set; } = 200;
+        public string ReasonPhrase { get; set; }
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+        public Stream Body { get; set; } = new MemoryStream();
+        public bool HasStarted => true;
+        public void OnStarting(System.Func<object, Task> callback, object state) { }
+        public void OnCompleted(System.Func<object, Task> callback, object state) { }
+    }
+
+    [Fact]
+    public async Task NoException_PassesThroughUntouched()
+    {
+        var ctx = ContextFor("/v1/chat/completions");
+        ctx.Response.StatusCode = 200;
+
+        await PromptOverflowMiddleware.InvokeAsync(ctx, () => Task.CompletedTask);
+
+        Assert.Equal(200, ctx.Response.StatusCode);
+    }
+}

--- a/TensorSharp.Server/ChatGenerationPipeline.cs
+++ b/TensorSharp.Server/ChatGenerationPipeline.cs
@@ -606,7 +606,7 @@ namespace TensorSharp.Server
             int available = maxCtx - maxTokens;
             if (available < 1)
             {
-                throw new InvalidOperationException(
+                throw new PromptContextOverflowException(
                     $"Prompt ({inputTokens.Count} tokens) exceeds the model's context limit ({maxCtx} tokens). " +
                     "Please shorten the input or reduce attached file size.");
             }
@@ -616,7 +616,7 @@ namespace TensorSharp.Server
             int kept = inputTokens.Count - trimStart;
             if (kept < 1)
             {
-                throw new InvalidOperationException(
+                throw new PromptContextOverflowException(
                     $"Prompt ({inputTokens.Count} tokens) exceeds the model's context limit ({maxCtx} tokens). " +
                     "Please shorten the input or reduce attached file size.");
             }
@@ -641,7 +641,7 @@ namespace TensorSharp.Server
                 return;
             }
 
-            throw new InvalidOperationException(
+            throw new PromptContextOverflowException(
                 $"The prompt containing the complete attached document requires {promptTokens} prompt " +
                 $"tokens plus a {maxTokens}-token generation reserve, but the current model/engine " +
                 $"configuration allows {modelContextLimit} context tokens. No document content was " +

--- a/TensorSharp.Server/Logging/PromptOverflowMiddleware.cs
+++ b/TensorSharp.Server/Logging/PromptOverflowMiddleware.cs
@@ -1,0 +1,54 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace TensorSharp.Server.Logging
+{
+    /// <summary>
+    /// Maps a <see cref="PromptContextOverflowException"/> — a client input
+    /// error (the prompt does not fit the context window) — to a 400 with a
+    /// protocol-appropriate JSON body. The overflow surfaces during prompt
+    /// preparation, before any response body is written, so the status is still
+    /// settable. Once the response has started, the exception is left to
+    /// propagate.
+    /// </summary>
+    internal static class PromptOverflowMiddleware
+    {
+        public static IApplicationBuilder UsePromptOverflowHandling(this IApplicationBuilder app)
+        {
+            return app.Use(next => context => InvokeAsync(context, () => next(context)));
+        }
+
+        internal static async Task InvokeAsync(HttpContext context, System.Func<Task> next)
+        {
+            try
+            {
+                await next();
+            }
+            catch (PromptContextOverflowException ex) when (!context.Response.HasStarted)
+            {
+                await WriteBadRequestAsync(context, ex.Message);
+            }
+        }
+
+        private static async Task WriteBadRequestAsync(HttpContext context, string message)
+        {
+            context.Response.Clear();
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+
+            // OpenAI SDKs parse {error:{message,type}}; the Ollama and Web UI
+            // clients expect a flat {error:"..."}. Shape by route prefix.
+            if (context.Request.Path.StartsWithSegments("/v1"))
+            {
+                await context.Response.WriteAsJsonAsync(new
+                {
+                    error = new { message, type = "invalid_request_error", code = "context_length_exceeded" }
+                });
+            }
+            else
+            {
+                await context.Response.WriteAsJsonAsync(new { error = message });
+            }
+        }
+    }
+}

--- a/TensorSharp.Server/Program.cs
+++ b/TensorSharp.Server/Program.cs
@@ -244,6 +244,10 @@ if (qwenImageFlagsApplied)
 StartupBanner.EmitBackendFallback(startupLogger, hostingOptions, configuredBackendInput);
 
 app.UseTensorSharpRequestLogging();
+// Convert a prompt-doesn't-fit-context failure into a 400. After request
+// logging so the rejection is still traced; before the endpoints so it covers
+// every protocol surface.
+app.UsePromptOverflowHandling();
 // Serve the bundled static UI. GET / sends index.html too (see
 // HealthEndpoints), so a bare http://host:port/ opens the chat UI; the plain
 // liveness response moved to GET /health and still answers / on headless

--- a/TensorSharp.Server/PromptContextOverflowException.cs
+++ b/TensorSharp.Server/PromptContextOverflowException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace TensorSharp.Server
+{
+    /// <summary>
+    /// The prompt, plus its generation reserve, does not fit the model's
+    /// context window — a client input error the HTTP layer maps to 400.
+    /// Derives from <see cref="InvalidOperationException"/> so callers that
+    /// catch the broader type still handle it.
+    /// </summary>
+    public sealed class PromptContextOverflowException : InvalidOperationException
+    {
+        public PromptContextOverflowException(string message) : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
A prompt that does not fit the context window threw a raw `InvalidOperationException` from the prompt-preparation stage. With no exception handler in the pipeline, the OpenAI and Ollama endpoints surfaced it as an unhandled 500 (or a torn SSE stream); only the Web UI caught it.

This introduces a typed `PromptContextOverflowException` and a small middleware that maps it to a 400 with a protocol-appropriate body — an OpenAI error object on `/v1`, a flat `{error}` elsewhere. The overflow is detected during prompt preparation, before any token is written, so the status is still settable, including for streaming requests. Once the response has started the exception is left to propagate, and the middleware never masks unrelated exceptions.

**Verification:** `PromptOverflowMiddlewareTests` (5 tests) — OpenAI and Ollama error shapes, non-overflow exceptions pass through, an already-started response is left alone. Confirmed end-to-end against a local GGUF (`MAX_CONTEXT=2048`, reserve 2048): `main` returns 500 on both `POST /v1/chat/completions` and `POST /api/generate`; this branch returns 400 (including `stream=true`). Full suite green.

Note: touches the same lines of `TruncatePromptToContext` / `RejectAttachedDocumentOverflow` as #147; whichever merges second rebases cleanly on the other.
