### PR TITLE
Trait-based test lanes: filterable inner loop, and PR CI on a stock runner

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -1,0 +1,45 @@
+name: PR Unit Tests
+
+# Deterministic correctness signal for every PR on a stock GitHub-hosted
+# runner: builds the solution (including the CPU-only native GGML library,
+# which the TensorSharp.Backends.GGML build triggers automatically) and runs
+# the environment-independent test lane — no GPU, no model downloads, no
+# secrets. Lane taxonomy: InferenceWeb.Tests/TestAssemblyConfig.cs and
+# DEVELOPMENT.md "Test lanes". The engine-comparison benchmark workflow
+# (test-matrix.yml) on the self-hosted CUDA runner is unaffected.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Tests run on the GGML CPU backend (TS_TEST_GGML_BACKEND default), so skip
+  # the Vulkan native build the script would otherwise auto-enable if the
+  # runner image ships a Vulkan loader.
+  TENSORSHARP_GGML_NATIVE_ENABLE_VULKAN: "OFF"
+  DOTNET_NOLOGO: "true"
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run environment-independent tests
+        run: >
+          dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj
+          --filter "Category!=Bench&Requires!=Cuda&Requires!=Mlx&Requires!=Models"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -440,6 +440,24 @@ the fused path engages.
 dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj
 ```
 
+#### Test lanes
+
+Tests are tagged with xUnit traits on two axes (declared in `InferenceWeb.Tests/TestAssemblyConfig.cs`): `Category=Bench` marks the timing/throughput benchmark classes, and `Requires=Cuda|Mlx|Models` marks what a test needs from the environment (`Models` = real GGUF weights via the test model directory). Untagged tests are self-contained correctness tests that run anywhere. An unfiltered `dotnet test` runs everything, exactly as before; `--filter` selects a lane:
+
+```bash
+# Inner loop while editing: environment-independent correctness tests, runs anywhere in seconds.
+# This is also the lane PR CI runs (.github/workflows/pr-unit-tests.yml).
+dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj --filter "Category!=Bench&Requires!=Cuda&Requires!=Mlx&Requires!=Models"
+
+# Full correctness (pre-push on a box with a GPU and model files): everything except benchmarks.
+dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj --filter "Category!=Bench"
+
+# Benchmarks only, run deliberately on quiet hardware — their assertions are timing-sensitive.
+dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj --filter "Category=Bench"
+```
+
+Note that CUDA-, MLX-, and model-gated tests currently pass silently when their prerequisite is missing, so excluding them from a lane changes what is exercised, not what a green run looks like.
+
 ### Server integration tests
 
 Integration tests for TensorSharp.Server are in `TensorSharp.Server/testdata/`. They cover all three API styles (Web UI SSE, Ollama, OpenAI), multi-turn conversations, thinking mode, tool calling, structured outputs, queue-status compatibility, concurrent requests, and abort support. Architecture-specific features (thinking, tool calling) are auto-detected and skipped when the active model does not support them.

--- a/DEVELOPMENT_zh-cn.md
+++ b/DEVELOPMENT_zh-cn.md
@@ -421,6 +421,24 @@ TensorSharp 采用分层系统结构：
 dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj
 ```
 
+#### 测试分组（Test lanes）
+
+测试通过 xUnit trait 按两个维度打标（声明见 `InferenceWeb.Tests/TestAssemblyConfig.cs`）：`Category=Bench` 标记含时延/吞吐断言的基准测试类；`Requires=Cuda|Mlx|Models` 标记测试对环境的依赖（`Models` = 需要测试模型目录下的真实 GGUF 权重）。未打标的测试是自包含的正确性测试，可在任何环境运行。不带过滤器的 `dotnet test` 行为与之前完全一致；用 `--filter` 选择分组：
+
+```bash
+# 内循环（边改边测）：与环境无关的正确性测试，任何机器上数秒内跑完。
+# PR CI 也运行这一分组（.github/workflows/pr-unit-tests.yml）。
+dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj --filter "Category!=Bench&Requires!=Cuda&Requires!=Mlx&Requires!=Models"
+
+# 完整正确性（推送前，在有 GPU 和模型文件的机器上）：除基准外的全部测试。
+dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj --filter "Category!=Bench"
+
+# 仅基准测试：其断言对时序敏感，应在空闲机器上有意运行。
+dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj --filter "Category=Bench"
+```
+
+注意：CUDA、MLX 和模型相关的测试在前提条件缺失时目前会静默通过，因此从分组中排除它们改变的是实际执行的内容，而不是绿色结果的样子。
+
 ### 服务端集成测试
 
 TensorSharp.Server 的集成测试位于 `TensorSharp.Server/testdata/`。测试覆盖所有三种 API 风格（Web UI SSE、Ollama、OpenAI）、多轮对话、思维链模式、工具调用、结构化输出、队列状态兼容、并发请求和中断支持。架构特定能力（思维链、工具调用）会自动检测，当前模型不支持时会自动跳过。

