### PR TITLE
Keep a serving model when a runtime reload fails

### DIFF
--- a/InferenceWeb.Tests/ModelReloadRollbackTests.cs
+++ b/InferenceWeb.Tests/ModelReloadRollbackTests.cs
@@ -1,0 +1,253 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging.Abstractions;
+using TensorSharp;
+
+namespace InferenceWeb.Tests;
+
+/// <summary>
+/// A runtime model reload that fails must not leave the server modelless: bad
+/// files are rejected before the current model is unloaded, and a failure
+/// during the load itself restores the previous model.
+/// </summary>
+public class ModelReloadRollbackTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ModelReloadRollbackTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"ts-reload-rollback-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_dir, recursive: true);
+    }
+
+    [Fact]
+    public void MissingFile_IsRejectedWithCurrentModelStillLoaded()
+    {
+        var factory = new ScriptedFactory();
+        var svc = NewService(factory);
+        string pathA = WriteMinimalGguf("model-a.gguf");
+        factory.Enqueue(p => new FakeModel(p));
+        svc.LoadModel(pathA, null, "cpu");
+        var modelA = (FakeModel)svc.Model;
+
+        Assert.Throws<FileNotFoundException>(
+            () => svc.LoadModel(Path.Combine(_dir, "missing.gguf"), null, "cpu"));
+
+        Assert.True(svc.IsLoaded);
+        Assert.Same(modelA, svc.Model);
+        Assert.False(modelA.Disposed);
+        Assert.Single(factory.Calls);
+    }
+
+    [Fact]
+    public void NonGgufFile_IsRejectedWithCurrentModelStillLoaded()
+    {
+        var factory = new ScriptedFactory();
+        var svc = NewService(factory);
+        string pathA = WriteMinimalGguf("model-a.gguf");
+        factory.Enqueue(p => new FakeModel(p));
+        svc.LoadModel(pathA, null, "cpu");
+        var modelA = (FakeModel)svc.Model;
+
+        string junk = Path.Combine(_dir, "junk.gguf");
+        File.WriteAllText(junk, "not a gguf file at all");
+        Assert.Throws<InvalidDataException>(() => svc.LoadModel(junk, null, "cpu"));
+
+        Assert.Same(modelA, svc.Model);
+        Assert.False(modelA.Disposed);
+        Assert.Single(factory.Calls);
+    }
+
+    [Fact]
+    public void TruncatedGguf_IsRejectedWithCurrentModelStillLoaded()
+    {
+        var factory = new ScriptedFactory();
+        var svc = NewService(factory);
+        string pathA = WriteMinimalGguf("model-a.gguf");
+        factory.Enqueue(p => new FakeModel(p));
+        svc.LoadModel(pathA, null, "cpu");
+        var modelA = (FakeModel)svc.Model;
+
+        string truncated = WriteTruncatedGguf("truncated.gguf");
+        Assert.Throws<IOException>(() => svc.LoadModel(truncated, null, "cpu"));
+
+        Assert.Same(modelA, svc.Model);
+        Assert.False(modelA.Disposed);
+        Assert.Single(factory.Calls);
+    }
+
+    [Fact]
+    public void TruncatedMmProj_IsRejectedWithCurrentModelStillLoaded()
+    {
+        var factory = new ScriptedFactory();
+        var svc = NewService(factory);
+        string pathA = WriteMinimalGguf("model-a.gguf");
+        factory.Enqueue(p => new FakeModel(p));
+        svc.LoadModel(pathA, null, "cpu");
+        var modelA = (FakeModel)svc.Model;
+
+        string pathB = WriteMinimalGguf("model-b.gguf");
+        string badMmProj = WriteTruncatedGguf("mmproj-bad.gguf");
+        Assert.Throws<IOException>(() => svc.LoadModel(pathB, badMmProj, "cpu"));
+
+        Assert.Same(modelA, svc.Model);
+        Assert.False(modelA.Disposed);
+        Assert.Single(factory.Calls);
+    }
+
+    [Fact]
+    public void FailedLoad_RestoresPreviousModel()
+    {
+        var factory = new ScriptedFactory();
+        var svc = NewService(factory);
+        string pathA = WriteMinimalGguf("model-a.gguf");
+        string pathB = WriteMinimalGguf("model-b.gguf");
+        factory.Enqueue(p => new FakeModel(p));
+        svc.LoadModel(pathA, null, "cpu");
+        var firstModelA = (FakeModel)svc.Model;
+
+        factory.Enqueue(_ => throw new InvalidOperationException("backend init failed"));
+        factory.Enqueue(p => new FakeModel(p));
+        var thrown = Assert.Throws<InvalidOperationException>(() => svc.LoadModel(pathB, null, "cpu"));
+        Assert.Equal("backend init failed", thrown.Message);
+
+        Assert.True(svc.IsLoaded);
+        Assert.Equal("model-a.gguf", svc.LoadedModelName);
+        Assert.True(firstModelA.Disposed);
+        Assert.NotSame(firstModelA, svc.Model);
+        Assert.Equal(3, factory.Calls.Count);
+        Assert.Equal((pathA, BackendType.Cpu), factory.Calls[2]);
+    }
+
+    [Fact]
+    public void FailedLoadAndFailedRollback_LeavesNoModel()
+    {
+        var factory = new ScriptedFactory();
+        var svc = NewService(factory);
+        string pathA = WriteMinimalGguf("model-a.gguf");
+        string pathB = WriteMinimalGguf("model-b.gguf");
+        factory.Enqueue(p => new FakeModel(p));
+        svc.LoadModel(pathA, null, "cpu");
+
+        factory.Enqueue(_ => throw new InvalidOperationException("load failed"));
+        factory.Enqueue(_ => throw new OutOfMemoryException("rollback failed"));
+        var thrown = Assert.Throws<InvalidOperationException>(() => svc.LoadModel(pathB, null, "cpu"));
+        Assert.Equal("load failed", thrown.Message);
+
+        Assert.False(svc.IsLoaded);
+        Assert.Null(svc.Model);
+        Assert.Null(svc.LoadedModelName);
+        Assert.Equal(3, factory.Calls.Count);
+    }
+
+    [Fact]
+    public void FailedFirstLoad_DoesNotAttemptRollback()
+    {
+        var factory = new ScriptedFactory();
+        var svc = NewService(factory);
+        string pathA = WriteMinimalGguf("model-a.gguf");
+
+        factory.Enqueue(_ => throw new InvalidOperationException("load failed"));
+        Assert.Throws<InvalidOperationException>(() => svc.LoadModel(pathA, null, "cpu"));
+
+        Assert.False(svc.IsLoaded);
+        Assert.Single(factory.Calls);
+    }
+
+    [Fact]
+    public void SuccessfulReload_SwapsAndDisposesPreviousModel()
+    {
+        var factory = new ScriptedFactory();
+        var svc = NewService(factory);
+        string pathA = WriteMinimalGguf("model-a.gguf");
+        string pathB = WriteMinimalGguf("model-b.gguf");
+        factory.Enqueue(p => new FakeModel(p));
+        svc.LoadModel(pathA, null, "cpu");
+        var modelA = (FakeModel)svc.Model;
+
+        factory.Enqueue(p => new FakeModel(p));
+        svc.LoadModel(pathB, null, "cpu");
+
+        Assert.True(modelA.Disposed);
+        Assert.Equal("model-b.gguf", svc.LoadedModelName);
+        Assert.Equal(2, factory.Calls.Count);
+    }
+
+    private static ModelLifecycleService NewService(ScriptedFactory factory)
+    {
+        return new ModelLifecycleService(NullLogger.Instance, factory.Create);
+    }
+
+    private string WriteMinimalGguf(string name)
+    {
+        // Smallest file GgufFile accepts: header with zero tensors and zero
+        // metadata entries, padded out to the 32-byte data alignment.
+        string path = Path.Combine(_dir, name);
+        using var bw = new BinaryWriter(File.Create(path));
+        bw.Write(0x46554747u); // "GGUF"
+        bw.Write(3u);          // version
+        bw.Write(0UL);         // tensor count
+        bw.Write(0UL);         // metadata count
+        bw.Write(new byte[8]);
+        return path;
+    }
+
+    private string WriteTruncatedGguf(string name)
+    {
+        // The tensor table declares one F32 tensor of 1024 elements but the
+        // file ends right after the header, so ThrowIfTruncated fires.
+        string path = Path.Combine(_dir, name);
+        using var bw = new BinaryWriter(File.Create(path));
+        bw.Write(0x46554747u); // "GGUF"
+        bw.Write(3u);          // version
+        bw.Write(1UL);         // tensor count
+        bw.Write(0UL);         // metadata count
+        bw.Write(1UL);         // tensor name length
+        bw.Write((byte)'t');
+        bw.Write(1u);          // dims
+        bw.Write(1024UL);      // shape[0]
+        bw.Write(0u);          // GgmlTensorType.F32
+        bw.Write(0UL);         // data offset
+        return path;
+    }
+
+    private sealed class ScriptedFactory
+    {
+        public readonly List<(string Path, BackendType Backend)> Calls = new();
+        private readonly Queue<Func<string, ModelBase>> _steps = new();
+
+        public void Enqueue(Func<string, ModelBase> step) => _steps.Enqueue(step);
+
+        public ModelBase Create(string path, BackendType backend, ITensorParallelGroup tpGroup, string draftPath)
+        {
+            Calls.Add((path, backend));
+            return _steps.Dequeue()(path);
+        }
+    }
+
+    private sealed class FakeModel : ModelBase
+    {
+        public bool Disposed;
+
+        public FakeModel(string ggufPath)
+            : base(ggufPath, BackendType.Cpu)
+        {
+        }
+
+        protected override float[] ForwardCore(int[] tokens) => Array.Empty<float>();
+
+        protected override void ResetKVCacheCore()
+        {
+        }
+
+        public override void Dispose()
+        {
+            Disposed = true;
+            base.Dispose();
+        }
+    }
+}

