### PR TITLE
Confine image-edit and video imagePath to the upload directory correctly

### DIFF
--- a/InferenceWeb.Tests/UploadRootConfinementTests.cs
+++ b/InferenceWeb.Tests/UploadRootConfinementTests.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using TensorSharp.Server.Hosting;
+using TensorSharp.Server.ProtocolAdapters;
+using TensorSharp.Server.RequestParsers;
+
+namespace InferenceWeb.Tests;
+
+/// <summary>
+/// The image-edit (<c>imagePath</c>/<c>imagePaths</c>) and Wan video
+/// (<c>imagePath</c>) endpoints read client-supplied paths that must resolve
+/// inside the upload directory. These check the confinement at both call sites
+/// and in the shared <see cref="UploadPathGuard"/>: paths outside the root —
+/// including a sibling directory that merely shares the root's name — are
+/// rejected.
+/// </summary>
+public class UploadRootConfinementTests : IDisposable
+{
+    private readonly string _baseDir;
+    private readonly string _uploadRoot;
+
+    public UploadRootConfinementTests()
+    {
+        _baseDir = Path.Combine(Path.GetTempPath(), "ts-upload-confine-" + Guid.NewGuid().ToString("N"));
+        _uploadRoot = Path.Combine(_baseDir, "uploads");
+        Directory.CreateDirectory(_uploadRoot);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    // ---- UploadPathGuard ---------------------------------------------------
+
+    [Fact]
+    public void Guard_PathInsideRoot_IsAccepted()
+    {
+        Assert.True(UploadPathGuard.IsInsideDirectory(_uploadRoot, Path.Combine(_uploadRoot, "img.png")));
+        Assert.True(UploadPathGuard.IsInsideDirectory(_uploadRoot, Path.Combine(_uploadRoot, "nested", "img.png")));
+    }
+
+    [Fact]
+    public void Guard_SiblingDirectorySharingPrefix_IsRejected()
+    {
+        Assert.False(UploadPathGuard.IsInsideDirectory(_uploadRoot, Path.Combine(_baseDir, "uploads-evil", "img.png")));
+    }
+
+    [Fact]
+    public void Guard_PathOutsideRoot_IsRejected()
+    {
+        Assert.False(UploadPathGuard.IsInsideDirectory(_uploadRoot, Path.Combine(_baseDir, "secret.png")));
+        Assert.False(UploadPathGuard.IsInsideDirectory(_uploadRoot, _baseDir));
+    }
+
+    [Fact]
+    public void Guard_TraversalOutOfRoot_IsRejected()
+    {
+        string traversal = Path.GetFullPath(Path.Combine(_uploadRoot, "..", "secret.png"));
+        Assert.False(UploadPathGuard.IsInsideDirectory(_uploadRoot, traversal));
+    }
+
+    // ---- Wan video imagePath ----------------------------------------------
+
+    [Fact]
+    public void WanParser_ImagePathInsideRoot_IsRead()
+    {
+        string inside = Path.Combine(_uploadRoot, "cond.png");
+        File.WriteAllBytes(inside, new byte[] { 1, 2, 3 });
+
+        var p = WanVideoParamsParser.Parse(VideoRequest(inside), Options(), out string error);
+
+        Assert.Null(error);
+        Assert.Equal(new byte[] { 1, 2, 3 }, p.ImageBytes);
+    }
+
+    [Fact]
+    public void WanParser_ImagePathInSiblingDirectory_IsRejected()
+    {
+        string sibling = Path.Combine(_baseDir, "uploads-evil");
+        Directory.CreateDirectory(sibling);
+        string outside = Path.Combine(sibling, "cond.png");
+        File.WriteAllBytes(outside, new byte[] { 1, 2, 3 });
+
+        var p = WanVideoParamsParser.Parse(VideoRequest(outside), Options(), out string error);
+
+        Assert.NotNull(error);
+        Assert.Null(p.ImageBytes);
+    }
+
+    [Fact]
+    public void WanParser_ImagePathOutsideRoot_IsRejected()
+    {
+        string outside = Path.Combine(_baseDir, "secret.png");
+        File.WriteAllBytes(outside, new byte[] { 1, 2, 3 });
+
+        WanVideoParamsParser.Parse(VideoRequest(outside), Options(), out string error);
+
+        Assert.NotNull(error);
+    }
+
+    // ---- Image-edit imagePath(s) -------------------------------------------
+
+    [Fact]
+    public async Task ImageEdit_PathInsideRoot_IsRead()
+    {
+        string inside = Path.Combine(_uploadRoot, "edit.png");
+        File.WriteAllBytes(inside, new byte[] { 4, 5, 6 });
+        var images = new List<byte[]>();
+
+        string error = await Adapter().ReadUploadedImagesAsync(
+            EditRequest(inside), images, CancellationToken.None);
+
+        Assert.Null(error);
+        Assert.Single(images);
+        Assert.Equal(new byte[] { 4, 5, 6 }, images[0]);
+    }
+
+    [Fact]
+    public async Task ImageEdit_PathInSiblingDirectory_IsRejected()
+    {
+        string sibling = Path.Combine(_baseDir, "uploads-evil");
+        Directory.CreateDirectory(sibling);
+        string outside = Path.Combine(sibling, "edit.png");
+        File.WriteAllBytes(outside, new byte[] { 4, 5, 6 });
+        var images = new List<byte[]>();
+
+        string error = await Adapter().ReadUploadedImagesAsync(
+            EditRequest(outside), images, CancellationToken.None);
+
+        Assert.NotNull(error);
+        Assert.Empty(images);
+    }
+
+    [Fact]
+    public async Task ImageEdit_PathOutsideRootInImagePathsArray_IsRejected()
+    {
+        string inside = Path.Combine(_uploadRoot, "ok.png");
+        File.WriteAllBytes(inside, new byte[] { 7 });
+        string outside = Path.Combine(_baseDir, "secret.png");
+        File.WriteAllBytes(outside, new byte[] { 8 });
+        var images = new List<byte[]>();
+
+        var request = JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(new { imagePaths = new[] { inside, outside } }));
+        string error = await Adapter().ReadUploadedImagesAsync(request, images, CancellationToken.None);
+
+        Assert.NotNull(error);
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private ServerHostingOptions Options() => new(
+        startupModelPath: null,
+        startupMmProjPath: null,
+        defaultBackend: "ggml_cpu",
+        supportedBackends: null,
+        defaultMaxTokens: 100,
+        maxTokensPinned: false,
+        defaultWanVideoFrames: 0,
+        defaultWanVideoFps: 0,
+        uploadDirectory: _uploadRoot,
+        logDirectory: Path.Combine(_baseDir, "logs"),
+        fileLoggingEnabled: false,
+        samplingDefaults: null);
+
+    private WebUiAdapter Adapter() => new(
+        new ModelService(),
+        new InferenceQueue(),
+        new SessionManager(),
+        Options(),
+        NullLoggerFactory.Instance);
+
+    private static JsonElement VideoRequest(string imagePath) =>
+        JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(new { prompt = "a cat", imagePath }));
+
+    private static JsonElement EditRequest(string imagePath) =>
+        JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(new { imagePath }));
+}

