### PR TITLE
Report environment-gated tests as skipped instead of silently passing

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -442,7 +442,7 @@ dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj
 
 #### Test lanes
 
-Tests are tagged with xUnit traits on two axes (declared in `InferenceWeb.Tests/TestAssemblyConfig.cs`): `Category=Bench` marks the timing/throughput benchmark classes, and `Requires=Cuda|Mlx|Models` marks what a test needs from the environment (`Models` = real GGUF weights via the test model directory). Untagged tests are self-contained correctness tests that run anywhere. An unfiltered `dotnet test` runs everything, exactly as before; `--filter` selects a lane:
+Tests are tagged on two axes (declared in `InferenceWeb.Tests/TestAssemblyConfig.cs`): `Category=Bench` marks the timing/throughput benchmark classes with a plain `[Trait]`, and `Requires=Cuda|Mlx|Models` marks what a test needs from the environment (`Models` = real GGUF weights via the test model directory). Environment-gated tests are written with the gated attributes from `InferenceWeb.Tests/GatedFacts.cs` — `[CudaFact]`/`[CudaTheory]`, `[MlxFact]`/`[MlxTheory]`, `[ModelFact("ENV_VAR", "gguf-substring")]`/`[ModelTheory(...)]` — which apply the matching `Requires` trait automatically and skip visibly when the prerequisite is missing. Calling `CudaBackend.IsAvailable()`/`MlxBackend.IsAvailable()` directly from a test is a build error (`BannedSymbols.txt`): use the attribute instead. Untagged `[Fact]`/`[Theory]` tests are self-contained correctness tests that run anywhere. An unfiltered `dotnet test` runs everything; `--filter` selects a lane:
 
 ```bash
 # Inner loop while editing: environment-independent correctness tests, runs anywhere in seconds.
@@ -456,7 +456,7 @@ dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj --filter "Category!=Ben
 dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj --filter "Category=Bench"
 ```
 
-Note that CUDA-, MLX-, and model-gated tests currently pass silently when their prerequisite is missing, so excluding them from a lane changes what is exercised, not what a green run looks like.
+Gated tests report as **Skipped** when their prerequisite is missing (a skipped `[Theory]` counts once, not per data row), so a green run on a bare box reads "N passed, M skipped" rather than silently passing tests that never executed. A few classes with compound prerequisites (multiple env vars, per-method model choice) still gate inside the test body and keep explicit `[Trait("Requires", ...)]` lines.
 
 ### Server integration tests
 

--- a/DEVELOPMENT_zh-cn.md
+++ b/DEVELOPMENT_zh-cn.md
@@ -423,7 +423,7 @@ dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj
 
 #### 测试分组（Test lanes）
 
-测试通过 xUnit trait 按两个维度打标（声明见 `InferenceWeb.Tests/TestAssemblyConfig.cs`）：`Category=Bench` 标记含时延/吞吐断言的基准测试类；`Requires=Cuda|Mlx|Models` 标记测试对环境的依赖（`Models` = 需要测试模型目录下的真实 GGUF 权重）。未打标的测试是自包含的正确性测试，可在任何环境运行。不带过滤器的 `dotnet test` 行为与之前完全一致；用 `--filter` 选择分组：
+测试按两个维度打标（声明见 `InferenceWeb.Tests/TestAssemblyConfig.cs`）：`Category=Bench` 用普通 `[Trait]` 标记含时延/吞吐断言的基准测试类；`Requires=Cuda|Mlx|Models` 标记测试对环境的依赖（`Models` = 需要测试模型目录下的真实 GGUF 权重）。依赖环境的测试使用 `InferenceWeb.Tests/GatedFacts.cs` 中的门控特性编写 —— `[CudaFact]`/`[CudaTheory]`、`[MlxFact]`/`[MlxTheory]`、`[ModelFact("ENV_VAR", "gguf-substring")]`/`[ModelTheory(...)]` —— 它们会自动附加对应的 `Requires` trait，并在前提条件缺失时显式跳过。在测试中直接调用 `CudaBackend.IsAvailable()`/`MlxBackend.IsAvailable()` 会产生编译错误（`BannedSymbols.txt`）：请改用门控特性。未打标的 `[Fact]`/`[Theory]` 是自包含的正确性测试，可在任何环境运行。不带过滤器的 `dotnet test` 运行全部测试；用 `--filter` 选择分组：
 
 ```bash
 # 内循环（边改边测）：与环境无关的正确性测试，任何机器上数秒内跑完。
@@ -437,7 +437,7 @@ dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj --filter "Category!=Ben
 dotnet test InferenceWeb.Tests/InferenceWeb.Tests.csproj --filter "Category=Bench"
 ```
 
-注意：CUDA、MLX 和模型相关的测试在前提条件缺失时目前会静默通过，因此从分组中排除它们改变的是实际执行的内容，而不是绿色结果的样子。
+门控测试在前提条件缺失时会报告为**已跳过**（被跳过的 `[Theory]` 只计一次，不按数据行展开），因此在没有相应硬件/权重的机器上，绿色结果会显示为"N 通过，M 跳过"，而不是静默通过从未执行的测试。少数前提条件复杂的测试类（多个环境变量、按方法选择模型）仍在测试体内做门控，并保留显式的 `[Trait("Requires", ...)]` 标注。
 
 ### 服务端集成测试
 

--- a/InferenceWeb.Tests/BannedSymbols.txt
+++ b/InferenceWeb.Tests/BannedSymbols.txt
@@ -1,0 +1,2 @@
+M:TensorSharp.Cuda.CudaBackend.IsAvailable;Gate the test with [CudaFact]/[CudaTheory] instead of a silent in-test availability check
+M:TensorSharp.MLX.MlxBackend.IsAvailable;Gate the test with [MlxFact]/[MlxTheory] instead of a silent in-test availability check

--- a/InferenceWeb.Tests/CudaAllocatorConcurrencyTests.cs
+++ b/InferenceWeb.Tests/CudaAllocatorConcurrencyTests.cs
@@ -14,7 +14,7 @@
 // The microbenchmark uses a fake (free) backing allocator so it isolates the
 // managed pool's synchronization cost — exactly the hot spot the change
 // targets — and therefore runs without a GPU. The real-device correctness and
-// throughput tests are gated on CudaBackend.IsAvailable().
+// throughput tests are gated with [CudaFact].
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -28,7 +28,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Cuda")]
 public class CudaAllocatorConcurrencyTests
 {
     private readonly ITestOutputHelper _output;
@@ -41,15 +40,9 @@ public class CudaAllocatorConcurrencyTests
     // must reuse pooled blocks (high hit ratio), and must keep cachedBytes /
     // metric accounting consistent (no negative or leaked accounting).
     // ---------------------------------------------------------------------
-    [Fact]
+    [CudaFact]
     public void RealDevice_ConcurrentAllocateDispose_IsRaceFreeAndPools()
     {
-        if (!CudaBackend.IsAvailable())
-        {
-            _output.WriteLine("[cuda-alloc] CUDA unavailable; skipping real-device test.");
-            return;
-        }
-
         using var allocator = new CudaAllocator();
 
         const int threads = 16;
@@ -103,15 +96,9 @@ public class CudaAllocatorConcurrencyTests
     // ---------------------------------------------------------------------
     // Deterministic single-threaded metric accounting.
     // ---------------------------------------------------------------------
-    [Fact]
+    [CudaFact]
     public void RealDevice_Metrics_CountHitsMissesAndDriverAllocs()
     {
-        if (!CudaBackend.IsAvailable())
-        {
-            _output.WriteLine("[cuda-alloc] CUDA unavailable; skipping metrics test.");
-            return;
-        }
-
         using var allocator = new CudaAllocator();
         CudaAllocatorStats start = allocator.GetStats();
 
@@ -139,15 +126,9 @@ public class CudaAllocatorConcurrencyTests
     // Real-device throughput (informational): aggregate alloc/free ops/sec
     // across thread counts. Never fails on throughput; just prints.
     // ---------------------------------------------------------------------
-    [Fact]
+    [CudaFact]
     public void RealDevice_AllocationThroughput_ScalesWithThreads()
     {
-        if (!CudaBackend.IsAvailable())
-        {
-            _output.WriteLine("[cuda-alloc] CUDA unavailable; skipping throughput test.");
-            return;
-        }
-
         using var allocator = new CudaAllocator();
         long[] elementCounts = { 256, 1024, 4096 };
         const int opsPerThread = 3000;

--- a/InferenceWeb.Tests/CudaBackendTests.cs
+++ b/InferenceWeb.Tests/CudaBackendTests.cs
@@ -6,15 +6,11 @@ using System.Threading;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Cuda")]
 public class CudaBackendTests
 {
-    [Fact]
+    [CudaFact]
     public void CudaAddmm_MatchesCpuForContiguousRhs()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var a = Tensor.FromArray(allocator, new float[,] { { 1, 2, 3 }, { 4, 5, 6 } });
         using var b = Tensor.FromArray(allocator, new float[,] { { 7, 8 }, { 9, 10 }, { 11, 12 } });
@@ -25,12 +21,9 @@ public class CudaBackendTests
         AssertClose(new[] { 58f, 64f, 139f, 154f }, c.GetElementsAsFloat(4));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaStagedHostEmbeddingCopy_PreservesDeviceResidentTensorData()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var tensor = new Tensor(allocator, DType.Float32, 4, 4);
         FillSequential(tensor, scale: 1f, offset: 0f);
@@ -50,7 +43,7 @@ public class CudaBackendTests
         }, tensor.GetElementsAsFloat(16));
     }
 
-    [Theory]
+    [CudaTheory]
     // (rows, wide, narrow) — narrow < wide forces a strided source row pitch, so
     // NewContiguous hits the 2D strided-copy kernel (ts_copy2d_bytes) rather than
     // a single dense DtoD. Covers the exact prefill shape ([seqLen, 8192] out of a
@@ -61,9 +54,6 @@ public class CudaBackendTests
     [InlineData(1, 512, 200)]
     public void CudaStridedNewContiguous_MatchesHostReference(int rows, int wide, int narrow)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var wideT = new Tensor(allocator, DType.Float32, rows, wide);
         FillSequential(wideT, scale: 0.5f, offset: -3f);
@@ -82,12 +72,9 @@ public class CudaBackendTests
         AssertClose(expected, dense.GetElementsAsFloat(rows * narrow));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaStridedNewContiguous_3D_OuterGroupLoop_MatchesHostReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // A [d0, d1, d2] tensor narrowed on the last axis exercises the kernel's
         // per-outer-group launch loop (groupDims == 1, rows == d1) rather than a
         // single launch, verifying the multi-dimensional counter arithmetic.
@@ -110,12 +97,9 @@ public class CudaBackendTests
         AssertClose(expected, dense.GetElementsAsFloat(d0 * d1 * narrow));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaAddmm_MatchesCpuForTransposedWeightView()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var input = Tensor.FromArray(allocator, new float[,] { { 1, 2, 3 }, { 4, 5, 6 } });
         using var weights = Tensor.FromArray(allocator, new float[,] { { 7, 9, 11 }, { 8, 10, 12 } });
@@ -127,12 +111,9 @@ public class CudaBackendTests
         AssertClose(new[] { 58f, 64f, 139f, 154f }, output.GetElementsAsFloat(4));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaAddmmBatch_MatchesCpuForTransposedRightOperand()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int batch = 3;
         const int rows = 5;
         const int shared = 7;
@@ -174,12 +155,9 @@ public class CudaBackendTests
         AssertClose(expected, actual, 1e-4f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaAddmmBatch_LargeAttentionShape_MatchesCpuForTransposedRightOperand()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int batch = 2;
         const int rows = 257;
         const int shared = 64;
@@ -219,12 +197,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaSoftmax_WithNegativeInfinityMask_MatchesExpected()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var logits = Tensor.FromArray(allocator, new float[,]
         {
@@ -241,12 +216,9 @@ public class CudaBackendTests
             actual[4..], 1e-5f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaSoftmax_LargeRows_MatchesReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int rows = 3;
         const int cols = 2304;
         float[,] values = new float[rows, cols];
@@ -275,12 +247,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaFallbackOps_PreserveTensorSemantics()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var x = Tensor.FromArray(allocator, new float[,] { { 1, 2, 3 }, { 4, 5, 6 } });
         using var y = new Tensor(allocator, DType.Float32, 2, 3);
@@ -297,12 +266,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaElementwiseAndScalarOps_MatchExpected()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var x = Tensor.FromArray(allocator, new float[,] { { 1, -2, 3 }, { -4, 5, -6 } });
         using var y = Tensor.FromArray(allocator, new float[,] { { 0.5f, 2, -1 }, { 4, -0.25f, 3 } });
@@ -337,12 +303,9 @@ public class CudaBackendTests
         AssertClose(new[] { -1.5f, -4.75f, -2f, -16.75f, -7.25f, -26f }, mulMulAdd.GetElementsAsFloat(6), 1e-5f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaRmsNormSoftmaxAndIndexSelect_MatchExpected()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var x = Tensor.FromArray(allocator, new float[,] { { 1, 2, 3, 4 }, { -1, -2, -3, -4 } });
         using var alpha = Tensor.FromArray(allocator, new float[] { 1, 0.5f, 2, -1 });
@@ -363,12 +326,9 @@ public class CudaBackendTests
         AssertClose(new[] { -1f, -2f, -3f, -4f, 1f, 2f, 3f, 4f }, selected.GetElementsAsFloat(8));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaMoEGroupedScatterAdd_MatchesHostReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var output = new Tensor(allocator, DType.Float32, 3, 4);
         Ops.Fill(output, 0f);
@@ -401,12 +361,9 @@ public class CudaBackendTests
         }, output.GetElementsAsFloat(12));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaMoEGroupedScatterAdd_HonorsContiguousViewOffsets()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var outputBacking = new Tensor(allocator, DType.Float32, 3, 4);
         Ops.Fill(outputBacking, 9f);
@@ -440,12 +397,9 @@ public class CudaBackendTests
         }, outputBacking.GetElementsAsFloat(12));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQwen35GatedDeltaNetPacked_MatchesCpuReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int seqLen = 4;
         const int numKHeads = 2;
         const int numVHeads = 4;
@@ -572,12 +526,9 @@ public class CudaBackendTests
         AssertClose(expectedConv, convTensor.GetElementsAsFloat(expectedConv.Length), 1e-6f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQwen35GatedDeltaNetPacked_ProductionHeadDims_MatchesCpuReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // Production-shaped geometry (Qwen3.5-9B: headKDim = headVDim = 128).
         // headVDim > the kernel's warp count used to route through a multi-block-
         // per-head layout whose whole-state decay raced between blocks; this test
@@ -648,12 +599,9 @@ public class CudaBackendTests
         AssertClose(expectedConv, convTensor.GetElementsAsFloat(expectedConv.Length), 1e-6f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaFusedQKNormRopeNeox_PartialRopeDims_MatchesNormThenRopeReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // Qwen3.5 attention geometry: headDim 256, partial RoPE (ropeDim 64 < headDim),
         // large base. The fused kernel used to derive frequencies from headDim instead
         // of ropeDim, mis-rotating every position on partial-RoPE models.
@@ -722,12 +670,9 @@ public class CudaBackendTests
         AssertClose(expected, dataTensor.GetElementsAsFloat(rows * headDim), 2e-4f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaPrefillGraphCache_CaptureReplayAndAbort_BehaveCorrectly()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var cache = new CudaPrefillGraphCache(allocator);
         if (!cache.IsUsable)
@@ -833,12 +778,9 @@ public class CudaBackendTests
     /// slot. Also checks the MaxAttendLen entry expiry used by the single-block
     /// attention route.
     /// </summary>
-    [Fact]
+    [CudaFact]
     public void CudaDecodeDynParams_GraphReplay_ReadsFreshValues()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var cache = new CudaPrefillGraphCache(allocator);
         if (!cache.IsUsable)
@@ -928,12 +870,9 @@ public class CudaBackendTests
         Assert.True(cache.ShouldCapture(key));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaDecodeDynParams_AmbientStateIsThreadLocalAndAllocatorScoped()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocatorA = new CudaAllocator();
         using var allocatorB = new CudaAllocator();
         using var dynA = new CudaDecodeDynParams(allocatorA);
@@ -1025,12 +964,9 @@ public class CudaBackendTests
         AssertClose(new float[headDim], Slot(otherThread, 7), 0f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaNeoXRopeDynamicTables_GraphReplayUsesFreshPosition()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var cache = new CudaPrefillGraphCache(allocator);
         if (!cache.IsUsable)
@@ -1148,12 +1084,9 @@ public class CudaBackendTests
         AssertPosition(11);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaDecodeGraph_CircularDynamicWriteAndAttentionCrossWrap()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var cache = new CudaPrefillGraphCache(allocator);
         if (!cache.IsUsable)
@@ -1315,7 +1248,7 @@ public class CudaBackendTests
     /// empty partitions). Results must be bit-identical to a plain launch with
     /// the same effective length.
     /// </summary>
-    [Fact]
+    [CudaFact]
     public void CudaGqaDecodeAttention_DynAttendLen_MatchesPlainLaunch()
     {
         // Gemma E4B's d=512 GQA switches launch topology above the tuned
@@ -1330,9 +1263,6 @@ public class CudaBackendTests
             keyIsHalf: true, circular: false,
             numQHeads: 8, numKVHeads: 2, headDim: 512,
             attendLen: 513, cacheSize: 8192));
-
-        if (!CudaBackend.IsAvailable())
-            return;
 
         using var allocator = new CudaAllocator();
         using var dyn = new CudaDecodeDynParams(allocator);
@@ -1395,12 +1325,9 @@ public class CudaBackendTests
         RunCase(cacheSize: 6144, scalarLen: 3000, dynLen: 2500);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaRoPE_MatchesReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var x = Tensor.FromArray(allocator, new float[,] { { 1, 2, 3, 4 }, { 5, 6, 7, 8 } });
         using var rope = Ops.RoPE(null, x, seqLen: 2, rowOffset: 1);
@@ -1425,7 +1352,7 @@ public class CudaBackendTests
         AssertClose(expected, rope.GetElementsAsFloat(8), 1e-4f);
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(256, 8, true)]
     [InlineData(32, 32, true)]
     [InlineData(32, 0, false)]
@@ -1439,15 +1366,12 @@ public class CudaBackendTests
             CudaFusedOps.IsMoERouterConfigurationSupported(numExperts, nUsed));
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(32, 0)]
     [InlineData(0, 1)]
     public void CudaMoEExpertFFNDecode_RejectsInvalidRouterBeforeLaunch(
         int numExperts, int nUsed)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var logits = new Tensor(allocator, DType.Float32, 1, 1);
         using var moeInput = new Tensor(allocator, DType.Float32, 1, 32);
@@ -1467,12 +1391,9 @@ public class CudaBackendTests
             gateUpQuantType: 2, downQuantType: 2, numExperts, nUsed, hiddenDim: 32, nFf: 32));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaMoEWrappers_RejectInvalidTensorContractsBeforeLaunch()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numExperts = 2;
         const int nUsed = 1;
         const int hiddenDim = 32;