--- a/TensorSharp.Server/ModelLifecycleService.cs
+++ b/TensorSharp.Server/ModelLifecycleService.cs
@@ -18,6 +18,7 @@ namespace TensorSharp.Server
     internal sealed class ModelLifecycleService : IDisposable
     {
         private readonly ILogger _logger;
+        private readonly Func<string, BackendType, ITensorParallelGroup, string, ModelBase> _createModel;
 
         private ModelBase _model;
         private string _loadedModelPath;
@@ -25,8 +26,17 @@ namespace TensorSharp.Server
         private BackendType _backend;
 
         public ModelLifecycleService(ILogger logger)
+            : this(logger, static (path, backend, tpGroup, draftPath) =>
+                ModelBase.Create(path, backend, tpGroup: tpGroup, draftModelPath: draftPath))
+        {
+        }
+
+        /// <summary>Test seam: <paramref name="createModel"/> stands in for
+        /// <see cref="ModelBase.Create(string, BackendType, int, ITensorParallelGroup, string)"/>.</summary>
+        internal ModelLifecycleService(ILogger logger, Func<string, BackendType, ITensorParallelGroup, string, ModelBase> createModel)
         {
             _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+            _createModel = createModel;
         }
 
         public bool IsLoaded => _model != null;
@@ -66,6 +76,73 @@ namespace TensorSharp.Server
                 Path.GetFileName(modelPath), Path.GetFileName(mmProjPath ?? string.Empty),
                 backendStr ?? "(default)", modelPath, mmProjPath ?? "(none)");
 
