### PR TITLE
Restrict uploads to an extension allow-list with safe serve content types

### DIFF
--- a/InferenceWeb.Tests/UploadContentPolicyTests.cs
+++ b/InferenceWeb.Tests/UploadContentPolicyTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+using TensorSharp.Server.Hosting;
+
+namespace InferenceWeb.Tests;
+
+/// <summary>
+/// Tests for <see cref="UploadContentPolicy"/>: the upload extension allow-list
+/// and the content types /uploads serves back. Uploaded files are attacker
+/// content, so an uploaded .html/.svg must never come back with a content type
+/// a browser will execute in the server's origin.
+/// </summary>
+public class UploadContentPolicyTests
+{
+    [Theory]
+    [InlineData(".png", "image")]
+    [InlineData(".jpeg", "image")]
+    [InlineData(".heic", "image")]
+    [InlineData(".mp4", "video")]
+    [InlineData(".mp3", "audio")]
+    [InlineData(".pdf", "pdf")]
+    [InlineData(".txt", "text")]
+    [InlineData(".html", "text")]
+    [InlineData(".cs", "text")]
+    public void Classify_KnownExtensions_KeepTheirMediaType(string ext, string expected)
+    {
+        Assert.Equal(expected, UploadContentPolicy.Classify(ext));
+    }
+
+    [Theory]
+    [InlineData(".svg")]
+    [InlineData(".exe")]
+    [InlineData(".xhtml")]
+    [InlineData(".docx")]
+    [InlineData("")]
+    public void Classify_UnlistedExtensions_AreUnknown(string ext)
+    {
+        Assert.Equal("unknown", UploadContentPolicy.Classify(ext));
+    }
+
+    [Theory]
+    [InlineData(".png", "image/png")]
+    [InlineData(".jpg", "image/jpeg")]
+    [InlineData(".heic", "image/heic")]
+    [InlineData(".heif", "image/heif")]
+    [InlineData(".mp4", "video/mp4")]
+    [InlineData(".webm", "video/webm")]
+    [InlineData(".wav", "audio/wav")]
+    [InlineData(".pdf", "application/pdf")]
+    public void Serve_MediaExtensions_KeepRealContentTypes(string ext, string expected)
+    {
+        var provider = UploadContentPolicy.BuildServeContentTypes();
+        Assert.True(provider.TryGetContentType("f" + ext, out string contentType));
+        Assert.Equal(expected, contentType);
+    }
+
+    [Theory]
+    [InlineData(".html")]
+    [InlineData(".js")]
+    [InlineData(".css")]
+    [InlineData(".xml")]
+    [InlineData(".md")]
+    [InlineData(".json")]
+    [InlineData(".txt")]
+    public void Serve_TextExtensions_AlwaysComeBackAsPlainText(string ext)
+    {
+        var provider = UploadContentPolicy.BuildServeContentTypes();
+        Assert.True(provider.TryGetContentType("f" + ext, out string contentType));
+        Assert.Equal("text/plain; charset=utf-8", contentType);
+    }
+
+    [Theory]
+    [InlineData("f.svg")]
+    [InlineData("f.exe")]
+    [InlineData("f.xhtml")]
+    [InlineData("f")]
+    public void Serve_UnlistedExtensions_HaveNoContentType(string fileName)
+    {
+        var provider = UploadContentPolicy.BuildServeContentTypes();
+        Assert.False(provider.TryGetContentType(fileName, out _));
+    }
+
+    [Fact]
+    public void Serve_CoversEveryAcceptedUploadExtension()
+    {
+        var provider = UploadContentPolicy.BuildServeContentTypes();
+        foreach (string ext in UploadContentPolicy.SupportedExtensions)
+            Assert.True(provider.TryGetContentType("f" + ext, out _),
+                $"accepted upload extension {ext} has no serve content type");
+    }
+
+    [Fact]
+    public void StaticFileOptions_MountUploadsWithNosniffAndNoUnknownTypes()
+    {
+        string dir = Directory.CreateTempSubdirectory("ts-uploads-test").FullName;
+        try
+        {
+            var options = UploadContentPolicy.BuildStaticFileOptions(dir);
+
+            Assert.Equal("/uploads", options.RequestPath.Value);
+            Assert.False(options.ServeUnknownFileTypes);
+
+            var responseContext = new StaticFileResponseContext(
+                new DefaultHttpContext(), new NotFoundFileInfo("f.png"));
+            options.OnPrepareResponse(responseContext);
+            Assert.Equal("nosniff",
+                responseContext.Context.Response.Headers["X-Content-Type-Options"]);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/TensorSharp.Server/Hosting/UploadContentPolicy.cs
+++ b/TensorSharp.Server/Hosting/UploadContentPolicy.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+
+namespace TensorSharp.Server.Hosting
+{
+    /// <summary>
+    /// Single source of truth for which upload extensions the server accepts
+    /// and what content type <c>/uploads</c> serves each one back with.
+    /// Uploaded files are untrusted, so every text/code extension is served as
+    /// <c>text/plain</c> — an uploaded .html page must never execute in the
+    /// server's origin — and unlisted extensions are rejected at upload and
+    /// unmapped (404) when served.
+    /// </summary>
+    internal static class UploadContentPolicy
+    {
+        private const string TextPlain = "text/plain; charset=utf-8";
+
+        // Value = (media type reported to the Web UI, content type served on /uploads).
+        private static readonly Dictionary<string, (string MediaType, string ContentType)> Extensions =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                [".png"] = ("image", "image/png"),
+                [".jpg"] = ("image", "image/jpeg"),
+                [".jpeg"] = ("image", "image/jpeg"),
+                [".gif"] = ("image", "image/gif"),
+                [".webp"] = ("image", "image/webp"),
+                [".bmp"] = ("image", "image/bmp"),
+                // HEIC/HEIF (iPhone photos): browsers can't render them in <img> —
+                // the Web UI shows the server-generated PNG previewUrl — but the
+                // original must stay downloadable, and the default provider has no
+                // mapping for either extension.
+                [".heic"] = ("image", "image/heic"),
+                [".heif"] = ("image", "image/heif"),
+
+                [".mp4"] = ("video", "video/mp4"),
+                [".mov"] = ("video", "video/quicktime"),
+                [".avi"] = ("video", "video/x-msvideo"),
+                [".mkv"] = ("video", "video/x-matroska"),
+                [".webm"] = ("video", "video/webm"),
+
+                [".mp3"] = ("audio", "audio/mpeg"),
+                [".wav"] = ("audio", "audio/wav"),
+                [".ogg"] = ("audio", "audio/ogg"),
+                [".flac"] = ("audio", "audio/flac"),
+                [".m4a"] = ("audio", "audio/mp4"),
+
+                [".pdf"] = ("pdf", "application/pdf"),
+
+                [".txt"] = ("text", TextPlain),
+                [".csv"] = ("text", TextPlain),
+                [".json"] = ("text", TextPlain),
+                [".xml"] = ("text", TextPlain),
+                [".md"] = ("text", TextPlain),
+                [".log"] = ("text", TextPlain),
+                [".py"] = ("text", TextPlain),
+                [".js"] = ("text", TextPlain),
+                [".ts"] = ("text", TextPlain),
+                [".cs"] = ("text", TextPlain),
+                [".java"] = ("text", TextPlain),
+                [".cpp"] = ("text", TextPlain),
+                [".c"] = ("text", TextPlain),
+                [".h"] = ("text", TextPlain),
+                [".html"] = ("text", TextPlain),
+                [".css"] = ("text", TextPlain),
+                [".yaml"] = ("text", TextPlain),
+                [".yml"] = ("text", TextPlain),
+                [".toml"] = ("text", TextPlain),
+                [".ini"] = ("text", TextPlain),
+                [".cfg"] = ("text", TextPlain),
+                [".sh"] = ("text", TextPlain),
+                [".bat"] = ("text", TextPlain),
+                [".ps1"] = ("text", TextPlain),
+                [".rb"] = ("text", TextPlain),
+                [".go"] = ("text", TextPlain),
+                [".rs"] = ("text", TextPlain),
+                [".swift"] = ("text", TextPlain),
+                [".kt"] = ("text", TextPlain),
+                [".sql"] = ("text", TextPlain),
+                [".r"] = ("text", TextPlain),
+                [".m"] = ("text", TextPlain),
+                [".tex"] = ("text", TextPlain),
+                [".rtf"] = ("text", TextPlain),
+            };
+
+        internal static IEnumerable<string> SupportedExtensions => Extensions.Keys;
+
+        /// <summary>
+        /// Media type for an upload extension: image, video, audio, pdf, text,
+        /// or "unknown" for anything unlisted. Unknown uploads are rejected.
+        /// </summary>
+        internal static string Classify(string ext) =>
+            Extensions.TryGetValue(ext, out var entry) ? entry.MediaType : "unknown";
+
+        internal static IContentTypeProvider BuildServeContentTypes() =>
+            new FileExtensionContentTypeProvider(Extensions.ToDictionary(
+                kv => kv.Key, kv => kv.Value.ContentType, StringComparer.OrdinalIgnoreCase));
+
+        internal static StaticFileOptions BuildStaticFileOptions(string uploadDirectory) => new()
+        {
+            FileProvider = new PhysicalFileProvider(uploadDirectory),
+            RequestPath = "/uploads",
+            ContentTypeProvider = BuildServeContentTypes(),
+            OnPrepareResponse = ctx =>
+                ctx.Context.Response.Headers["X-Content-Type-Options"] = "nosniff",
+        };
+    }
+}

--- a/TensorSharp.Server/Program.cs
+++ b/TensorSharp.Server/Program.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using TensorSharp.GGML;
 using TensorSharp.Runtime.Logging;
@@ -254,19 +253,12 @@ app.UsePromptOverflowHandling();
 // deployments that ship no wwwroot content.
 app.UseDefaultFiles();
 app.UseStaticFiles();
-// The default content-type provider has no HEIC/HEIF mapping, so uploaded iPhone
-// photos 404'd under /uploads (browsers can't render HEIC in <img> anyway — the
-// Web UI displays the server-generated PNG previewUrl — but the original should
-// at least stay downloadable).
-var uploadContentTypes = new Microsoft.AspNetCore.StaticFiles.FileExtensionContentTypeProvider();
-uploadContentTypes.Mappings[".heic"] = "image/heic";
-uploadContentTypes.Mappings[".heif"] = "image/heif";
-app.UseStaticFiles(new StaticFileOptions
-{
-    FileProvider = new PhysicalFileProvider(hostingOptions.UploadDirectory),
-    RequestPath = "/uploads",
-    ContentTypeProvider = uploadContentTypes,
-});
+// /uploads holds user-supplied files, so its content types come from the
+// UploadContentPolicy allow-list: media keeps real types, text/code always
+// comes back as text/plain (an uploaded .html page must never execute in the
+// server's origin), unlisted extensions 404, and every response carries
+// X-Content-Type-Options: nosniff.
+app.UseStaticFiles(UploadContentPolicy.BuildStaticFileOptions(hostingOptions.UploadDirectory));
 
 app.MapHealthEndpoints(app.Environment);
 app.MapSessionEndpoints();

--- a/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
+++ b/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
@@ -241,14 +241,29 @@ namespace TensorSharp.Server.ProtocolAdapters
             }
 
             string ext = Path.GetExtension(file.FileName).ToLowerInvariant();
+            // Classify before anything touches disk: an upload with an extension
+            // outside the allow-list is rejected without ever being written, so
+            // /uploads can only ever hold files the serve-side policy covers.
+            string mediaType = UploadContentPolicy.Classify(ext);
+            if (mediaType == "unknown")
+            {
+                uploadLogger.LogWarning(LogEventIds.UploadRejected,
+                    "Upload rejected: unsupported extension {Extension} (name={FileName})",
+                    ext.Length == 0 ? "(none)" : ext, file.FileName);
+                return Results.BadRequest(new
+                {
+                    error = ext.Length == 0
+                        ? "Files without an extension are not supported. Upload an image, video, audio, PDF, or plain-text/code file."
+                        : $"Unsupported file type '{ext}'. Upload an image, video, audio, PDF, or plain-text/code file.",
+                });
+            }
+
             string safeFileName = $"{Guid.NewGuid():N}{ext}";
             string savePath = Path.Combine(_options.UploadDirectory, safeFileName);
             string uploadUrl = BuildUploadUrl(safeFileName);
 
             using (var stream = File.Create(savePath))
                 await file.CopyToAsync(stream);
-
-            string mediaType = ClassifyExtension(ext);
 
             // Include the full saved path and the classified media type so this entry
             // is self-sufficient for tracing back from the per-turn chat log
@@ -1052,21 +1067,6 @@ namespace TensorSharp.Server.ProtocolAdapters
                 return v;
             return 0;
         }