@@ -1548,7 +1469,7 @@ public class CudaBackendTests
             scatterOutput, sharedDown, nonContiguousExpert));
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(2, 32, true)]
     [InlineData(2, 288, true)]
     [InlineData(2, 704, true)]
@@ -1569,7 +1490,7 @@ public class CudaBackendTests
             CudaFusedOps.IsMoeDp4aDimensionSupported(ggmlType, inDim));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaMoEDp4aEnablement_IsIndependentForEachQuantType()
     {
         bool savedQ40 = CudaQuantizedOps.Q40Dp4aEnabled;
@@ -1598,12 +1519,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmulAndRows_Q8_0MatchExpected()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         byte[] weights = CreateQ8_0Rows(new[]
         {
             Enumerable.Range(1, 32).Select(i => (sbyte)i).ToArray(),
@@ -1645,12 +1563,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedWeight_CanRunAfterHostCopyReleased()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         byte[] weights = CreateQ8_0Rows(new[]
         {
             Enumerable.Range(1, 32).Select(i => (sbyte)i).ToArray(),
@@ -1681,12 +1596,9 @@ public class CudaBackendTests
         CudaQuantizedOps.ReleaseQuantizedWeight(allocator, cacheKey);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedWeightArena_IsOwnedByAllocator()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         byte[] weights = CreateQ8_0Rows(new[]
         {
             Enumerable.Range(1, 32).Select(i => (sbyte)i).ToArray(),
@@ -1728,12 +1640,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmul_Q8_0WithMultipleBlocksAndScales_MatchesDequantizedReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int inDim = 64;
         const int outDim = 5;
         const int rows = 3;
@@ -1764,14 +1673,11 @@ public class CudaBackendTests
         }
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(1)] // warp-per-column dp4a matvec (decode)
     [InlineData(3)] // block-tile dp4a GEMM (verify window)
     public void CudaQuantizedMatmul_Q8_0Dp4aMatchesDequantizedReference(int rows)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int inDim = 96;
         const int outDim = 9;
         byte[] weights = CreateQ8_0Rows(outDim, inDim, (r, c) => (sbyte)(((r + 2) * (c - 11)) % 63), r => 0.125f + r * 0.0625f);
@@ -1809,15 +1715,12 @@ public class CudaBackendTests
         }
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(8, 1)] // Q8_0 decode matvec
     [InlineData(8, 3)] // Q8_0 small-batch dp4a
     [InlineData(2, 1)] // Q4_0 also consumes q8_1.s
     public void CudaQ81WarpQuantizer_BitMatchesLegacyMatmul(int ggmlType, int rows)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // Nine q8_1 blocks leave one live warp in the final 8-warp CTA, covering
         // both the cooperative reduction and its grid tail.
         const int inDim = 288;
@@ -1879,12 +1782,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmul_GraphReplaySurvivesQ81ScratchGrowth()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int inDim = 288;
         const int outDim = 13;
         const int growthRows = 256;
@@ -1982,14 +1882,11 @@ public class CudaBackendTests
         }
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(64, 32)] // exactly one 2048-value staging chunk
     [InlineData(96, 7)]  // 672 values: partial chunk and odd 34-byte-block count
     public void CudaQ80F16Dequantizer_BitMatchesLegacyGemm(int inDim, int outDim)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // rows >= 32 selects RunF16Gemm when MMQ is disabled. Comparing its final
         // F32 output exercises the specialized dequantizer through the same
         // cuBLAS consumer used by real large-prefill projections.
@@ -2045,12 +1942,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmul_Q8_0MmqPrefillRows_MatchesDequantizedReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // rows >= 32 auto-routes to the int8 tensor-core MMQ GEMM (mma.m16n8k32).
         // Odd sizes exercise the M/N tail handling; K = 96 exercises the k-step tail.
         const int inDim = 96;
@@ -2098,10 +1992,12 @@ public class CudaBackendTests
     /// the Gemma4 --tp 2 direct-CUDA prefill runs; a divergence here is the
     /// repeated-token garbage seen at prompt lengths >= 32 tokens.
     /// </summary>
-    [Fact]
+    [CudaFact]
     public void CudaF16GemmColumnShards_TwoRanksConcurrent_MatchSingleAllocator()
     {
-        if (!CudaBackend.IsAvailable() || CudaDevice.GetDeviceCount() < 2)
+        // CudaFact covers availability; the two-device requirement stays a
+        // silent gate (no lane filters on device count).
+        if (CudaDevice.GetDeviceCount() < 2)
             return;
 
         const int inDim = 2048;
@@ -2214,12 +2110,9 @@ public class CudaBackendTests
     /// accumulation order - only the staging differs. Odd out_dim/rows cover
     /// the N/M tails (including unstaged garbage rows zeroed by their scales).
     /// </summary>
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmul_Q8_0Mmq2CpAsync_BitMatchesBaseMmq()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int inDim = 512;
         const int outDim = 70;
         const int rows = 41;
@@ -2268,12 +2161,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmul_Q4_0WithMultipleOutputColumns_MatchesDequantizedReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int inDim = 64;
         const int outDim = 7;
         const int rows = 3;
@@ -2309,16 +2199,13 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmul_Q4_0BatchedSpansMultipleRowTilesAndColumnEdge_MatchesReference()
     {
         // Exercises the row-tiled batched Q4_0 kernel (ts_quant_matmul_q4_0_batched_f32)
         // used for the speculative-MTP verify window: rows=20 spans more than one
         // TS_Q40_ROW_TILE (12) tile, and outDim=5 leaves the last TS_Q40_COLS (2)
         // column block with a single live column — both edges of the kernel.
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int inDim = 128;
         const int outDim = 5;
         const int rows = 20;
@@ -2352,7 +2239,7 @@ public class CudaBackendTests
         }
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(1)]    // single-token decode
     [InlineData(5)]    // mid speculative-verify window
     [InlineData(9)]    // full draft window (n_max + 1)
@@ -2363,9 +2250,6 @@ public class CudaBackendTests
         // so it matches the FP32 dequant reference only to int8 precision (same as
         // ggml's mul_mat_q). A wider inDim keeps the relative quantization error well
         // bounded; the tolerance is scaled to the accumulated dot-product magnitude.
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int inDim = 256;
         const int outDim = 6;
         byte[] weights = CreateQ4_0Rows(outDim, inDim, (r, c) => (sbyte)(((r * 7 + c * 3) % 16) - 8), r => 0.0625f + r * 0.0078125f);
@@ -2405,15 +2289,12 @@ public class CudaBackendTests
         }
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData((int)GgmlTensorType.Q4_K)]
     [InlineData((int)GgmlTensorType.Q5_K)]
     [InlineData((int)GgmlTensorType.Q6_K)]
     public void CudaQuantizedMatmul_KQuantsMatchDequantizedReferenceAfterHostRelease(int ggmlType)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int rows = 3;
         const int inDim = 256;
         const int outDim = 5;
@@ -2451,14 +2332,11 @@ public class CudaBackendTests
         }
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData((int)GgmlTensorType.Q5_K)]
     [InlineData((int)GgmlTensorType.Q6_K)]
     public void CudaQuantizedMatmul_KQuantDecodeDp4aMatchesQ8ActivationReference(int ggmlType)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int inDim = 512; // two super-blocks exercises row/block addressing
         const int outDim = 7;  // non-power-of-two grid edge
         byte[] weights = CreateKQuantRows(ggmlType, outDim, inDim);
@@ -2519,15 +2397,12 @@ public class CudaBackendTests
         }
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData((int)GgmlTensorType.Q4_K)]
     [InlineData((int)GgmlTensorType.Q5_K)]
     [InlineData((int)GgmlTensorType.Q6_K)]
     public void CudaQuantizedRows_KQuantsMatchDequantizedReferenceAfterHostRelease(int ggmlType)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int inDim = 256;
         const int outDim = 5;
         int[] rows = { 4, 1, 3 };
@@ -2572,12 +2447,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmulAndRows_IQ2XXSMatchQ8ActivationReferenceAfterHostRelease()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int rows = 3;
         const int inDim = 512;
         const int outDim = 5;
@@ -2639,14 +2511,11 @@ public class CudaBackendTests
         }
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData((int)GgmlTensorType.IQ2_XXS)]
     [InlineData((int)GgmlTensorType.IQ2_S)]
     public void CudaQuantizedMatmul_IQ2DecodeGlobalQ81MatchesNativeReference(int ggmlType)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int inDim = 512;
         const int outDim = 5;
         byte[] weights = ggmlType == (int)GgmlTensorType.IQ2_XXS
@@ -2698,12 +2567,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaMoEDecode_MixedIq2StagesMatchQuantizedCpuReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int hiddenDim = 256;
         const int nFf = 256;
         const int numExperts = 2;