--- a/InferenceWeb.Tests/CudaAllocatorConcurrencyTests.cs
+++ b/InferenceWeb.Tests/CudaAllocatorConcurrencyTests.cs
@@ -28,6 +28,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Cuda")]
 public class CudaAllocatorConcurrencyTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/CudaBackendTests.cs
+++ b/InferenceWeb.Tests/CudaBackendTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Cuda")]
 public class CudaBackendTests
 {
     [Fact]

--- a/InferenceWeb.Tests/CudaDecodeAttentionWrapTests.cs
+++ b/InferenceWeb.Tests/CudaDecodeAttentionWrapTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Cuda")]
 public class CudaDecodeAttentionWrapTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/CudaGraphPocTests.cs
+++ b/InferenceWeb.Tests/CudaGraphPocTests.cs
@@ -20,6 +20,8 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Category", "Bench")]
+[Trait("Requires", "Cuda")]
 public class CudaGraphPocTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/CudaKvCacheResizeTests.cs
+++ b/InferenceWeb.Tests/CudaKvCacheResizeTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Cuda")]
 public class CudaKvCacheResizeTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/CudaLongDecodeReproTests.cs
+++ b/InferenceWeb.Tests/CudaLongDecodeReproTests.cs
@@ -24,6 +24,8 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Cuda")]
+[Trait("Requires", "Models")]
 public class CudaLongDecodeReproTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/CudaQ8MatmulHarnessTests.cs
+++ b/InferenceWeb.Tests/CudaQ8MatmulHarnessTests.cs
@@ -26,6 +26,8 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Category", "Bench")]
+[Trait("Requires", "Cuda")]
 public class CudaQ8MatmulHarnessTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/DecodeBackendParityTests.cs
+++ b/InferenceWeb.Tests/DecodeBackendParityTests.cs
@@ -30,6 +30,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class DecodeBackendParityTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/DiffusionGemmaTests.cs
+++ b/InferenceWeb.Tests/DiffusionGemmaTests.cs
@@ -26,6 +26,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class DiffusionGemmaTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/EngineParallelInferenceTests.cs
+++ b/InferenceWeb.Tests/EngineParallelInferenceTests.cs
@@ -24,6 +24,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class EngineParallelInferenceTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/Gemma4AudioEncoderTests.cs
+++ b/InferenceWeb.Tests/Gemma4AudioEncoderTests.cs
@@ -24,6 +24,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class Gemma4AudioEncoderTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/Gemma4BatchedForwardTests.cs
+++ b/InferenceWeb.Tests/Gemma4BatchedForwardTests.cs
@@ -31,6 +31,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class Gemma4BatchedForwardTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/Gemma4BatchedPerfBench.cs
+++ b/InferenceWeb.Tests/Gemma4BatchedPerfBench.cs
@@ -31,6 +31,8 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Category", "Bench")]
+[Trait("Requires", "Models")]
 public class Gemma4BatchedPerfBench
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/Gemma4MtpTests.cs
+++ b/InferenceWeb.Tests/Gemma4MtpTests.cs
@@ -36,6 +36,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class Gemma4MtpTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/Gemma4PromptRenderReproTests.cs
+++ b/InferenceWeb.Tests/Gemma4PromptRenderReproTests.cs
@@ -192,6 +192,7 @@ public class Gemma4PromptRenderReproTests
         return candidates.FirstOrDefault(p => !string.IsNullOrEmpty(p) && File.Exists(p));
     }
 
+    [Trait("Requires", "Models")]
     [Fact]
     public void RealGemma4BpeTokenizer_MatchesLlamaCppOracle()
     {
@@ -244,6 +245,7 @@ public class Gemma4PromptRenderReproTests
             tokenizer.Decode(new List<int> { 9259, 236888, 2088, 740, 564, 1601, 611, 3124, 236881 }));
     }
 
+    [Trait("Requires", "Models")]
     [Fact]
     public void RealTemplate_RendersUserText_AndSingleBos()
     {
@@ -267,6 +269,7 @@ public class Gemma4PromptRenderReproTests
         Assert.Equal(1, CountLeading(tokens, bosId)); // exactly one BOS
     }
 