--- a/TensorSharp.Server/Hosting/UploadPathGuard.cs
+++ b/TensorSharp.Server/Hosting/UploadPathGuard.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+
+namespace TensorSharp.Server.Hosting
+{
+    /// <summary>
+    /// Confinement check for client-supplied file paths that must resolve
+    /// inside the upload directory.
+    /// </summary>
+    internal static class UploadPathGuard
+    {
+        /// <summary>
+        /// True when <paramref name="path"/> resolves inside <paramref name="root"/>.
+        /// Built on <see cref="Path.GetRelativePath(string, string)"/> rather than a
+        /// string prefix comparison, so a sibling directory that merely shares the
+        /// root's name (<c>uploads-evil</c>) and traversal out of the root are both
+        /// rejected. Both arguments must already be full paths.
+        /// </summary>
+        public static bool IsInsideDirectory(string root, string path)
+        {
+            string relative = Path.GetRelativePath(root, path);
+            return relative != ".."
+                && !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                && !Path.IsPathRooted(relative);
+        }
+    }
+}

--- a/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
+++ b/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
@@ -586,7 +586,7 @@ namespace TensorSharp.Server.ProtocolAdapters
         /// <c>imagePaths</c> (array, multi-image) or legacy <c>imagePath</c> (single). Every path
         /// must resolve inside the upload directory. Returns an error message, or null on success.
         /// </summary>