-
-        private static string ClassifyExtension(string ext) => ext switch
-        {
-            ".png" or ".jpg" or ".jpeg" or ".gif" or ".webp" or ".bmp"
-                or ".heic" or ".heif" => "image",
-            ".mp4" or ".mov" or ".avi" or ".mkv" or ".webm" => "video",
-            ".mp3" or ".wav" or ".ogg" or ".flac" or ".m4a" => "audio",
-            ".pdf" => "pdf",
-            ".txt" or ".csv" or ".json" or ".xml" or ".md" or ".log"
-                or ".py" or ".js" or ".ts" or ".cs" or ".java" or ".cpp" or ".c" or ".h"
-                or ".html" or ".css" or ".yaml" or ".yml" or ".toml" or ".ini" or ".cfg"
-                or ".sh" or ".bat" or ".ps1" or ".rb" or ".go" or ".rs" or ".swift"
-                or ".kt" or ".sql" or ".r" or ".m" or ".tex" or ".rtf" => "text",
-            _ => "unknown",
-        };
 
         // ---- Chat (SSE) -------------------------------------------------------
 


### PR DESCRIPTION
**Problem**

`POST /api/upload` accepts any file extension, writes the file to the uploads directory before classifying it, and `/uploads` serves everything back with the framework's default content-type mappings. An uploaded `.html` or `.svg` is therefore served as `text/html` / `image/svg+xml` and executes script in the server's origin — a stored XSS an unauthenticated client can plant and then link anyone to (`http://host:5000/uploads/<guid>.html`).