+    [Trait("Requires", "Models")]
     [Fact]
     public async Task Generate_FinalFantasyPrompt_ProducesRelevantOutput()
     {
@@ -319,6 +322,7 @@ public class Gemma4PromptRenderReproTests
         }
     }
 
+    [Trait("Requires", "Models")]
     [Fact]
     public async Task Generate_ThreeDistinctPromptsInParallel_EachStaysOnTopic()
     {
@@ -378,6 +382,7 @@ public class Gemma4PromptRenderReproTests
     // producing coherent-but-off-topic output. The multi-token prefill must yield
     // the SAME next-token as feeding the prompt one token at a time (decode path),
     // and must be deterministic across repeats.
+    [Trait("Requires", "Models")]
     [Fact]
     public void PrefillNextToken_MatchesIncrementalDecode_AndIsDeterministic()
     {

--- a/InferenceWeb.Tests/GptOssBatchedCorrectnessTests.cs
+++ b/InferenceWeb.Tests/GptOssBatchedCorrectnessTests.cs
@@ -25,6 +25,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class GptOssBatchedCorrectnessTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/GptOssBatchedPerfBench.cs
+++ b/InferenceWeb.Tests/GptOssBatchedPerfBench.cs
@@ -25,6 +25,8 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Category", "Bench")]
+[Trait("Requires", "Models")]
 public class GptOssBatchedPerfBench
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/GptOssLongDecodeReproTests.cs
+++ b/InferenceWeb.Tests/GptOssLongDecodeReproTests.cs
@@ -24,6 +24,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class GptOssLongDecodeReproTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/HarmonyToolCallIntegrationTests.cs
+++ b/InferenceWeb.Tests/HarmonyToolCallIntegrationTests.cs
@@ -29,6 +29,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class HarmonyToolCallIntegrationTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/Mistral3BatchedForwardTests.cs
+++ b/InferenceWeb.Tests/Mistral3BatchedForwardTests.cs
@@ -23,6 +23,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class Mistral3BatchedForwardTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/MlxBackendTests.cs
+++ b/InferenceWeb.Tests/MlxBackendTests.cs
@@ -5,6 +5,7 @@ using TensorSharp.Runtime;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Mlx")]
 public class MlxBackendTests
 {
     [Fact]

--- a/InferenceWeb.Tests/MlxIQuantDecodeMatmulTests.cs
+++ b/InferenceWeb.Tests/MlxIQuantDecodeMatmulTests.cs
@@ -32,6 +32,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Mlx")]
 public class MlxIQuantDecodeMatmulTests
 {
     private const int QK_K = 256;

--- a/InferenceWeb.Tests/MlxIq3XxsKernelTests.cs
+++ b/InferenceWeb.Tests/MlxIq3XxsKernelTests.cs
@@ -27,6 +27,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Mlx")]
 public class MlxIq3XxsKernelTests
 {
     private const int QK_K = 256;

--- a/InferenceWeb.Tests/MlxStorageBulkElementIoTests.cs
+++ b/InferenceWeb.Tests/MlxStorageBulkElementIoTests.cs
@@ -16,6 +16,7 @@ namespace InferenceWeb.Tests;
 /// contract: identical values to the per-element path, and unchanged
 /// host/device dirty semantics.
 /// </summary>
+[Trait("Requires", "Mlx")]
 public class MlxStorageBulkElementIoTests
 {
     [Fact]

--- a/InferenceWeb.Tests/MuseGlimmerKvSnapshotTests.cs
+++ b/InferenceWeb.Tests/MuseGlimmerKvSnapshotTests.cs
@@ -35,6 +35,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class MuseGlimmerKvSnapshotTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/MuseGlimmerMlxDecodeTests.cs
+++ b/InferenceWeb.Tests/MuseGlimmerMlxDecodeTests.cs
@@ -23,6 +23,7 @@ using Xunit;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Mlx")]
 public class MuseGlimmerMlxDecodeTests
 {
     // The pipelined step computes argmax and the next embedding ON DEVICE with

--- a/InferenceWeb.Tests/MuseGlimmerParityTests.cs
+++ b/InferenceWeb.Tests/MuseGlimmerParityTests.cs
@@ -32,6 +32,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class MuseGlimmerParityTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/NemotronBatchedCorrectnessTests.cs
+++ b/InferenceWeb.Tests/NemotronBatchedCorrectnessTests.cs
@@ -27,6 +27,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class NemotronBatchedCorrectnessTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/NemotronBatchedPerfBench.cs
+++ b/InferenceWeb.Tests/NemotronBatchedPerfBench.cs
@@ -26,6 +26,8 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Category", "Bench")]
+[Trait("Requires", "Models")]
 public class NemotronBatchedPerfBench
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/ParallelThroughputBench.cs
+++ b/InferenceWeb.Tests/ParallelThroughputBench.cs
@@ -29,6 +29,8 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Category", "Bench")]
+[Trait("Requires", "Models")]
 public class ParallelThroughputBench
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/PrefillOptimizationBenchmark.cs
+++ b/InferenceWeb.Tests/PrefillOptimizationBenchmark.cs
@@ -10,6 +10,7 @@ using TensorSharp.GGML;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Category", "Bench")]
 public class PrefillOptimizationBenchmark
 {
     private readonly IAllocator _alloc = new CpuAllocator(BlasEnum.DotNet);

--- a/InferenceWeb.Tests/Qwen35BatchedCorrectnessTests.cs
+++ b/InferenceWeb.Tests/Qwen35BatchedCorrectnessTests.cs
@@ -32,6 +32,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class Qwen35BatchedCorrectnessTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/Qwen35BatchedPerfBench.cs
+++ b/InferenceWeb.Tests/Qwen35BatchedPerfBench.cs
@@ -33,6 +33,8 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Category", "Bench")]
+[Trait("Requires", "Models")]
 public class Qwen35BatchedPerfBench
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/Qwen36MtpTests.cs
+++ b/InferenceWeb.Tests/Qwen36MtpTests.cs
@@ -30,6 +30,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class Qwen36MtpTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/Qwen3BatchedForwardTests.cs
+++ b/InferenceWeb.Tests/Qwen3BatchedForwardTests.cs
@@ -27,6 +27,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class Qwen3BatchedForwardTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";

--- a/InferenceWeb.Tests/SafetensorsReaderTests.cs
+++ b/InferenceWeb.Tests/SafetensorsReaderTests.cs
@@ -102,6 +102,7 @@ namespace InferenceWeb.Tests
 
         // ---- parity against the converted GGUF (the trusted existing path) -----------------------
 
+        [Trait("Requires", "Models")]
         [Fact]
         public void Vae_Safetensors_BitIdentical_To_Gguf()
         {
@@ -139,6 +140,7 @@ namespace InferenceWeb.Tests
             Assert.Equal(194, compared);
         }
 
+        [Trait("Requires", "Models")]
         [Fact]
         public void Vae_Header_Shapes_AreCorrect()
         {

--- a/InferenceWeb.Tests/TestAssemblyConfig.cs
+++ b/InferenceWeb.Tests/TestAssemblyConfig.cs
@@ -8,3 +8,15 @@ using Xunit;
 // race (CUDA error 700 or a request observing another test's override), so run
 // test collections serially for deterministic correctness.
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+// Trait taxonomy, selectable with dotnet test --filter:
+//   Category=Bench    timing/throughput assertions — a failure means the perf
+//                     regressed or the box was busy, never that code is wrong
+//   Requires=Cuda     needs a CUDA device (otherwise the tests no-op)
+//   Requires=Mlx      needs the MLX native backend (macOS)
+//   Requires=Models   needs real GGUF weights (TS_TEST_MODEL_DIR and friends)
+// Untagged tests are self-contained correctness tests that run anywhere.
+// Common lanes:
+//   --filter "Category!=Bench&Requires!=Models&Requires!=Cuda&Requires!=Mlx"   fast inner loop
+//   --filter "Category!=Bench"                                                 full correctness
+//   --filter "Category=Bench"                                                  perf, on a quiet box

--- a/InferenceWeb.Tests/ToolFunctionParserBenchmark.cs
+++ b/InferenceWeb.Tests/ToolFunctionParserBenchmark.cs
@@ -40,6 +40,7 @@ namespace InferenceWeb.Tests;
 /// <see cref="JsonValueKind"/> before each access costs nothing.
 /// </para>
 /// </summary>
+[Trait("Category", "Bench")]
 public class ToolFunctionParserBenchmark
 {
     // A tool catalogue the size of a working agent harness: 12 tools x 6

--- a/InferenceWeb.Tests/TurboQuantKvCodecBenchmark.cs
+++ b/InferenceWeb.Tests/TurboQuantKvCodecBenchmark.cs
@@ -25,6 +25,7 @@ namespace InferenceWeb.Tests;
 /// the timings are roughly representative of a production paged tier rather
 /// than the toy sizes used by the correctness tests.
 /// </summary>
+[Trait("Category", "Bench")]
 public class TurboQuantKvCodecBenchmark
 {
     // 16 layers × 8 KV heads × 256 tokens × 128 headDim × 2 (K+V) = 8,388,608 elements

--- a/InferenceWeb.Tests/VisionEncoderCudaTests.cs
+++ b/InferenceWeb.Tests/VisionEncoderCudaTests.cs
@@ -10,6 +10,7 @@ namespace InferenceWeb.Tests;
 /// defects these guard against were all silent: the encoder produced plausible
 /// but wrong embeddings rather than throwing.
 /// </summary>
+[Trait("Requires", "Cuda")]
 public class VisionEncoderCudaTests
 {
     // Ops.Add(x[rows, cols], bias[cols]) is how every linear layer in the vision

--- a/InferenceWeb.Tests/WanDirectOpsTests.cs
+++ b/InferenceWeb.Tests/WanDirectOpsTests.cs
@@ -132,6 +132,7 @@ public class WanDirectOpsTests
     // kernel without an additive mask: a non-aligned KV length and a
     // non-aligned bidirectional self-attention length. Wan's DiT attention is
     // unmasked, and neither length is a multiple of its 32/256-wide tiling.
+    [Trait("Requires", "Cuda")]
     [Theory]
     [InlineData(37, 257)]
     [InlineData(513, 513)]
@@ -222,6 +223,8 @@ public class WanDirectOpsTests
 
     // Manual perf probe (TS_WAN_ATTN_BENCH=1): raw streaming-attention kernel
     // throughput at the 832x480x33f DiT shape, printed as GFLOPS.
+    [Trait("Category", "Bench")]
+    [Trait("Requires", "Cuda")]
     [Fact]
     public void WanAttentionThroughput()
     {
@@ -249,6 +252,7 @@ public class WanDirectOpsTests
         ctx.Dispose();
     }
 
+    [Trait("Requires", "Cuda")]
     [Fact]
     public void CudaWanKernels_MatchCpu()
     {

--- a/InferenceWeb.Tests/WanDitBackendParityTests.cs
+++ b/InferenceWeb.Tests/WanDitBackendParityTests.cs
@@ -32,6 +32,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class WanDitBackendParityTests
 {
     private readonly ITestOutputHelper _output;

--- a/InferenceWeb.Tests/WanVaeBackendParityTests.cs
+++ b/InferenceWeb.Tests/WanVaeBackendParityTests.cs
@@ -33,6 +33,7 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
+[Trait("Requires", "Models")]
 public class WanVaeBackendParityTests
 {
     private readonly ITestOutputHelper _output;


### PR DESCRIPTION
Implements #153 — plain xUnit traits that make the existing test suite filterable into lanes, plus a minimal PR workflow that runs the environment-independent lane on a stock GitHub-hosted runner.

**What's in the diff**

1. **Trait tagging** (43 files, additive only — no test moves, no behavior change): `[Trait]` attributes on the existing classes, method-level for the three mixed classes. Membership was determined from each class's actual gate (availability early-returns, model-dir env lookups), not from names — e.g. `ConfigFileArgsTests` mentions `.gguf` but is pure-unit and stays untagged.

   | Trait | Meaning | Tests |
   |---|---|---|
   | `Category=Bench` | benchmark harnesses (11 classes) | 39 |
   | `Requires=Cuda` | needs a CUDA device | 164 |
   | `Requires=Mlx` | needs the MLX backend | 94 |
   | `Requires=Models` | needs real GGUF weights | 89 |

   Untagged = self-contained correctness tests that run anywhere. The taxonomy and lane filters are documented in `InferenceWeb.Tests/TestAssemblyConfig.cs`.

2. **Lane documentation**: a "Test lanes" section in DEVELOPMENT.md (and the zh-cn twin) with the three filter invocations — inner loop, full correctness, bench-only.

3. **PR CI** (`.github/workflows/pr-unit-tests.yml`): runs the inner-loop filter on `ubuntu-latest` for every PR — no GPU, no model downloads, no secrets — so PRs get a deterministic test signal even when the self-hosted CUDA runner is offline. The managed build already triggers the CPU-only native GGML build by itself; Vulkan is pinned off since tests default to the CPU backend. The engine-comparison benchmark workflow (`test-matrix.yml`) is untouched.

**Verified** on a Linux box without CUDA/MLX/model weights, rebased on current main:

| Invocation | Result |
|---|---|
| unfiltered `dotnet test` | unchanged — 1,474 passed in ~3m29s |
| `--filter "Category!=Bench"` | 1,435 passed, ~8 s |
| inner-loop filter (CI lane) | 1,110 passed, ~5 s |

One thing this PR deliberately does *not* do: CUDA/MLX/model-gated tests still silently pass when their prerequisite is missing. Turning those into visible xUnit *Skipped* counts needs custom fact attributes; happy to follow up separately if you want that.