-        private async Task<string> ReadUploadedImagesAsync(JsonElement root, List<byte[]> images, CancellationToken ct)
+        internal async Task<string> ReadUploadedImagesAsync(JsonElement root, List<byte[]> images, CancellationToken ct)
         {
             var paths = new List<string>();
             if (root.TryGetProperty("imagePaths", out var ips) && ips.ValueKind == JsonValueKind.Array)
@@ -602,7 +602,7 @@ namespace TensorSharp.Server.ProtocolAdapters
             foreach (var path in paths)
             {
                 string full = path == null ? null : Path.GetFullPath(path);
-                if (full == null || !full.StartsWith(uploadRoot, StringComparison.OrdinalIgnoreCase) || !File.Exists(full))
+                if (full == null || !UploadPathGuard.IsInsideDirectory(uploadRoot, full) || !File.Exists(full))
                     return "imagePath must reference a previously uploaded file.";
                 images.Add(await File.ReadAllBytesAsync(full, ct));
             }

--- a/TensorSharp.Server/RequestParsers/WanVideoParamsParser.cs
+++ b/TensorSharp.Server/RequestParsers/WanVideoParamsParser.cs
@@ -59,7 +59,7 @@ namespace TensorSharp.Server.RequestParsers
             {
                 string uploadRoot = Path.GetFullPath(options.UploadDirectory);
                 string full = Path.GetFullPath(ip.GetString());
-                if (!full.StartsWith(uploadRoot, StringComparison.OrdinalIgnoreCase) || !File.Exists(full))
+                if (!UploadPathGuard.IsInsideDirectory(uploadRoot, full) || !File.Exists(full))
                 {
                     error = "imagePath must reference a previously uploaded file.";
                     return p;


### PR DESCRIPTION
**Problem**

Two endpoints check client-supplied paths against the upload root with a string `StartsWith` on the full path, which a sibling directory sharing the root's name defeats: with an uploads directory at `…/uploads`, a path under `…/uploads-evil` passes the check and the file is read and fed to the pipeline. Affected: the image-edit endpoint's `imagePath`/`imagePaths` (`WebUiAdapter.ReadUploadedImagesAsync`) and the Wan image-to-video conditioning `imagePath` (`WanVideoParamsParser`). This is the same class of bypass that #146 closed for `/api/chat` attachments.

**Fix**

A shared `UploadPathGuard.IsInsideDirectory` replaces both checks, built on `Path.GetRelativePath` instead of string prefix comparison: a path is inside the root only when its relative form neither escapes (`..`) nor is rooted, which rejects sibling directories and traversal on the BCL's own path semantics — the same containment rule #146 uses. `ReadUploadedImagesAsync` became `internal` so the tests drive the real call site (`InternalsVisibleTo` already in place).

**Verification**

- `UploadRootConfinementTests` (10 cases): guard unit tests plus both call sites end-to-end; the two sibling-directory cases fail before the fix and pass after.
- Full `InferenceWeb.Tests` suite green after rebasing onto current main (1390 tests).