@@ -2850,12 +2716,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmulAndRows_IQ4XSMatchNativeReferenceAfterHostRelease()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // IQ4_XS (ggml type 23) is a mixed-quant staple (e.g. Qwen3.5-9B-IQ4_XS).
         // Before device residency was wired in, its weights stayed host-backed and
         // the matmul dequantized on the CPU. This exercises the device-resident
@@ -2934,12 +2797,9 @@ public class CudaBackendTests
 
     // Builds a byte-valid IQ4_XS weight buffer (any bit pattern is a legal block).
     // block_iq4_xs = d(half) @0, scales_h(uint16) @2, scales_l[4] @4, qs[128] @8 => 136 bytes / 256 elems.
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmul_IQ4NLMatchesNativeReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // IQ4_NL (ggml type 20) shares IQ4_XS's non-linear codebook but uses a flat
         // 18-byte / 32-element block with a single scale and no sub-block scales.
         // "Unsloth dynamic" quants mix it with other types per projection (the
@@ -2988,12 +2848,9 @@ public class CudaBackendTests
         }
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaQuantizedMatmul_MXFP4MatchesNativeReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // MXFP4 (ggml type 39) is the expert format of gpt-oss. Without device
         // support its ffn_*_exps tensors stayed host-backed and every MoE matmul
         // dequantized on the CPU (gpt-oss-20b decode measured 3.3 tok/s vs 150 on
@@ -3112,12 +2969,9 @@ public class CudaBackendTests
         return raw;
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaScaledDotProductAttention_WithMaskMatchesReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int batch = 2;
         const int seqQ = 3;
         const int seqK = 4;
@@ -3167,12 +3021,9 @@ public class CudaBackendTests
         AssertClose(expected, actual, 1e-5f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaGqaPrefillAttention_WithWindowMatchesReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numQHeads = 4;
         const int numKVHeads = 2;
         const int seqLen = 3;
@@ -3219,12 +3070,9 @@ public class CudaBackendTests
         AssertClose(expected, actualTensor.GetElementsAsFloat(seqLen * numQHeads * headDim), 1e-5f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaGqaPrefillAttention_ReadsFloat16KvCache()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numQHeads = 4;
         const int numKVHeads = 2;
         const int seqLen = 3;
@@ -3275,14 +3123,11 @@ public class CudaBackendTests
         AssertClose(expected, actualTensor.GetElementsAsFloat(seqLen * numQHeads * headDim), 2e-3f);
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(false)]
     [InlineData(true)]
     public void CudaExpandKvHeads_ConvertsActiveStridedCacheAndRepeatsHeads(bool halfCache)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int kvHeads = 2;
         const int groupSize = 3;
         const int seqLen = 3;
@@ -3324,12 +3169,9 @@ public class CudaBackendTests
             halfCache ? 1e-3f : 1e-6f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaRepeatInterleave_StaysOnDeviceAndMatchesReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var source = Tensor.FromArray(
             allocator,
@@ -3343,14 +3185,11 @@ public class CudaBackendTests
             0f);
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(false)]
     [InlineData(true)]
     public void CudaGqaPrefillAttention_Group4D256StridedWindowMatchesReference(bool halfCache)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // This is the bounded Gemma 4 local-attention specialization:
         // GQA ratio 4, d=256, seq >= 32, a sliding window, and a live-cache
         // stride larger than the logical prefix.
@@ -3416,14 +3255,11 @@ public class CudaBackendTests
             tolerance);
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(false)]
     [InlineData(true)]
     public void CudaGqaPrefillAttention_Group4D512GlobalMatchesReference(bool halfCache)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numQHeads = 8;
         const int numKVHeads = 2;
         const int seqLen = 128;
@@ -3482,12 +3318,9 @@ public class CudaBackendTests
             halfCache ? 3e-3f : 5e-5f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaGqaPrefillAttention_Group4OnlineD512LongCacheMatchesReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numQHeads = 4;
         const int numKVHeads = 1;
         const int seqLen = 3;
@@ -3550,16 +3383,13 @@ public class CudaBackendTests
         }
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(256, false)]
     [InlineData(256, true)]
     [InlineData(512, false)]
     [InlineData(512, true)]
     public void CudaGqaPrefillAttention_Flash2MultiChunkMatchesReference(int headDim, bool halfCache)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         // seqLen/kvLen well past the flash2 K-chunk width (64) so the online
         // softmax crosses several chunks and the multi-slot Phase B reduction is
         // exercised, for both a windowed (SWA) and a full-causal (window 0) mask.
@@ -3611,12 +3441,9 @@ public class CudaBackendTests
             halfCache ? 4e-3f : 7e-5f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaGqaPrefillAttentionWithSinks_ReadsStridedKvCache()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numQHeads = 4;
         const int numKVHeads = 2;
         const int seqLen = 3;
@@ -3688,12 +3515,9 @@ public class CudaBackendTests
         AssertClose(expected, actualF16.GetElementsAsFloat(seqLen * numQHeads * headDim), 2e-3f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaFusedLayoutOps_MatchReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var qkv = new Tensor(allocator, DType.Float32, 3, 10);
         FillSequential(qkv, scale: 1f, offset: 0f);
@@ -3716,12 +3540,9 @@ public class CudaBackendTests
             heads.GetElementsAsFloat(18));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaGqaDecodeAttention_CircularMatchesReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numQHeads = 4;
         const int numKVHeads = 2;
         const int headDim = 3;
@@ -3750,12 +3571,9 @@ public class CudaBackendTests
         AssertClose(expected, actual.GetElementsAsFloat(numQHeads * headDim), 1e-5f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaGqaDecodeAttention_ReadsFloat16KvCache()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numQHeads = 4;
         const int numKVHeads = 2;
         const int headDim = 3;
@@ -3789,7 +3607,7 @@ public class CudaBackendTests
         AssertClose(expected, actual.GetElementsAsFloat(numQHeads * headDim), 2e-3f);
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(256, 64, 23, 0, true, false)]
     [InlineData(256, 64, 23, 0, true, true)]
     [InlineData(256, 64, 64, 17, true, false)]
@@ -3804,9 +3622,6 @@ public class CudaBackendTests
         bool circular,
         bool dynamicLength)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numQHeads = 8;
         const int numKVHeads = 2;
         float scale = 1.0f / MathF.Sqrt(headDim);
@@ -3864,12 +3679,9 @@ public class CudaBackendTests
             3e-3f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaGqaDecodeAttentionWithSinks_ReadsFloat16KvCache()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numQHeads = 4;
         const int numKVHeads = 2;
         const int headDim = 3;
@@ -3907,12 +3719,9 @@ public class CudaBackendTests
         AssertClose(expected, actual.GetElementsAsFloat(numQHeads * headDim), 2e-3f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaGqaDecodeAttentionWithSinks_PartitionedMatchesReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int numQHeads = 4;
         const int numKVHeads = 2;
         const int headDim = 16;
@@ -3956,12 +3765,9 @@ public class CudaBackendTests
         AssertClose(expected, actualF16.GetElementsAsFloat(numQHeads * headDim), 2e-3f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaFusedCacheOps_MatchReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var src = new Tensor(allocator, DType.Float32, 2, 4, 3);
         FillSequential(src, scale: 1f, offset: 1f);
@@ -3986,12 +3792,9 @@ public class CudaBackendTests
         }, concat.GetElementsAsFloat(30));
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaFusedFloat16CacheOps_MatchReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var filled = new Tensor(allocator, DType.Float16, 1, 4, 2);
         Ops.Fill(filled, 1.5f);