**Fix**

A new `UploadContentPolicy` (`TensorSharp.Server/Hosting`) owns both ends:

- **Upload:** the extension is classified before the file touches disk (the classification list is unchanged from `WebUiAdapter.ClassifyExtension`, which moved here); anything unlisted (`.svg`, `.exe`, no extension, …) is rejected with 400 and never written.
- **Serve:** `/uploads` uses an explicit content-type map. Media extensions keep their real types (including the HEIC/HEIF mappings, which moved here); every text/code extension — including `.html`, `.js`, `.xml` — is served as `text/plain; charset=utf-8`, so uploaded markup displays as source. Every `/uploads` response carries `X-Content-Type-Options: nosniff`, and unmapped extensions are not served (404), which also neutralizes hostile files stored before this change.

**Behavior changes**

- Uploads with an extension outside the classification list now return 400 (they previously returned `ok: true` but no pipeline could consume them).
- `/uploads/*.html` and other text/code files now display as plain text.

**Verification**

- `UploadContentPolicyTests` (35 cases): classification parity with the old switch, serve types for media and text, unlisted extensions unmapped, every accepted upload extension has a serve mapping, `/uploads` static-file options set nosniff.
- Full `InferenceWeb.Tests` suite green after rebasing onto current main (1415 tests).
- Live check against a running server: an uploaded `<script>…</script>` `.html` is stored but served `text/plain` + nosniff; `.svg` and extensionless uploads get 400; a pre-existing `.svg` in the uploads directory 404s; `.png` still serves as `image/png`.
