### PR TITLE
Stop exposing host filesystem paths via /api/models and the 404 fallback

### DIFF
--- a/InferenceWeb.Tests/ApiModelsResponseTests.cs
+++ b/InferenceWeb.Tests/ApiModelsResponseTests.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using TensorSharp.Server.Hosting;
+using TensorSharp.Server.ProtocolAdapters;
+
+namespace InferenceWeb.Tests;
+
+/// <summary>
+/// The /api/models response is readable by any client, so it must identify the
+/// hosted model and projector by filename only — absolute host paths reveal the
+/// server's filesystem layout. /api/models/load resolves the filename against
+/// the startup path server-side (HostedModelGuard), so no client needs the
+/// full path.
+/// </summary>
+public class ApiModelsResponseTests : IDisposable
+{
+    private readonly string _baseDir;
+
+    public ApiModelsResponseTests()
+    {
+        _baseDir = Path.Combine(Path.GetTempPath(), "ts-models-response-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_baseDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void GetModels_ExposesFileNamesButNoHostPaths()
+    {
+        string modelDir = Path.Combine(_baseDir, "secret-model-location");
+        var adapter = new WebUiAdapter(
+            new ModelService(),
+            new InferenceQueue(),
+            new SessionManager(),
+            new ServerHostingOptions(
+                startupModelPath: Path.Combine(modelDir, "foo.gguf"),
+                startupMmProjPath: Path.Combine(modelDir, "mmproj-foo.gguf"),
+                defaultBackend: "ggml_cpu",
+                supportedBackends: null,
+                defaultMaxTokens: 100,
+                maxTokensPinned: false,
+                defaultWanVideoFrames: 0,
+                defaultWanVideoFps: 0,
+                uploadDirectory: _baseDir,
+                logDirectory: Path.Combine(_baseDir, "logs"),
+                fileLoggingEnabled: false,
+                samplingDefaults: null),
+            NullLoggerFactory.Instance);
+
+        var result = adapter.GetModels();
+        object value = result.GetType().GetProperty("Value")?.GetValue(result);
+        Assert.NotNull(value);
+        string json = JsonSerializer.Serialize(value);
+
+        Assert.Contains("foo.gguf", json);
+        Assert.Contains("mmproj-foo.gguf", json);
+        Assert.DoesNotContain("secret-model-location", json);
+        Assert.DoesNotContain(modelDir, json);
+    }
+}

--- a/TensorSharp.Server/Endpoints/HealthEndpoints.cs
+++ b/TensorSharp.Server/Endpoints/HealthEndpoints.cs
@@ -14,6 +14,9 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TensorSharp.Runtime.Logging;
 
 namespace TensorSharp.Server.Endpoints
 {
@@ -50,8 +53,16 @@ namespace TensorSharp.Server.Endpoints
             {
                 if (await TrySendIndexAsync(ctx, environment))
                     return;
+                // The resolved web root goes to the server log for the operator
+                // diagnosing a misdeployed wwwroot; the response stays generic so
+                // clients don't learn host filesystem paths.
+                ctx.RequestServices.GetService<ILoggerFactory>()
+                    ?.CreateLogger("TensorSharp.Server.Health")
+                    .LogWarning(LogEventIds.HttpRequestRejected,
+                        "Fallback route hit but index.html is missing. WebRootPath: {WebRootPath}",
+                        environment.WebRootPath ?? "(null)");
                 ctx.Response.StatusCode = 404;
-                await ctx.Response.WriteAsync("index.html not found. WebRootPath: " + (environment.WebRootPath ?? "(null)"));
+                await ctx.Response.WriteAsync("index.html not found.");
             });
 
             return endpoints;

--- a/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
+++ b/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
@@ -158,8 +158,6 @@ namespace TensorSharp.Server.ProtocolAdapters
                 defaultBackend = _options.DefaultBackend,
                 supportedBackends = _options.SupportedBackends,
                 architecture = _svc.Architecture,
-                hostedModelPath = _options.StartupModelPath,
-                hostedMmProjPath = _options.StartupMmProjPath,
                 defaultMaxTokens = _options.DefaultMaxTokens,
             });
         }


### PR DESCRIPTION
**Problem**

Two anonymous-readable responses reveal the server's filesystem layout (install location, user name, OS conventions):

- `/api/models` returns the startup model and projector as absolute host paths (`hostedModelPath` / `hostedMmProjPath`).
- When no `wwwroot` content is found, the SPA fallback's 404 body echoes the resolved `WebRootPath` to the client.

**Fix**

- The two path fields are removed from `/api/models`. Nothing consumes them: the Web UI uses the filename lists, and `/api/models/load` resolves a filename against the startup path server-side via `HostedModelGuard`.
- The 404 fallback body is now a generic message; the resolved path moves to a server-side warning log, which is where the misdeployed-wwwroot diagnostic was aimed anyway.

**Verification**

- `ApiModelsResponseTests` fails before the field removal and passes after: filenames present, no directory component anywhere in the response.
- Live check: with `index.html` removed, the fallback body is the generic message and the `WebRootPath` appears in the server log; `/api/models` carries no path fields.
- Full `InferenceWeb.Tests` suite green after rebasing onto current main (1381 tests; the one failure seen in a batch run was `PrefillOptimizationBenchmark.MoE_BatchedExperts_IsFasterThanTokenByToken`, a timing-sensitive benchmark that is flaky under full-suite load on unmodified main and passes standalone and on rerun).