@@ -4010,12 +3813,9 @@ public class CudaBackendTests
         AssertClose(src.GetElementsAsFloat(24), gathered.GetElementsAsFloat(24), 1e-3f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaCopy_Float16NarrowedKvCacheLayout_StaysOnDevice()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int heads = 3;
         const int oldCapacity = 8;
         const int newCapacity = 16;
@@ -4048,12 +3848,9 @@ public class CudaBackendTests
             tail.GetElementsAsFloat(heads * (newCapacity - cacheSeqLen) * headDim), 1e-3f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaFusedGeluAndNeoXRope_MatchReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var gateUp = new Tensor(allocator, DType.Float32, 2, 6);
         gateUp.SetElementsAsFloat(new[] { -1f, 0.5f, 2f, 3f, -4f, 0.25f, 1.25f, -0.75f, 0.1f, 2f, 3f, -5f });
@@ -4094,12 +3891,9 @@ public class CudaBackendTests
         AssertClose(expectedRope, data.GetElementsAsFloat(16), 1e-5f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaFusedBiasAndOaiSwiGlu_MatchReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var matrix = Tensor.FromArray(allocator, new float[,]
         {
@@ -4140,12 +3934,9 @@ public class CudaBackendTests
         AssertClose(expected, activated.GetElementsAsFloat(6), 1e-5f);
     }
 
-    [Fact]
+    [CudaFact]
     public void CudaAttentionSoftmaxWithSinksAndWindow_MatchesReference()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int heads = 2;
         const int seqLen = 3;
         const int kvLen = 6;

--- a/InferenceWeb.Tests/CudaDecodeAttentionWrapTests.cs
+++ b/InferenceWeb.Tests/CudaDecodeAttentionWrapTests.cs
@@ -18,26 +18,19 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Cuda")]
 public class CudaDecodeAttentionWrapTests
 {
     private readonly ITestOutputHelper _output;
 
     public CudaDecodeAttentionWrapTests(ITestOutputHelper output) => _output = output;
 
-    [Theory]
+    [CudaTheory]
     [InlineData(4, 2, 8, 16)]    // small, exercises wrap quickly
     [InlineData(8, 1, 16, 64)]   // MQA-ish
     [InlineData(8, 4, 32, 128)]  // closer to a real local layer shape
     public void CircularDecodeAttention_MatchesCpuAcrossWrapBoundary(
         int numQHeads, int numKVHeads, int headDim, int cacheSize)
     {
-        if (!CudaBackend.IsAvailable())
-        {
-            _output.WriteLine("[wrap] CUDA unavailable; skipping.");
-            return;
-        }
-
         using var allocator = new CudaAllocator();
 
         int window = cacheSize;                  // local layer attends the whole window
@@ -139,18 +132,12 @@ public class CudaDecodeAttentionWrapTests
     // and is populated through the real CUDA write kernel (TryCopyHeadFirstToCache),
     // exactly as Gemma4Model.CopyToCacheDecode does. This exercises the F16 write
     // and F16 read kernels together across the wrap boundary.
-    [Theory]
+    [CudaTheory]
     [InlineData(4, 2, 8, 16)]
     [InlineData(8, 4, 32, 128)]
     public void CircularDecodeAttentionF16_MatchesCpuAcrossWrapBoundary(
         int numQHeads, int numKVHeads, int headDim, int cacheSize)
     {
-        if (!CudaBackend.IsAvailable())
-        {
-            _output.WriteLine("[wrap-f16] CUDA unavailable; skipping.");
-            return;
-        }
-
         using var allocator = new CudaAllocator();
         int window = cacheSize;
         float scale = 1.0f / MathF.Sqrt(headDim);
@@ -248,17 +235,11 @@ public class CudaDecodeAttentionWrapTests
     // the case that crosses blockDim (256 -> multiple score elements per thread)
     // and the partitioned-attention threshold (2048). Sweeps attendLen across all
     // those boundaries and compares CUDA against a CPU reference.
-    [Theory]
+    [CudaTheory]
     [InlineData(false)]
     [InlineData(true)]   // true => Float16 cache (the q4_0 model default)
     public void GlobalDecodeAttention_MatchesCpuAsSequenceGrows(bool halfCache)
     {
-        if (!CudaBackend.IsAvailable())
-        {
-            _output.WriteLine("[global] CUDA unavailable; skipping.");
-            return;
-        }
-
         using var allocator = new CudaAllocator();
         int numQHeads = 8, numKVHeads = 2, headDim = 32;
         int cacheSize = 4096;                 // big enough to hold every position

--- a/InferenceWeb.Tests/CudaGraphPocTests.cs
+++ b/InferenceWeb.Tests/CudaGraphPocTests.cs
@@ -21,15 +21,16 @@ using Xunit.Abstractions;
 namespace InferenceWeb.Tests;
 
 [Trait("Category", "Bench")]
-[Trait("Requires", "Cuda")]
 public class CudaGraphPocTests
 {
     private readonly ITestOutputHelper _output;
     public CudaGraphPocTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [CudaFact]
     public void CudaGraph_LaunchOverhead_GoNoGo()
     {
+        // CudaFact covers availability; TS_CUDA_GRAPH_POC stays an opt-in gate
+        // so this benchmark never runs in the normal suite.
         if (Environment.GetEnvironmentVariable("TS_CUDA_GRAPH_POC") != "1")
         { _output.WriteLine("[graph-poc] set TS_CUDA_GRAPH_POC=1 to run; skipping"); return; }
 

--- a/InferenceWeb.Tests/CudaKvCacheResizeTests.cs
+++ b/InferenceWeb.Tests/CudaKvCacheResizeTests.cs
@@ -17,23 +17,16 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Cuda")]
 public class CudaKvCacheResizeTests
 {
     private readonly ITestOutputHelper _output;
     public CudaKvCacheResizeTests(ITestOutputHelper output) => _output = output;
 
-    [Theory]
+    [CudaTheory]
     [InlineData(8, 2048, 4096, 32, 2000)]   // the real first-grow shape (cross 2048)
     [InlineData(4, 64, 128, 16, 50)]        // tiny
     public void ResizeCopy_PreservesStridedHistory(int heads, int oldCap, int newCap, int headDim, int seqLen)
     {
-        if (!CudaBackend.IsAvailable())
-        {
-            _output.WriteLine("[resize] CUDA unavailable; skipping.");
-            return;
-        }
-
         using var allocator = new CudaAllocator();
 
         static float KVal(int pos, int h, int d) => MathF.Sin(0.0021f * pos + 0.31f * h + 0.07f * d);

--- a/InferenceWeb.Tests/CudaLongDecodeReproTests.cs
+++ b/InferenceWeb.Tests/CudaLongDecodeReproTests.cs
@@ -24,16 +24,17 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Cuda")]
-[Trait("Requires", "Models")]
 public class CudaLongDecodeReproTests
 {
     private readonly ITestOutputHelper _output;
     public CudaLongDecodeReproTests(ITestOutputHelper output) => _output = output;
 
-    [Fact]
+    [CudaFact("TS_REPRO_MODEL")]
     public async Task GreedyDecode_RealPrompt_RecordText()
     {
+        // CudaFact covers Cuda + Models availability; TS_REPRO_BACKEND stays a
+        // separate opt-in gate (it also selects a non-CUDA backend) so this
+        // never runs in the normal suite.
         string backendStr = Environment.GetEnvironmentVariable("TS_REPRO_BACKEND");
         if (string.IsNullOrWhiteSpace(backendStr))
         {

--- a/InferenceWeb.Tests/CudaQ8MatmulHarnessTests.cs
+++ b/InferenceWeb.Tests/CudaQ8MatmulHarnessTests.cs
@@ -27,15 +27,16 @@ using Xunit.Abstractions;
 namespace InferenceWeb.Tests;
 
 [Trait("Category", "Bench")]
-[Trait("Requires", "Cuda")]
 public class CudaQ8MatmulHarnessTests
 {
     private readonly ITestOutputHelper _output;
     public CudaQ8MatmulHarnessTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [CudaFact]
     public void Cuda_Q8Mma_CorrectnessVsDp4aAndReference()
     {
+        // CudaFact covers availability; TS_CUDA_Q8_HARNESS stays an opt-in gate
+        // so this benchmark never runs in the normal suite.
         if (Environment.GetEnvironmentVariable("TS_CUDA_Q8_HARNESS") != "1")
         { _output.WriteLine("[q8-mma] set TS_CUDA_Q8_HARNESS=1 to run; skipping"); return; }
 
@@ -119,9 +120,11 @@ public class CudaQ8MatmulHarnessTests
         _output.WriteLine("[q8-mma] CORRECTNESS PASS — tensor-core MMA matches dp4a + f32 reference.");
     }
 
-    [Fact]
+    [CudaFact]
     public void Cuda_Q8Matmul_ScalingProfile_GoNoGo()
     {
+        // CudaFact covers availability; TS_CUDA_Q8_HARNESS stays an opt-in gate
+        // so this benchmark never runs in the normal suite.
         if (Environment.GetEnvironmentVariable("TS_CUDA_Q8_HARNESS") != "1")
         { _output.WriteLine("[q8-harness] set TS_CUDA_Q8_HARNESS=1 to run; skipping"); return; }
 

--- a/InferenceWeb.Tests/DecodeBackendParityTests.cs
+++ b/InferenceWeb.Tests/DecodeBackendParityTests.cs
@@ -30,13 +30,12 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class DecodeBackendParityTests
 {
     private readonly ITestOutputHelper _output;
     public DecodeBackendParityTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [ModelFact("TS_PARITY_MODEL")]
     public void DumpGreedyDecodeTrace()
     {
         string modelPath = Environment.GetEnvironmentVariable("TS_PARITY_MODEL");

--- a/InferenceWeb.Tests/DiffusionGemmaTests.cs
+++ b/InferenceWeb.Tests/DiffusionGemmaTests.cs
@@ -6,7 +6,7 @@
 // TensorSharp is licensed under the BSD-3-Clause license found in the LICENSE file in the root directory of this source tree.
 //
 // Correctness + performance tests for the DiffusionGemma block-diffusion MoE model
-// (architecture key "diffusion-gemma") against a real GGUF. Opt-in via TS_TEST_MODEL_DIR.
+// (architecture key "diffusion-gemma|gemma-diffusion") against a real GGUF. Opt-in via TS_TEST_MODEL_DIR.
 //
 // These tests exercise the full denoising pipeline (DiffusionGemmaModel.ForwardCanvas +
 // DiffusionGemmaSampler EntropyBound sampler). They are skipped cleanly when the model file
@@ -26,7 +26,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class DiffusionGemmaTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -90,7 +89,7 @@ public class DiffusionGemmaTests
         return model.Tokenizer.Encode(rendered, addSpecial: true).ToArray();
     }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void ForwardCanvas_ProducesFiniteLogits_AndArgmaxIsValid()
     {
         using var model = TryLoad();
@@ -125,7 +124,7 @@ public class DiffusionGemmaTests
         _output.WriteLine("[diffusion-gemma] ForwardCanvas produced finite, valid logits.");
     }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void CapitalOfFrance_Generates_Paris()
     {
         using var model = TryLoad();
@@ -149,7 +148,7 @@ public class DiffusionGemmaTests
         Assert.Contains("Paris", text, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void Benchmark_StepThroughput()
     {
         using var model = TryLoad();
@@ -173,7 +172,7 @@ public class DiffusionGemmaTests
         Assert.True(msPerStep > 0);
     }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void PromptKvCache_LogitsMatchUnified()
     {
         using var model = TryLoad();
@@ -221,7 +220,7 @@ public class DiffusionGemmaTests
         Assert.True(cosine >= 0.99, $"PKV logits diverged from unified (cosine {cosine:F6}) — likely a bug");
     }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void Benchmark_PromptKvCache_SpeedupOnLongPrompt()
     {
         using var model = TryLoad();
@@ -292,7 +291,7 @@ public class DiffusionGemmaTests
     // because the host softcap/readback raced the in-flight device->host logits blit. A healthy answer is
     // substantial and token-diverse. Exercises the default (fused decode + fused lm_head + PKV) path on the
     // GPU backend. Skipped without TS_TEST_MODEL_DIR.
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void Generate_LongAnswer_IsCoherent_NotDegenerate()
     {
         using var model = TryLoad();
@@ -332,7 +331,7 @@ public class DiffusionGemmaTests
     // (kIOGPUCommandBufferCallbackErrorOutOfMemory). The fix (ReleasePromptKvTensor) frees the cached
     // device copy before disposing each K/V tensor. This test reallocates the prompt K/V many times and
     // asserts the resident device-copy bytes stay bounded (≈ one prefill's K/V), not growing per prefill.
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void PromptKvCache_DeviceCopiesDoNotLeakAcrossPrefills()
     {
         using var model = TryLoad();
@@ -380,7 +379,7 @@ public class DiffusionGemmaTests
     // every block of every turn leaked its prompt K/V device copies. Asserts generation keeps succeeding
     // and resident device memory stays bounded across turns. Uses a fixed prompt so the per-turn resident
     // footprint is constant (isolates the leak from the natural growth of an accumulating chat history).
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void MultiTurn_Generation_DoesNotLeakDeviceMemory()
     {
         using var model = TryLoad();
@@ -423,7 +422,7 @@ public class DiffusionGemmaTests
     // whether it is decoded alone or batched with another sequence (each canvas row's attention/FFN/lm_head
     // depends only on that row + its own prompt K/V, so batching must not perturb it). Uses fixed mask-token
     // canvases with self-conditioning off so the forward is deterministic. Skipped without a GPU/PKV backend.
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void BatchedDecode_LogitsMatchSolo()
     {
         using var model = TryLoad();
@@ -493,7 +492,7 @@ public class DiffusionGemmaTests
     // End-to-end mirror of the reported bug: two prompts generated together in ONE batched run must BOTH
     // produce a correct, non-empty answer (pre-fix, a second parallel request produced nothing). Drives the
     // batched sampler the way the server scheduler does — one block at a time over the active set.
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void BatchedGeneration_TwoPrompts_BothProduceOutput()
     {
         using var model = TryLoad();
@@ -527,7 +526,7 @@ public class DiffusionGemmaTests
     // TrimCanvas, a single request driven through RunBlockBatched must produce TOKEN-IDENTICAL output
     // to the single-request Generate() path — on every backend. Runs a few fixed steps so it is cheap
     // enough for the CPU backends.
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void BatchedScheduler_SingleRequest_MatchesGenerate_AllBackends()
     {
         using var model = TryLoad();
@@ -591,7 +590,7 @@ public class DiffusionGemmaTests
     // throughput; worse, the per-op batched forward is markedly slower per canvas than the fused kernel, so
     // the fused time-slice wins. This benchmark proves that ordering (so the scheduler default is correct)
     // and reports the numbers. Skipped without a GPU/PKV backend.
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "diffusion-gemma|gemma-diffusion")]
     public void Benchmark_BatchedDecodeThroughput()
     {
         using var model = TryLoad();

--- a/InferenceWeb.Tests/GatedFacts.cs
+++ b/InferenceWeb.Tests/GatedFacts.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace InferenceWeb.Tests
+{
+    /// <summary>
+    /// Environment probes shared by the gated fact attributes below. Probe
+    /// results are cached: attributes run at discovery time for every test.
+    /// </summary>
+    internal static class TestGates
+    {
+        // The probes are banned from test code (BannedSymbols.txt) so gating
+        // can't silently regress to in-test checks; this is the one caller.
+#pragma warning disable RS0030
+        private static readonly Lazy<bool> CudaAvailable = new(() =>
+        {
+            try { return TensorSharp.Cuda.CudaBackend.IsAvailable(); }
+            catch { return false; }
+        });
+
+        private static readonly Lazy<bool> MlxAvailable = new(() =>
+        {
+            try { return TensorSharp.MLX.MlxBackend.IsAvailable(); }
+            catch { return false; }
+        });
+#pragma warning restore RS0030
+
+        public static string CudaSkip =>
+            CudaAvailable.Value ? null : "Requires a CUDA device.";
+
+        public static string MlxSkip =>
+            MlxAvailable.Value ? null : "Requires the MLX native backend.";
+
+        /// <summary>
+        /// Skip reason for weight-gated tests, or null to run. The env var may
+        /// name a file or a directory; with <paramref name="ggufContains"/> the
+        /// directory must hold a matching GGUF (see <see cref="FindGguf"/>).
+        /// </summary>
+        public static string ModelSkip(string envVar, string ggufContains = null)
+        {
+            string value = Environment.GetEnvironmentVariable(envVar);
+            if (string.IsNullOrEmpty(value))
+                return $"Requires model weights ({envVar} not set).";
+            if (File.Exists(value))
+                return null;
+            if (!Directory.Exists(value))
+                return $"Requires model weights ({envVar} points to a missing path).";
+            if (ggufContains != null && FindGguf(value, ggufContains) == null)
+                return $"Requires model weights (no '*{ggufContains}*' GGUF under {envVar}).";
+            return null;
+        }
+
+        /// <summary>
+        /// First GGUF in <paramref name="dir"/> whose name contains
+        /// <paramref name="contains"/> (case-insensitive; '|' separates
+        /// accepted alternatives, e.g. "gpt-oss|gpt_oss"), skipping companion
+        /// files (mmproj / assistant drafts). Shared by the attributes and the
+        /// per-class loaders so the skip decision and the load pick the same file.
+        /// </summary>
+        public static string FindGguf(string dir, string contains)
+        {
+            string[] alternatives = contains.ToLowerInvariant().Split('|');
+            return Directory.GetFiles(dir, "*.gguf").FirstOrDefault(p =>
+            {
+                string n = Path.GetFileName(p).ToLowerInvariant();
+                return alternatives.Any(n.Contains)
+                    && !n.Contains("mmproj") && !n.Contains("assistant");
+            });
+        }
+    }
+
+    /// <summary>
+    /// Emits the Requires trait(s) declared by a gated fact attribute, so
+    /// --filter "Requires!=..." lanes work without a separate [Trait] line.
+    /// </summary>
+    public sealed class RequiresTraitDiscoverer : ITraitDiscoverer
+    {
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            foreach (string value in traitAttribute.GetNamedArgument<string>("RequiresValue").Split(','))
+                yield return new KeyValuePair<string, string>("Requires", value);
+        }
+    }
+
+    /// <summary>
+    /// [Fact] that needs a CUDA device: skips visibly when none is present and
+    /// carries Requires=Cuda. Passing a model env var adds the Requires=Models
+    /// gate on the same test.
+    /// </summary>
+    [TraitDiscoverer("InferenceWeb.Tests.RequiresTraitDiscoverer", "InferenceWeb.Tests")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class CudaFactAttribute : FactAttribute, ITraitAttribute
+    {
+        public string RequiresValue { get; }
+
+        public CudaFactAttribute(string modelEnvVar = null, string ggufContains = null)
+        {
+            RequiresValue = modelEnvVar == null ? "Cuda" : "Cuda,Models";
+            Skip = TestGates.CudaSkip
+                ?? (modelEnvVar == null ? null : TestGates.ModelSkip(modelEnvVar, ggufContains));
+        }
+    }
+
+    /// <summary>[Theory] variant of <see cref="CudaFactAttribute"/>.</summary>
+    [TraitDiscoverer("InferenceWeb.Tests.RequiresTraitDiscoverer", "InferenceWeb.Tests")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class CudaTheoryAttribute : TheoryAttribute, ITraitAttribute
+    {
+        public string RequiresValue { get; }
+
+        public CudaTheoryAttribute(string modelEnvVar = null, string ggufContains = null)
+        {
+            RequiresValue = modelEnvVar == null ? "Cuda" : "Cuda,Models";
+            Skip = TestGates.CudaSkip
+                ?? (modelEnvVar == null ? null : TestGates.ModelSkip(modelEnvVar, ggufContains));
+        }
+    }
+
+    /// <summary>
+    /// [Fact] that needs the MLX native backend: skips visibly when it is
+    /// absent and carries Requires=Mlx.
+    /// </summary>
+    [TraitDiscoverer("InferenceWeb.Tests.RequiresTraitDiscoverer", "InferenceWeb.Tests")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class MlxFactAttribute : FactAttribute, ITraitAttribute
+    {
+        public string RequiresValue => "Mlx";
+
+        public MlxFactAttribute() => Skip = TestGates.MlxSkip;
+    }
+
+    /// <summary>[Theory] variant of <see cref="MlxFactAttribute"/>.</summary>
+    [TraitDiscoverer("InferenceWeb.Tests.RequiresTraitDiscoverer", "InferenceWeb.Tests")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class MlxTheoryAttribute : TheoryAttribute, ITraitAttribute
+    {
+        public string RequiresValue => "Mlx";
+
+        public MlxTheoryAttribute() => Skip = TestGates.MlxSkip;
+    }
+
+    /// <summary>
+    /// [Fact] that needs real GGUF weights: skips visibly when the env var is
+    /// unset or the weights are absent, and carries Requires=Models.
+    /// </summary>
+    [TraitDiscoverer("InferenceWeb.Tests.RequiresTraitDiscoverer", "InferenceWeb.Tests")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class ModelFactAttribute : FactAttribute, ITraitAttribute
+    {
+        public string RequiresValue => "Models";
+
+        public ModelFactAttribute(string envVar, string ggufContains = null)
+            => Skip = TestGates.ModelSkip(envVar, ggufContains);
+    }
+
+    /// <summary>[Theory] variant of <see cref="ModelFactAttribute"/>.</summary>
+    [TraitDiscoverer("InferenceWeb.Tests.RequiresTraitDiscoverer", "InferenceWeb.Tests")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class ModelTheoryAttribute : TheoryAttribute, ITraitAttribute
+    {
+        public string RequiresValue => "Models";
+
+        public ModelTheoryAttribute(string envVar, string ggufContains = null)
+            => Skip = TestGates.ModelSkip(envVar, ggufContains);
+    }
+}

--- a/InferenceWeb.Tests/Gemma4BatchedForwardTests.cs
+++ b/InferenceWeb.Tests/Gemma4BatchedForwardTests.cs
@@ -31,7 +31,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class Gemma4BatchedForwardTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -39,7 +38,7 @@ public class Gemma4BatchedForwardTests
     private readonly ITestOutputHelper _output;
     public Gemma4BatchedForwardTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "gemma-4-e4b")]
     public Task Gemma4_BatchSize1_ForwardBatchEitherMatchesLegacyOrThrows()
         => RunCorrectnessTest();
 

--- a/InferenceWeb.Tests/Gemma4BatchedPerfBench.cs
+++ b/InferenceWeb.Tests/Gemma4BatchedPerfBench.cs
@@ -32,7 +32,6 @@ using Xunit.Abstractions;
 namespace InferenceWeb.Tests;
 
 [Trait("Category", "Bench")]
-[Trait("Requires", "Models")]
 public class Gemma4BatchedPerfBench
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -44,7 +43,7 @@ public class Gemma4BatchedPerfBench
     // Five short prompts in parallel - representative of a typical chat
     // workload where each request is a few hundred tokens of prompt and
     // we want low p50 latency.
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "gemma-4-e4b")]
     public Task Gemma4_ShortPromptsParallel_BatchedVsLegacy() =>
         RunComparison(
             label: "short-parallel",
@@ -56,7 +55,7 @@ public class Gemma4BatchedPerfBench
     // batched paged kernel was expected to show its biggest win over the
     // per-seq KV-swap path (gather + GPU launch overhead amortised across
     // the longer attention compute).
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "gemma-4-e4b")]
     public Task Gemma4_LongPromptsParallel_BatchedVsLegacy() =>
         RunComparison(
             label: "long-parallel",
@@ -67,7 +66,7 @@ public class Gemma4BatchedPerfBench
     // Single sequence - sanity check that batched isn't WORSE than legacy
     // on the degenerate batch=1 case. The fixed per-call overheads
     // (graph build, gather) shouldn't drown out the layer compute.
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "gemma-4-e4b")]
     public Task Gemma4_SingleSequence_BatchedVsLegacy() =>
         RunComparison(
             label: "single-seq",
@@ -79,7 +78,7 @@ public class Gemma4BatchedPerfBench
     // paged-attention amortisation should be most visible. Need
     // SchedulerConfig.MaxNumRunningSequences >= 8 (already set in
     // BenchContext).
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "gemma-4-e4b")]
     public Task Gemma4_EightPromptsParallel_BatchedVsLegacy() =>
         RunComparison(
             label: "batch8-parallel",

--- a/InferenceWeb.Tests/Gemma4PromptRenderReproTests.cs
+++ b/InferenceWeb.Tests/Gemma4PromptRenderReproTests.cs
@@ -192,8 +192,7 @@ public class Gemma4PromptRenderReproTests
         return candidates.FirstOrDefault(p => !string.IsNullOrEmpty(p) && File.Exists(p));
     }
 
-    [Trait("Requires", "Models")]
-    [Fact]
+    [ModelFact("TS_GEMMA4_BPE_MODEL")]
     public void RealGemma4BpeTokenizer_MatchesLlamaCppOracle()
     {
         string? modelPath = FindBpeModel();
@@ -245,8 +244,7 @@ public class Gemma4PromptRenderReproTests
             tokenizer.Decode(new List<int> { 9259, 236888, 2088, 740, 564, 1601, 611, 3124, 236881 }));
     }
 
-    [Trait("Requires", "Models")]
-    [Fact]
+    [ModelFact("TS_GEMMA4_12B")]
     public void RealTemplate_RendersUserText_AndSingleBos()
     {
         string? modelPath = FindModel();
@@ -269,8 +267,7 @@ public class Gemma4PromptRenderReproTests
         Assert.Equal(1, CountLeading(tokens, bosId)); // exactly one BOS
     }
 
-    [Trait("Requires", "Models")]
-    [Fact]
+    [ModelFact("TS_GEMMA4_12B")]
     public async Task Generate_FinalFantasyPrompt_ProducesRelevantOutput()
     {
         string? modelPath = FindModel();
@@ -322,8 +319,7 @@ public class Gemma4PromptRenderReproTests
         }
     }
 
-    [Trait("Requires", "Models")]
-    [Fact]
+    [ModelFact("TS_GEMMA4_12B")]
     public async Task Generate_ThreeDistinctPromptsInParallel_EachStaysOnTopic()
     {
         string? modelPath = FindModel();
@@ -382,8 +378,7 @@ public class Gemma4PromptRenderReproTests
     // producing coherent-but-off-topic output. The multi-token prefill must yield
     // the SAME next-token as feeding the prompt one token at a time (decode path),
     // and must be deterministic across repeats.
-    [Trait("Requires", "Models")]
-    [Fact]
+    [ModelFact("TS_GEMMA4_12B")]
     public void PrefillNextToken_MatchesIncrementalDecode_AndIsDeterministic()
     {
         string? modelPath = FindModel();

--- a/InferenceWeb.Tests/GptOssBatchedCorrectnessTests.cs
+++ b/InferenceWeb.Tests/GptOssBatchedCorrectnessTests.cs
@@ -25,7 +25,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class GptOssBatchedCorrectnessTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -34,7 +33,7 @@ public class GptOssBatchedCorrectnessTests
     private readonly ITestOutputHelper _output;
     public GptOssBatchedCorrectnessTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "gpt-oss|gpt_oss|gptoss")]
     public async Task GptOss_Greedy_LegacyAndBatchedAgree()
     {
         var modelPath = FindGptOss();
@@ -125,7 +124,7 @@ public class GptOssBatchedCorrectnessTests
         return Directory.GetFiles(dir, "*.gguf").Where(p =>
         {
             var n = Path.GetFileName(p).ToLowerInvariant();
-            return (n.Contains("gpt-oss") || n.Contains("gpt_oss") || n.Contains("gptoss"))
+            return (n.Contains("gpt-oss|gpt_oss|gptoss") || n.Contains("gpt_oss") || n.Contains("gptoss"))
                 && !n.Contains("mmproj");
         }).OrderBy(p => Path.GetFileName(p)).FirstOrDefault();
     }

--- a/InferenceWeb.Tests/GptOssBatchedPerfBench.cs
+++ b/InferenceWeb.Tests/GptOssBatchedPerfBench.cs
@@ -26,7 +26,6 @@ using Xunit.Abstractions;
 namespace InferenceWeb.Tests;
 
 [Trait("Category", "Bench")]
-[Trait("Requires", "Models")]
 public class GptOssBatchedPerfBench
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -35,7 +34,7 @@ public class GptOssBatchedPerfBench
     private readonly ITestOutputHelper _output;
     public GptOssBatchedPerfBench(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "gpt-oss|gpt_oss|gptoss")]
     public Task GptOss_BatchedVsLegacy()
         => RunScenarios(new[]
         {
@@ -196,7 +195,7 @@ public class GptOssBatchedPerfBench
         return Directory.GetFiles(dir, "*.gguf").Where(p =>
         {
             var n = Path.GetFileName(p).ToLowerInvariant();
-            return (n.Contains("gpt-oss") || n.Contains("gpt_oss") || n.Contains("gptoss"))
+            return (n.Contains("gpt-oss|gpt_oss|gptoss") || n.Contains("gpt_oss") || n.Contains("gptoss"))
                 && !n.Contains("mmproj");
         }).OrderBy(p => Path.GetFileName(p)).FirstOrDefault();
     }

--- a/InferenceWeb.Tests/GptOssLongDecodeReproTests.cs
+++ b/InferenceWeb.Tests/GptOssLongDecodeReproTests.cs
@@ -24,7 +24,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class GptOssLongDecodeReproTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -32,7 +31,7 @@ public class GptOssLongDecodeReproTests
     private readonly ITestOutputHelper _output;
     public GptOssLongDecodeReproTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "gpt-oss|gpt_oss|gptoss")]
     public void GptOss_LongContextDecode_DoesNotStall()
     {
         var modelPath = FindGptOss();
@@ -149,7 +148,7 @@ public class GptOssLongDecodeReproTests
         return Directory.GetFiles(dir, "*.gguf").Where(p =>
         {
             var n = Path.GetFileName(p).ToLowerInvariant();
-            return (n.Contains("gpt-oss") || n.Contains("gpt_oss") || n.Contains("gptoss"))
+            return (n.Contains("gpt-oss|gpt_oss|gptoss") || n.Contains("gpt_oss") || n.Contains("gptoss"))
                 && !n.Contains("mmproj");
         }).OrderBy(p => Path.GetFileName(p)).FirstOrDefault();
     }

--- a/InferenceWeb.Tests/HarmonyToolCallIntegrationTests.cs
+++ b/InferenceWeb.Tests/HarmonyToolCallIntegrationTests.cs
@@ -29,7 +29,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class HarmonyToolCallIntegrationTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -61,7 +60,7 @@ public class HarmonyToolCallIntegrationTests
         },
     };
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "gpt-oss|gpt_oss|gptoss")]
     public async Task GptOss_ToolCall_RoundTrip()
     {
         var modelPath = FindGptOss();
@@ -195,7 +194,7 @@ public class HarmonyToolCallIntegrationTests
         return Directory.GetFiles(dir, "*.gguf").Where(p =>
         {
             var n = Path.GetFileName(p).ToLowerInvariant();
-            return (n.Contains("gpt-oss") || n.Contains("gpt_oss") || n.Contains("gptoss"))
+            return (n.Contains("gpt-oss|gpt_oss|gptoss") || n.Contains("gpt_oss") || n.Contains("gptoss"))
                 && !n.Contains("mmproj");
         }).OrderBy(p => Path.GetFileName(p)).FirstOrDefault();
     }

--- a/InferenceWeb.Tests/InferenceWeb.Tests.csproj
+++ b/InferenceWeb.Tests/InferenceWeb.Tests.csproj
@@ -5,9 +5,17 @@
     <IsPackable>false</IsPackable>
     <Nullable>annotations</Nullable>
     <Description>xUnit test suite for TensorSharp runtime, model, backend, and server behavior.</Description>
+    <!-- RS0030: backend availability probes are banned in test code
+         (BannedSymbols.txt) — gate with [CudaFact]/[MlxFact] instead, so a
+         missing backend counts as Skipped rather than silently Passed. -->
+    <WarningsAsErrors>$(WarningsAsErrors);RS0030</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="BannedSymbols.txt" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/InferenceWeb.Tests/Mistral3BatchedForwardTests.cs
+++ b/InferenceWeb.Tests/Mistral3BatchedForwardTests.cs
@@ -23,7 +23,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class Mistral3BatchedForwardTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -31,11 +30,11 @@ public class Mistral3BatchedForwardTests
     private readonly ITestOutputHelper _output;
     public Mistral3BatchedForwardTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "ministral|mistral")]
     public Task Mistral3_BatchSize1_ForwardBatchMatchesLegacyTop1()
         => RunCorrectnessTest();
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "ministral|mistral")]
     public Task Mistral3_BatchSize2_DistinctSequencesProduceDistinctLogits()
         => RunDistinctTest();
 
@@ -191,7 +190,7 @@ public class Mistral3BatchedForwardTests
             .FirstOrDefault(p =>
             {
                 var n = Path.GetFileName(p).ToLowerInvariant();
-                return (n.Contains("ministral") || n.Contains("mistral"))
+                return (n.Contains("ministral|mistral") || n.Contains("mistral"))
                     && !n.Contains("mmproj");
             });
         if (modelPath == null)

--- a/InferenceWeb.Tests/MlxBackendTests.cs
+++ b/InferenceWeb.Tests/MlxBackendTests.cs
@@ -5,9 +5,11 @@ using TensorSharp.Runtime;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Mlx")]
 public class MlxBackendTests
 {
+    // These two test the availability probe itself, so they are the exemption
+    // from the RS0030 ban on calling it directly (see BannedSymbols.txt).
+#pragma warning disable RS0030
     [Fact]
     public void MlxAvailabilityProbe_DoesNotThrow()
     {
@@ -24,13 +26,11 @@ public class MlxBackendTests
 
         Assert.True(MlxBackend.IsAvailable());
     }
+#pragma warning restore RS0030
 
-    [Fact]
+    [MlxFact]
     public void MlxAddmm_MatchesCpuForContiguousRhs()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var a = Tensor.FromArray(allocator, new float[,] { { 1, 2, 3 }, { 4, 5, 6 } });
         using var b = Tensor.FromArray(allocator, new float[,] { { 7, 8 }, { 9, 10 }, { 11, 12 } });
@@ -41,12 +41,9 @@ public class MlxBackendTests
         AssertClose(new[] { 58f, 64f, 139f, 154f }, c.GetElementsAsFloat(4));
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxSoftmax_MatchesExpectedRows()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var logits = Tensor.FromArray(allocator, new float[,] { { 1, 2, 3 }, { -2, 0, 2 } });
         using var probs = new Tensor(allocator, DType.Float32, 2, 3);
@@ -60,12 +57,9 @@ public class MlxBackendTests
         }, probs.GetElementsAsFloat(6), 1e-5f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxMul_BroadcastsColumnVector()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var values = Tensor.FromArray(allocator, new float[,]
         {
@@ -84,12 +78,9 @@ public class MlxBackendTests
         AssertClose(new[] { 2f, 4f, 6f, -4f, -5f, -6f }, output.GetElementsAsFloat(6));
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxHostWriteAfterDeviceOp_PreservesTensorData()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var tensor = Tensor.FromArray(allocator, new float[,] { { 1, 2 }, { 3, 4 } });
         Ops.Mul(tensor, tensor, 2f);
@@ -99,12 +90,9 @@ public class MlxBackendTests
         AssertClose(new[] { 2f, 100f, 6f, 8f }, tensor.GetElementsAsFloat(4));
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxCopyIntoNarrowView_UpdatesDeviceStorage()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var tensor = Tensor.FromArray(allocator, new float[,]
         {
@@ -126,12 +114,9 @@ public class MlxBackendTests
         }, tensor.GetElementsAsFloat(12));
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFill_WritesDeviceResidentTensor()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var tensor = new Tensor(allocator, DType.Float32, 2, 3);
 
@@ -140,12 +125,9 @@ public class MlxBackendTests
         AssertClose(new[] { 1.25f, 1.25f, 1.25f, 1.25f, 1.25f, 1.25f }, tensor.GetElementsAsFloat(6));
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxRmsNorm_MatchesExpectedRows()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var input = Tensor.FromArray(allocator, new float[,] { { 3, 4 }, { 5, 12 } });
         using var weight = Tensor.FromArray(allocator, new float[] { 1f, 0.5f });
@@ -160,12 +142,9 @@ public class MlxBackendTests
         }, output.GetElementsAsFloat(4), 1e-4f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxLayerNorm_MatchesExpectedRows()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var input = Tensor.FromArray(allocator, new float[,] { { 1, 2, 3 }, { -1, 1, 3 } });
         using var weight = Tensor.FromArray(allocator, new float[] { 1f, 2f, 0.5f });
@@ -181,12 +160,9 @@ public class MlxBackendTests
         }, output.GetElementsAsFloat(6), 1e-4f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxGeluAndGeluMul_MatchCpuFormula()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         float[,] gate =
         {
             { -2.0f, -0.5f, 0.0f },
@@ -219,12 +195,9 @@ public class MlxBackendTests
         AssertClose(expectedMul, mulTensor.GetElementsAsFloat(expectedMul.Length), 1e-5f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxSiLUMulSplit_MatchesSplitReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         float[,] gateUp =
         {
             { -2.0f, -0.5f, 0.0f, 1.5f, -2.0f, 0.25f },
@@ -243,12 +216,9 @@ public class MlxBackendTests
         AssertClose(expected, actualTensor.GetElementsAsFloat(expected.Length), 1e-5f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxScaledDotProductAttention_MatchesReferenceWithoutMask()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int batch = 1;
         const int seqQ = 3;
         const int seqK = 4;
@@ -278,12 +248,9 @@ public class MlxBackendTests
         AssertClose(ScaledDotProductAttentionReference(q, k, v, null, scale), actualTensor.GetElementsAsFloat((int)actualTensor.ElementCount()), 1e-3f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxScaledDotProductAttention_MatchesReferenceWithMask()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int batch = 1;
         const int seqQ = 3;
         const int seqK = 4;
@@ -313,12 +280,9 @@ public class MlxBackendTests
         AssertClose(ScaledDotProductAttentionReference(q, k, v, mask, scale), actualTensor.GetElementsAsFloat((int)actualTensor.ElementCount()), 1e-3f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxCopy_CastsFloat32ToFloat16OnDevice()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var src = Tensor.FromArray(allocator, new float[] { -1.25f, -0.5f, 0f, 0.75f, 1.5f, 3.25f });
         using var dst = new Tensor(allocator, DType.Float16, 6);
@@ -328,12 +292,9 @@ public class MlxBackendTests
         AssertClose(src.GetElementsAsFloat(6), dst.GetElementsAsFloat(6), 1e-3f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFusedPrefillAttention_GqaMatchesReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int heads = 4;
         const int kvHeads = 2;
         const int seq = 3;
@@ -367,12 +328,9 @@ public class MlxBackendTests
         AssertClose(HeadFirstAttentionReference(q, k, v, scale, causal: true), actualTensor.GetElementsAsFloat((int)actualTensor.ElementCount()), 1e-4f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFusedPrefillAttention_HeadDim256UsesChunkedVectorPath()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int heads = 24;
         const int kvHeads = 4;
         const int seq = 11;
@@ -415,12 +373,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFusedDecodeAttention_ReadsFloat16KvCache()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int heads = 4;
         const int kvHeads = 2;
         const int seq = 5;
@@ -459,12 +414,9 @@ public class MlxBackendTests
         AssertClose(HeadFirstAttentionReference(qHeads, k, v, scale, causal: false), actualTensor.GetElementsAsFloat((int)actualTensor.ElementCount()), 2e-3f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFusedCircularDecodeAttention_ReadsWrappedFloat16KvCache()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int heads = 4;
         const int kvHeads = 2;
         const int cacheLen = 5;
@@ -521,12 +473,9 @@ public class MlxBackendTests
             2e-3f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxIndexSelect_GathersRowsOnDevice()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var src = Tensor.FromArray(allocator, new float[,]
         {
@@ -541,12 +490,9 @@ public class MlxBackendTests
         AssertClose(new[] { 7f, 8f, 9f, 1f, 2f, 3f, 10f, 11f, 12f }, selected.GetElementsAsFloat(9));
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFusedGatherRows_GathersRowsOnDevice()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var src = Tensor.FromArray(allocator, new float[,]
         {
@@ -563,12 +509,9 @@ public class MlxBackendTests
         AssertClose(new[] { 7f, 8f, 9f, 1f, 2f, 3f, 10f, 11f, 12f }, gathered.GetElementsAsFloat(9));
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFusedScatterAddWeightedRows_AccumulatesRowsOnDevice()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var output = Tensor.FromArray(allocator, new float[,]
         {
@@ -597,12 +540,9 @@ public class MlxBackendTests
         }, output.GetElementsAsFloat(12));
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFusedRmsNormAddInPlace_MatchesCpu()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var residual = Tensor.FromArray(allocator, new float[,]
         {
@@ -642,12 +582,9 @@ public class MlxBackendTests
         AssertClose(expected, residual.GetElementsAsFloat(8), tolerance: 1e-5f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFusedGeluMulSplit_MatchesCpu()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var gateUp = Tensor.FromArray(allocator, new float[,]
         {
@@ -678,12 +615,9 @@ public class MlxBackendTests
         AssertClose(expected, result.GetElementsAsFloat(6), tolerance: 1e-5f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFusedFlatToHeadFirst_MatchesReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var input = Tensor.FromArray(allocator, new float[,]
         {
@@ -702,12 +636,9 @@ public class MlxBackendTests
         }, result.GetElementsAsFloat(12), tolerance: 1e-5f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxFusedNeoXRoPEFlatAndHeadFirst_MatchReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int heads = 2;
         const int seq = 2;
         const int dim = 4;
@@ -752,12 +683,9 @@ public class MlxBackendTests
         AssertClose(expectedHeadFirst, headFirstTensor.GetElementsAsFloat(expectedHeadFirst.Length), tolerance: 1e-5f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQwen35PackedGdnDecode_MatchesSeparateProjectionPath()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         string previousNative = Environment.GetEnvironmentVariable("TS_MLX_GDN_NATIVE");
         Environment.SetEnvironmentVariable("TS_MLX_GDN_NATIVE", null);
         try
@@ -838,12 +766,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxRepeatInterleave_RepeatsAlongAxis()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var src = Tensor.FromArray(allocator, new float[,]
         {
@@ -855,12 +780,9 @@ public class MlxBackendTests
         AssertClose(new[] { 1f, 2f, 1f, 2f, 3f, 4f, 3f, 4f }, repeated.GetElementsAsFloat(8));
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxAddCausalMask_MasksFuturePositionsOnDevice()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var scores = Tensor.FromArray(allocator, new float[,]
         {
@@ -882,12 +804,9 @@ public class MlxBackendTests
         }, actual);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxRoPEEx_NeoXDynamicPositions_MatchesReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int batch = 1;
         const int seq = 3;
         const int heads = 2;
@@ -908,12 +827,9 @@ public class MlxBackendTests
         AssertClose(expected, actualTensor.GetElementsAsFloat((int)actualTensor.ElementCount()), 1e-4f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxRoPEEx_InPlaceTraditional_MatchesReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int batch = 1;
         const int seq = 2;
         const int heads = 3;
@@ -935,12 +851,9 @@ public class MlxBackendTests
         AssertClose(expected, input.GetElementsAsFloat((int)input.ElementCount()), 1e-4f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedMatmul_Q80MatchesDequantizedReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 3;
         const int inDim = 64;
         const int outDim = 4;
@@ -977,14 +890,11 @@ public class MlxBackendTests
         }
     }
 
-    [Theory]
+    [MlxTheory]
     [InlineData(false)]
     [InlineData(true)]
     public void MlxQuantizedMatmul_Q4MatchesDequantizedReference(bool hasExplicitBias)
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 2;
         const int inDim = 64;
         const int outDim = 3;
@@ -1027,14 +937,11 @@ public class MlxBackendTests
         }
     }
 
-    [Theory]
+    [MlxTheory]
     [InlineData(false)]
     [InlineData(true)]
     public void MlxQuantizedMatmul_Q5MatchesDequantizedReference(bool hasExplicitBias)
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 2;
         const int inDim = 64;
         const int outDim = 3;
@@ -1077,15 +984,12 @@ public class MlxBackendTests
         }
     }
 
-    [Theory]
+    [MlxTheory]
     [InlineData((int)GgmlTensorType.Q4_K)]
     [InlineData((int)GgmlTensorType.Q5_K)]
     [InlineData((int)GgmlTensorType.Q6_K)]
     public void MlxQuantizedMatmul_KQuantsMatchDequantizedReference(int ggmlType)
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 2;
         const int inDim = 256;
         const int outDim = 2;
@@ -1134,12 +1038,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedMatmul_Q6KSingleRowMatchesDequantizedReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 1;
         const int inDim = 256;
         const int outDim = 5;
@@ -1178,12 +1079,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedMatmul_Q5KSingleRow4ColumnMatchesDequantizedReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 1;
         const int inDim = 256;
         const int outDim = 5;
@@ -1222,12 +1120,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedMatmul_RmsNormFusedMatchesReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 2;
         const int inDim = 256;
         const int outDim = 3;
@@ -1282,12 +1177,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedMatmul_AddIntoFusedMatchesReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 2;
         const int inDim = 256;
         const int outDim = 4;
@@ -1333,12 +1225,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedMatmul_MXFP4MatchesDequantizedReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 3;
         const int inDim = 64;
         const int outDim = 4;
@@ -1379,12 +1268,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedMatmul_IQ4XSMatchesDequantizedReferenceAfterHostRelease()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 3;
         const int inDim = 512;
         const int outDim = 3;
@@ -1426,12 +1312,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedMatmul_IQ2XXSMatchesNativeDequantizedReferenceAfterHostRelease()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 3;
         const int inDim = 512;
         const int outDim = 4;
@@ -1470,14 +1353,11 @@ public class MlxBackendTests
         }
     }
 
-    [Theory]
+    [MlxTheory]
     [InlineData((int)GgmlTensorType.IQ2_S)]
     [InlineData((int)GgmlTensorType.IQ3_S)]
     public void MlxQuantizedMatmul_IQ2SAndIQ3SMatchNativeDequantizedReferenceAfterHostRelease(int ggmlType)
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 3;
         const int inDim = 512;
         const int outDim = 4;
@@ -1517,12 +1397,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedRows_Q80MatchDequantizedReferenceAfterHostRelease()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int inDim = 64;
         const int outDim = 5;
         int[] rows = { 4, 1, 3 };
@@ -1559,15 +1436,12 @@ public class MlxBackendTests
         }
     }
 
-    [Theory]
+    [MlxTheory]
     [InlineData((int)GgmlTensorType.Q4_K)]
     [InlineData((int)GgmlTensorType.Q5_K)]
     [InlineData((int)GgmlTensorType.Q6_K)]
     public void MlxQuantizedRows_KQuantsMatchDequantizedReferenceAfterHostRelease(int ggmlType)
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int inDim = 256;
         const int outDim = 5;
         int[] rows = { 4, 1, 3 };
@@ -1623,12 +1497,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedMatmul_IQ4XSDecode4ColumnMatchesDequantizedReferenceAfterHostRelease()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 1;
         const int inDim = 512;
         const int outDim = 5;
@@ -1670,12 +1541,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedRows_IQ4XSMatchDequantizedReferenceAfterHostRelease()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int inDim = 512;
         const int outDim = 5;
         int[] rows = { 4, 1, 3 };
@@ -1712,12 +1580,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedRows_IQ2XXSMatchNativeDequantizedReferenceAfterHostRelease()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int inDim = 512;
         const int outDim = 5;
         int[] rows = { 4, 1, 3 };
@@ -1755,14 +1620,11 @@ public class MlxBackendTests
         }
     }
 
-    [Theory]
+    [MlxTheory]
     [InlineData((int)GgmlTensorType.IQ2_S)]
     [InlineData((int)GgmlTensorType.IQ3_S)]
     public void MlxQuantizedRows_IQ2SAndIQ3SMatchNativeDequantizedReferenceAfterHostRelease(int ggmlType)
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int inDim = 512;
         const int outDim = 5;
         int[] rows = { 4, 1, 3 };
@@ -1801,12 +1663,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedRows_MXFP4MatchDequantizedReferenceAfterHostRelease()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int inDim = 64;
         const int outDim = 5;
         int[] rows = { 4, 1, 3 };
@@ -2180,12 +2039,9 @@ public class MlxBackendTests
         return raw;
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxGatherQmm_MXFP4StackedExpertsMatchDequantizedReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int numExperts = 4;
         const int inDim = 64;
         const int outDim = 6;
@@ -2275,12 +2131,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxGatherQmm_SortedRhsProbe_GatesTheFastPath()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
 
         // The probe must return a stable verdict for the shipping GPT-OSS
@@ -2372,12 +2225,9 @@ public class MlxBackendTests
         }
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxGatherQmm_MXFP4GptOssShapes_NullLhsMatchesProvidedLhs()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         // GPT-OSS-20b decode/short-prefill shapes: E=32 experts, 2880x2880
         // projections, NK=56 pairs (14 tokens x K=4). NK/E < 4 keeps this on
         // the per-row gather_qmv kernel, matching what decode dispatches.
@@ -2485,12 +2335,9 @@ public class MlxBackendTests
         DequantizeMxfp4Row(slice, row, inDim, destination, 0);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxSwiGluOaiGatherBias_MatchesCpuReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int rows = 5;
         const int dim = 33;   // deliberately not a threadgroup-width multiple
         const int numExperts = 3;
@@ -2540,12 +2387,9 @@ public class MlxBackendTests
         AssertClose(expected, result.GetElementsAsFloat(rows * dim), 1e-4f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxMoeBiasWeightedSum_MatchesCpuReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int n = 3;
         const int k = 2;
         const int dim = 17;

--- a/InferenceWeb.Tests/MlxIQuantDecodeMatmulTests.cs
+++ b/InferenceWeb.Tests/MlxIQuantDecodeMatmulTests.cs
@@ -32,7 +32,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Mlx")]
 public class MlxIQuantDecodeMatmulTests
 {
     private const int QK_K = 256;
@@ -50,7 +49,7 @@ public class MlxIQuantDecodeMatmulTests
     // tolerance is loose enough for the block-scale factoring the amortized
     // form does (sum(d*g*x) -> d*sum(g*x)) but far tighter than any indexing
     // mistake could survive.
-    [Theory]
+    [MlxTheory]
     [InlineData((int)GgmlTensorType.IQ2_XXS, 1)]
     [InlineData((int)GgmlTensorType.IQ2_XXS, 3)]
     [InlineData((int)GgmlTensorType.IQ2_S, 1)]
@@ -59,9 +58,6 @@ public class MlxIQuantDecodeMatmulTests
     [InlineData((int)GgmlTensorType.IQ3_S, 3)]
     public void DecodeMatmul_MatchesManagedDequantReference(int ggmlType, int rows)
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int inDim = 512;   // 2 super-blocks per row
         const int outDim = 6;
         byte[] weights = CreateRows(ggmlType, outDim, inDim, seed: 0x2C51 + ggmlType);
@@ -102,15 +98,12 @@ public class MlxIQuantDecodeMatmulTests
     // which still uses the per-ELEMENT dequant helper - so this pins that the
     // rewrite left the scalar path intact and the two agree element for
     // element.
-    [Theory]
+    [MlxTheory]
     [InlineData((int)GgmlTensorType.IQ2_XXS)]
     [InlineData((int)GgmlTensorType.IQ2_S)]
     [InlineData((int)GgmlTensorType.IQ3_S)]
     public void GetRows_MatchesManagedDequantReference(int ggmlType)
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int inDim = 512;
         const int outDim = 6;
         int[] rowIds = { 4, 0, 2, 2 };

--- a/InferenceWeb.Tests/MlxIq3XxsKernelTests.cs
+++ b/InferenceWeb.Tests/MlxIq3XxsKernelTests.cs
@@ -27,7 +27,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Mlx")]
 public class MlxIq3XxsKernelTests
 {
     private const int QK_K = 256;
@@ -58,14 +57,11 @@ public class MlxIq3XxsKernelTests
     // weights and the activations as `half` before simdgroup_multiply_accumulate
     // — hence the looser fp16-scale tolerance there (same template all the other
     // i-quants use; not IQ3_XXS-specific).
-    [Theory]
+    [MlxTheory]
     [InlineData(3, 1e-4f)]
     [InlineData(8, 1e-2f)]
     public void MlxQuantizedMatmul_Iq3XxsMatchesManagedDequantReference(int rows, float tolerance)
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int inDim = 512;
         const int outDim = 6;
         byte[] weights = CreateIq3XxsRows(outDim, inDim, seed: 0x51F3);
@@ -111,12 +107,9 @@ public class MlxIq3XxsKernelTests
     // get_rows shares tensorsharp_dequant_iq3_xxs with the matmul kernel but
     // reaches every element individually, so it pins the full 256-element decode
     // (not just its dot product).
-    [Fact]
+    [MlxFact]
     public void MlxQuantizedRows_Iq3XxsMatchesManagedDequantReference()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         const int inDim = 512;
         const int outDim = 6;
         int[] rows = { 5, 0, 3, 3 };

--- a/InferenceWeb.Tests/MlxStorageBulkElementIoTests.cs
+++ b/InferenceWeb.Tests/MlxStorageBulkElementIoTests.cs
@@ -16,24 +16,17 @@ namespace InferenceWeb.Tests;
 /// contract: identical values to the per-element path, and unchanged
 /// host/device dirty semantics.
 /// </summary>
-[Trait("Requires", "Mlx")]
 public class MlxStorageBulkElementIoTests
 {
-    [Fact]
+    [MlxFact]
     public void MlxBulkFloat32Io_MatchesPerElementPath()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         AssertBulkMatchesPerElement(DType.Float32, tolerance: 0f);
     }
 
-    [Fact]
+    [MlxFact]
     public void MlxBulkFloat16Io_MatchesPerElementPath()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         // F16 loses precision on the way in; the bulk path must lose EXACTLY the
         // same precision as the per-element path (asserted bit-for-bit below),
         // and the round trip must still land within half's ~2^-11 relative step
@@ -45,12 +38,9 @@ public class MlxStorageBulkElementIoTests
     /// A bulk WRITE must mark the storage host-dirty, exactly as the per-element
     /// path did, or the next kernel silently reads the stale device array.
     /// </summary>
-    [Fact]
+    [MlxFact]
     public void MlxBulkSetElementsAsFloat_IsVisibleToTheNextDeviceOp()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var source = new Tensor(allocator, DType.Float32, 2, 3);
 
@@ -71,12 +61,9 @@ public class MlxStorageBulkElementIoTests
     /// A bulk READ must first pull the device array back to the host, and must
     /// keep doing so after each subsequent device op.
     /// </summary>
-    [Fact]
+    [MlxFact]
     public void MlxBulkGetElementsAsFloat_SeesDeviceComputedValues()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         using var allocator = new MlxAllocator();
         using var tensor = new Tensor(allocator, DType.Float32, 2, 3);
 

--- a/InferenceWeb.Tests/MuseGlimmerKvSnapshotTests.cs
+++ b/InferenceWeb.Tests/MuseGlimmerKvSnapshotTests.cs
@@ -35,7 +35,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class MuseGlimmerKvSnapshotTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -52,7 +51,7 @@ public class MuseGlimmerKvSnapshotTests
     /// the batch executor does. Before the fix this faulted the process the first
     /// time a block started at or beyond _kvSwaRows.
     /// </summary>
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "muse-glimmer")]
     public void MuseGlimmer_CapturingBlocksPastTheSwaRing_DoesNotFault()
     {
         string modelPath = TryFindModel();
@@ -125,7 +124,7 @@ public class MuseGlimmerKvSnapshotTests
     /// pick up exactly where it left off. Bit-identical logits are the bar: the
     /// restore writes the same rows the prefill did, so nothing should shift.
     /// </summary>
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "muse-glimmer")]
     public void MuseGlimmer_RestoringACapturedPrefix_ReproducesTheLivePrefillLogits()
     {
         string modelPath = TryFindModel();

--- a/InferenceWeb.Tests/MuseGlimmerMlxDecodeTests.cs
+++ b/InferenceWeb.Tests/MuseGlimmerMlxDecodeTests.cs
@@ -23,7 +23,6 @@ using Xunit;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Mlx")]
 public class MuseGlimmerMlxDecodeTests
 {
     // The pipelined step computes argmax and the next embedding ON DEVICE with
@@ -89,12 +88,9 @@ public class MuseGlimmerMlxDecodeTests
     // to a direct call (MlxWorker.IsOnWorkerThread) for the ~1150 nested MLX
     // calls a 52-layer decode step issues.
 
-    [Fact]
+    [MlxFact]
     public void RunDecodeGraphBatched_RunsCallbackOnTheMlxWorkerThread()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         Assert.False(MlxFusedOps.IsBuildingBatchedGraph);
 
         int callerThread = Thread.CurrentThread.ManagedThreadId;
@@ -108,12 +104,9 @@ public class MuseGlimmerMlxDecodeTests
 
     // Nesting has to be free AND ordered: a decode layer calls straight back
     // into MlxFusedOps / MlxQuantizedOps entry points that Invoke on their own.
-    [Fact]
+    [MlxFact]
     public void RunDecodeGraphBatched_NestedInvokesRunInlineOnTheSameThread()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         var (outer, inner) = MlxFusedOps.RunDecodeGraphBatched(() =>
         {
             int outerThread = Thread.CurrentThread.ManagedThreadId;
@@ -127,12 +120,9 @@ public class MuseGlimmerMlxDecodeTests
     // A failure inside the graph build must surface at the call site rather
     // than being swallowed on the worker (which would leave the caller holding
     // a half-built step and no error).
-    [Fact]
+    [MlxFact]
     public void RunDecodeGraphBatched_PropagatesExceptions()
     {
-        if (!MlxBackend.IsAvailable())
-            return;
-
         var ex = Assert.Throws<InvalidOperationException>(
             () => MlxFusedOps.RunDecodeGraphBatched<int>(() => throw new InvalidOperationException("boom")));
         Assert.Equal("boom", ex.Message);

--- a/InferenceWeb.Tests/MuseGlimmerParityTests.cs
+++ b/InferenceWeb.Tests/MuseGlimmerParityTests.cs
@@ -32,7 +32,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class MuseGlimmerParityTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -50,7 +49,7 @@ public class MuseGlimmerParityTests
         public string Content { get; set; }
     }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "muse-glimmer")]
     public void MuseGlimmer_GreedyContinuationMatchesLlamaCpp()
     {
         var records = TryLoadReference();
@@ -105,7 +104,7 @@ public class MuseGlimmerParityTests
     /// The forward pass is compared on recorded token ids, so the tokenizer needs
     /// its own check: our BPE must reproduce llama.cpp's prompt tokenization.
     /// </summary>
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "muse-glimmer")]
     public void MuseGlimmer_TokenizerMatchesLlamaCpp()
     {
         var records = TryLoadReference();
@@ -165,7 +164,7 @@ public class MuseGlimmerParityTests
     /// runs a ~4790-token prompt against a llama.cpp golden captured the same way.
     /// Generate it with .parity/gen_ref_long.py (needs a llama-server with -c 8192).
     /// </summary>
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "muse-glimmer")]
     public void MuseGlimmer_LongContextMatchesLlamaCpp()
     {
         var records = TryLoadReference(LocateReference("ref_text_long.json"), "TS_MUSE_GLIMMER_REF_LONG");
@@ -199,7 +198,7 @@ public class MuseGlimmerParityTests
     /// prompts reproduces its baseline token-for-token at 1.33x-4.77x, so anything
     /// other than an exact match here is a bug, not sampling noise.
     /// </summary>
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "muse-glimmer")]
     public void MuseGlimmer_DFlashDraftingIsLossless()
     {
         var records = TryLoadReference();

--- a/InferenceWeb.Tests/NemotronBatchedCorrectnessTests.cs
+++ b/InferenceWeb.Tests/NemotronBatchedCorrectnessTests.cs
@@ -27,7 +27,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class NemotronBatchedCorrectnessTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -36,7 +35,7 @@ public class NemotronBatchedCorrectnessTests
     private readonly ITestOutputHelper _output;
     public NemotronBatchedCorrectnessTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "nemotron")]
     public async Task Nemotron_Greedy_LegacyAndBatchedAgree()
     {
         var modelPath = FindNemotron();

--- a/InferenceWeb.Tests/NemotronBatchedPerfBench.cs
+++ b/InferenceWeb.Tests/NemotronBatchedPerfBench.cs
@@ -27,7 +27,6 @@ using Xunit.Abstractions;
 namespace InferenceWeb.Tests;
 
 [Trait("Category", "Bench")]
-[Trait("Requires", "Models")]
 public class NemotronBatchedPerfBench
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -36,7 +35,7 @@ public class NemotronBatchedPerfBench
     private readonly ITestOutputHelper _output;
     public NemotronBatchedPerfBench(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "nemotron")]
     public Task Nemotron_BatchedVsLegacy()
         => RunScenarios(new[]
         {

--- a/InferenceWeb.Tests/Qwen35BatchedCorrectnessTests.cs
+++ b/InferenceWeb.Tests/Qwen35BatchedCorrectnessTests.cs
@@ -32,7 +32,6 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class Qwen35BatchedCorrectnessTests
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -47,7 +46,7 @@ public class Qwen35BatchedCorrectnessTests
     // accumulated enough to flip the argmax). We assert at least 4 of the
     // first 8 tokens match — relaxes for accumulating FP drift while still
     // catching structural divergence (which would diverge at token 0).
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "27b")]
     public async Task Qwen35_Greedy_LegacyAndBatchedAgree()
     {
         var modelPath = FindQwen35();

--- a/InferenceWeb.Tests/Qwen35BatchedPerfBench.cs
+++ b/InferenceWeb.Tests/Qwen35BatchedPerfBench.cs
@@ -34,7 +34,6 @@ using Xunit.Abstractions;
 namespace InferenceWeb.Tests;
 
 [Trait("Category", "Bench")]
-[Trait("Requires", "Models")]
 public class Qwen35BatchedPerfBench
 {
     private const string EnvModelDir = "TS_TEST_MODEL_DIR";
@@ -46,7 +45,7 @@ public class Qwen35BatchedPerfBench
     // Run a few text-only scenarios back-to-back inside a single model
     // load, since each Qwen3.6-27B load takes ~30s. Each scenario runs
     // legacy first, then batched, so the numbers are directly comparable.
-    [Fact]
+    [ModelFact("TS_TEST_MODEL_DIR", "27b")]
     public Task Qwen35_BatchedVsLegacy()
         => RunScenarios(new[]
         {

--- a/InferenceWeb.Tests/TestAssemblyConfig.cs
+++ b/InferenceWeb.Tests/TestAssemblyConfig.cs
@@ -12,10 +12,13 @@ using Xunit;
 // Trait taxonomy, selectable with dotnet test --filter:
 //   Category=Bench    timing/throughput assertions — a failure means the perf
 //                     regressed or the box was busy, never that code is wrong
-//   Requires=Cuda     needs a CUDA device (otherwise the tests no-op)
+//   Requires=Cuda     needs a CUDA device
 //   Requires=Mlx      needs the MLX native backend (macOS)
 //   Requires=Models   needs real GGUF weights (TS_TEST_MODEL_DIR and friends)
-// Untagged tests are self-contained correctness tests that run anywhere.
+// Requires traits come from the gated attributes in GatedFacts.cs
+// ([CudaFact], [MlxFact], [ModelFact], ...), which also skip visibly when the
+// prerequisite is missing. Untagged tests are self-contained correctness
+// tests that run anywhere.
 // Common lanes:
 //   --filter "Category!=Bench&Requires!=Models&Requires!=Cuda&Requires!=Mlx"   fast inner loop
 //   --filter "Category!=Bench"                                                 full correctness

--- a/InferenceWeb.Tests/VisionEncoderCudaTests.cs
+++ b/InferenceWeb.Tests/VisionEncoderCudaTests.cs
@@ -10,7 +10,6 @@ namespace InferenceWeb.Tests;
 /// defects these guard against were all silent: the encoder produced plausible
 /// but wrong embeddings rather than throwing.
 /// </summary>
-[Trait("Requires", "Cuda")]
 public class VisionEncoderCudaTests
 {
     // Ops.Add(x[rows, cols], bias[cols]) is how every linear layer in the vision
@@ -18,16 +17,13 @@ public class VisionEncoderCudaTests
     // shapes, so this used to fall through to the CUDA CPU fallback, whose
     // Apply3 advances all three iterators together and stops at the shortest
     // operand's last block — biasing row 0 and leaving every other row untouched.
-    [Theory]
+    [CudaTheory]
     [InlineData(1, 8)]
     [InlineData(7, 3)]
     [InlineData(64, 1152)]
     [InlineData(257, 4304)]
     public void CudaAdd_RowBroadcastBias_AppliesToEveryRow(int rows, int cols)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         float[] baseValues = MakePattern(rows * cols, 0.7f, 0.1f);
         float[] biasValues = MakePattern(cols, 1.3f, -0.4f);
@@ -52,7 +48,7 @@ public class VisionEncoderCudaTests
     // vision projector standardises its pooled patches with Sub-then-Mul against
     // a [cols] vector, so on this backend exactly one of 130 patches was being
     // standardised and the model hallucinated the image contents.
-    [Theory]
+    [CudaTheory]
     [InlineData("sub", 130, 1152)]
     [InlineData("mul", 130, 1152)]
     [InlineData("div", 33, 129)]
@@ -60,9 +56,6 @@ public class VisionEncoderCudaTests
     [InlineData("mul", 7, 3)]
     public void CudaBinary_RowBroadcast_AppliesToEveryRow(string op, int rows, int cols)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         float[] baseValues = MakePattern(rows * cols, 0.7f, 0.1f);
         // Offset away from zero so the division case stays well conditioned.
@@ -122,12 +115,9 @@ public class VisionEncoderCudaTests
 
     // A same-shape add must keep using the elementwise kernel; the broadcast
     // detection above must not capture it.
-    [Fact]
+    [CudaFact]
     public void CudaAdd_SameShape_StillElementwise()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         const int rows = 5, cols = 9;
         float[] a = MakePattern(rows * cols, 0.9f, 0.2f);
@@ -149,12 +139,9 @@ public class VisionEncoderCudaTests
     }
 
     // A [cols]-sized 2D tensor is a single row, not a broadcast source.
-    [Fact]
+    [CudaFact]
     public void CudaAdd_SingleRowSameShape_IsNotTreatedAsBroadcast()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         using var a = new Tensor(allocator, DType.Float32, 1, 6);
         a.SetElementsAsFloat(new[] { 1f, 2f, 3f, 4f, 5f, 6f });
@@ -167,16 +154,13 @@ public class VisionEncoderCudaTests
         AssertClose(new[] { 11f, 22f, 33f, 44f, 55f, 66f }, result.GetElementsAsFloat(6));
     }
 
-    [Theory]
+    [CudaTheory]
     [InlineData(4, 16, true)]
     [InlineData(64, 1152, true)]
     [InlineData(31, 1153, true)]
     [InlineData(8, 512, false)]
     public void CudaLayerNorm_MatchesHostReference(int rows, int cols, bool withBias)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         const float eps = 1e-6f;
         float[] input = MakePattern(rows * cols, 2.5f, 0.3f);
@@ -228,7 +212,7 @@ public class VisionEncoderCudaTests
     // The bidirectional flash-shaped kernel used for vision attention. Checked
     // against a direct softmax(QK^T/sqrt(d))V reference, including the
     // seq % 128 != 0 tail and a sequence long enough to span many K tiles.
-    [Theory]
+    [CudaTheory]
     [InlineData(1, 1, 72)]
     [InlineData(37, 2, 72)]
     [InlineData(128, 4, 64)]
@@ -236,9 +220,6 @@ public class VisionEncoderCudaTests
     [InlineData(521, 16, 72)]
     public void CudaVisionAttention_MatchesHostReference(int seq, int heads, int headDim)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         using var allocator = new CudaAllocator();
         int count = seq * heads * headDim;
         float[] q = MakePattern(count, 0.8f, 0.05f);
@@ -262,12 +243,9 @@ public class VisionEncoderCudaTests
 
     // The kernel and the generic SDPA path must agree; the encoder falls back to
     // SDPA for head dims without a specialized instantiation.
-    [Fact]
+    [CudaFact]
     public void CudaVisionAttention_MatchesScaledDotProductAttention()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int seq = 200, heads = 4, headDim = 72;
         using var allocator = new CudaAllocator();
         int count = seq * heads * headDim;
@@ -297,14 +275,11 @@ public class VisionEncoderCudaTests
     // Vision RoPE: NeoX rotation over [seq, heads, headDim] with per-position
     // cos/sin tables. Guards the layout the encoder relies on (tables indexed by
     // position, shared across heads; the rotated pair is (d, d + half)).
-    [Theory]
+    [CudaTheory]
     [InlineData(5, 3, 72)]
     [InlineData(256, 16, 72)]
     public void CudaNeoxRopeFlat_MatchesHostReference(int seq, int heads, int headDim)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         int half = headDim / 2;
         using var allocator = new CudaAllocator();
         int count = seq * heads * headDim;

--- a/InferenceWeb.Tests/WanDirectOpsTests.cs
+++ b/InferenceWeb.Tests/WanDirectOpsTests.cs
@@ -132,15 +132,11 @@ public class WanDirectOpsTests
     // kernel without an additive mask: a non-aligned KV length and a
     // non-aligned bidirectional self-attention length. Wan's DiT attention is
     // unmasked, and neither length is a multiple of its 32/256-wide tiling.
-    [Trait("Requires", "Cuda")]
-    [Theory]
+    [CudaTheory]
     [InlineData(37, 257)]
     [InlineData(513, 513)]
     public void CudaWanAttention_UnmaskedNonAlignedLengths_MatchesNaive(int sq, int sk)
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int heads = 1, hd = 64;
         float[] q = Rand(sq * heads * hd, 14);
         float[] k = Rand(sk * heads * hd, 15);
@@ -224,11 +220,12 @@ public class WanDirectOpsTests
     // Manual perf probe (TS_WAN_ATTN_BENCH=1): raw streaming-attention kernel
     // throughput at the 832x480x33f DiT shape, printed as GFLOPS.
     [Trait("Category", "Bench")]
-    [Trait("Requires", "Cuda")]
-    [Fact]
+    [CudaFact]
     public void WanAttentionThroughput()
     {
-        if (Environment.GetEnvironmentVariable("TS_WAN_ATTN_BENCH") != "1" || !CudaBackend.IsAvailable())
+        // CudaFact covers availability; TS_WAN_ATTN_BENCH stays an opt-in gate
+        // so this benchmark never runs in the normal suite.
+        if (Environment.GetEnvironmentVariable("TS_WAN_ATTN_BENCH") != "1")
             return;
         const int seq = 14040, heads = 12, hd = 128;
         using var alloc = new CudaAllocator();
@@ -252,13 +249,9 @@ public class WanDirectOpsTests
         ctx.Dispose();
     }
 
-    [Trait("Requires", "Cuda")]
-    [Fact]
+    [CudaFact]
     public void CudaWanKernels_MatchCpu()
     {
-        if (!CudaBackend.IsAvailable())
-            return;
-
         const int heads = 2, hd = 128, sq = 300, sk = 70;
         var cpuAlloc = new CpuAllocator(BlasEnum.DotNet);
         using var cudaAlloc = new CudaAllocator();

--- a/InferenceWeb.Tests/WanDitBackendParityTests.cs
+++ b/InferenceWeb.Tests/WanDitBackendParityTests.cs
@@ -32,13 +32,12 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class WanDitBackendParityTests
 {
     private readonly ITestOutputHelper _output;
     public WanDitBackendParityTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [ModelFact("TS_WAN_PARITY_MODEL")]
     public void DumpDitForwardForBackendParity()
     {
         string model = Environment.GetEnvironmentVariable("TS_WAN_PARITY_MODEL");

--- a/InferenceWeb.Tests/WanVaeBackendParityTests.cs
+++ b/InferenceWeb.Tests/WanVaeBackendParityTests.cs
@@ -33,13 +33,12 @@ using Xunit.Abstractions;
 
 namespace InferenceWeb.Tests;
 
-[Trait("Requires", "Models")]
 public class WanVaeBackendParityTests
 {
     private readonly ITestOutputHelper _output;
     public WanVaeBackendParityTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    [ModelFact("TS_WAN_VAE_PARITY_VAE")]
     public void DumpVaeDecodeForBackendParity()
     {
         string vaePath = Environment.GetEnvironmentVariable("TS_WAN_VAE_PARITY_VAE");


### PR DESCRIPTION
Follow-up to #156 / #153. The traits work left one problem in place, called out in the issue: a test whose prerequisite is missing (no CUDA device, no MLX backend, no GGUF weights) early-returns and counts as **Passed**, so `dotnet test` on a bare machine reads "all green" while a third of the suite never executed.

This PR makes those tests report as **Skipped**:

- `InferenceWeb.Tests/GatedFacts.cs` adds `[CudaFact]`/`[CudaTheory]`, `[MlxFact]`/`[MlxTheory]`, and `[ModelFact("ENV_VAR", "gguf-substring")]`/`[ModelTheory(...)]`. Each sets `Skip` with a reason at discovery when its prerequisite is missing, and applies the matching `Requires` trait automatically through a trait discoverer — so the lane filters from #156 work exactly as before, and gated tests no longer need a separate `[Trait]` line. Plain xunit v2, no custom runners or test-case discoverers.
- 31 of the 39 gated files are migrated: the attribute replaces the class-level `Requires` trait and the in-body `if (!...IsAvailable()) return;` / "env not set; skipping" blocks (net −322 lines). Loader helpers are untouched; their null-checks remain as a backstop for load errors.
- 7 files keep explicit traits and in-body gating because their prerequisite doesn't reduce to one probe (multi-env opt-ins like `TS_GMTP_*`, per-method model selection in `ParallelThroughputBench`, hardcoded fixture paths in `SafetensorsReaderTests`). They behave exactly as before.
- To keep the silent idiom from coming back, `Microsoft.CodeAnalysis.BannedApiAnalyzers` bans `CudaBackend.IsAvailable()`/`MlxBackend.IsAvailable()` in test code (RS0030 as error, message points at the attributes). The probe cache in `GatedFacts.cs` and the two probe-under-test methods in `MlxBackendTests` are pragma-exempted.
- Lane docs updated in `DEVELOPMENT.md` and `DEVELOPMENT_zh-cn.md`.

Behavior change to be aware of: on a machine missing prerequisites, a green run now reads e.g. "1195 passed, 190 skipped" instead of "1385 passed". Also, a skipped `[Theory]` reports once rather than once per data row, so skip counts are per-method; on a machine that has the hardware, row-level counts are unchanged.

Verified locally (Linux, AMD GPU — no CUDA, no MLX, no test weights): inner-loop lane 1158 passed / 0 skipped in 8s, identical selection to before; `Category!=Bench` 1195 passed / 190 skipped / 0 failed; the RS0030 ban confirmed to fail the build on a direct probe call. The #156 PR CI lane is unaffected (it filters these tests out either way).