+            try
+            {
+                ValidateModelFiles(modelPath, mmProjPath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(LogEventIds.ModelLoadFailed, ex,
+                    "Rejected model load {ModelFile}: file validation failed; current model {CurrentModel} stays loaded",
+                    Path.GetFileName(modelPath), LoadedModelName ?? "(none)");
+                throw;
+            }
+
+            string previousModelPath = _loadedModelPath;
+            string previousMmProjPath = _loadedMmProjPath;
+            string previousBackendValue = LoadedBackend;
+
+            UnloadCurrentModel();
+
+            try
+            {
+                LoadModelCore(modelPath, mmProjPath, backendStr);
+            }
+            catch
+            {
+                // Best-effort rollback so a failed reload doesn't leave the
+                // server with no model. The original exception still reaches
+                // the caller; the rollback outcome is only logged.
+                if (previousModelPath != null)
+                {
+                    try
+                    {
+                        LoadModelCore(previousModelPath, previousMmProjPath, previousBackendValue);
+                        _logger.LogWarning("Restored previous model {PreviousModel} after failed load of {ModelFile}",
+                            Path.GetFileName(previousModelPath), Path.GetFileName(modelPath));
+                    }
+                    catch (Exception rollbackEx)
+                    {
+                        _logger.LogError(LogEventIds.ModelLoadFailed, rollbackEx,
+                            "Could not restore previous model {PreviousModel} after failed load of {ModelFile}; no model is loaded",
+                            Path.GetFileName(previousModelPath), Path.GetFileName(modelPath));
+                    }
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Header-only validation of the files a load is about to commit to,
+        /// run BEFORE the current model is disposed: a missing, non-GGUF, or
+        /// truncated file is rejected while there is still a working model.
+        /// </summary>
+        private static void ValidateModelFiles(string modelPath, string mmProjPath)
+        {
+            using (var gguf = new GgufFile(modelPath))
+                gguf.ThrowIfTruncated();
+
+            // A missing projector file is skipped by the load itself, but one
+            // that exists must parse.
+            if (!string.IsNullOrEmpty(mmProjPath) && File.Exists(mmProjPath))
+            {
+                using var mmProj = new GgufFile(mmProjPath);
+                mmProj.ThrowIfTruncated();
+            }
+        }
+
+        private void UnloadCurrentModel()
+        {
             string previousModel = LoadedModelName;
             _model?.Dispose();
             _model = null;
@@ -78,7 +155,10 @@ namespace TensorSharp.Server
                 _logger.LogInformation(LogEventIds.ModelUnloaded,
                     "Unloaded previous model {PreviousModel}", previousModel);
             }
+        }
 
+        private void LoadModelCore(string modelPath, string mmProjPath, string backendStr)
+        {
             _backend = ResolveBackend(backendStr);
 
             var loadSw = Stopwatch.StartNew();
@@ -107,7 +187,7 @@ namespace TensorSharp.Server
                 // drafter's weights have to be counted by the layer split and
                 // uploaded with the trunk.
                 string blockDraftPath = Environment.GetEnvironmentVariable("TS_DSV4_DSPARK");
-                _model = ModelBase.Create(modelPath, _backend, tpGroup: tpGroup, draftModelPath: blockDraftPath);
+                _model = _createModel(modelPath, _backend, tpGroup, blockDraftPath);
 
                 // Say so when a drafter was named but the loaded model has no
                 // block-draft head to put it in, instead of leaving the operator
@@ -147,7 +227,7 @@ namespace TensorSharp.Server
                 // (gemma4-assistant). Load it onto the target so HasMtp turns on
                 // and --mtp-spec engages. (Qwen3.6 embeds its NextN block in the
                 // trunk and needs no separate file.) MtpDraftActivationError was
-                // already cleared above before the model was (re)created.
+                // cleared when the previous model was unloaded.
                 string mtpDraftPath = Environment.GetEnvironmentVariable("TS_MTP_DRAFT_MODEL");
                 if (!string.IsNullOrEmpty(mtpDraftPath))
                 {
@@ -210,6 +290,13 @@ namespace TensorSharp.Server
                 _logger.LogError(LogEventIds.ModelLoadFailed, ex,
                     "Failed to load model {ModelFile} on backend {Backend} after {ElapsedMs:F1} ms",
                     Path.GetFileName(modelPath), backendStr ?? "(default)", loadSw.Elapsed.TotalMilliseconds);
+                // Drop any partially initialized model so the service holds
+                // either a fully loaded model or none at all.
+                _model?.Dispose();
+                _model = null;
+                _loadedModelPath = null;
+                _loadedMmProjPath = null;
+                MtpDraftActivationError = null;
                 throw;
             }
         }


### PR DESCRIPTION
`ModelLifecycleService.LoadModel` disposes the current model before loading the new one (required — two models generally don't fit in memory), so any load failure — deleted or truncated GGUF, backend init error, OOM — left the server with **no model at all**: every request failed until a process restart.

Two guards around the existing ordering:

- **Pre-flight:** before the current model is touched, the target GGUF (and projector, when present) is opened header-only and checked with `ThrowIfTruncated`. A missing, non-GGUF, or truncated file — the realistic failure modes, e.g. an interrupted re-download — is rejected while the old model keeps serving, with the reader's diagnostic instead of a mid-load short-read error.
- **Rollback:** if the load fails past pre-flight, the previous model/projector/backend triple is reloaded best-effort. The original exception still reaches the caller; the rollback outcome is logged.

`ModelReloadRollbackTests` covers pre-flight rejection, rollback success, and rollback failure. Verified locally: environment-independent lane 1149 passed / 0 failed on current main.
