### PR TITLE
Reference uploads by server filename instead of absolute host path

### DIFF
--- a/InferenceWeb.Tests/ChatAttachmentPathGuardTests.cs
+++ b/InferenceWeb.Tests/ChatAttachmentPathGuardTests.cs
@@ -4,11 +4,12 @@ using TensorSharp.Server.RequestParsers;
 namespace InferenceWeb.Tests;
 
 /// <summary>
-/// Web UI /api/chat attachment paths (imagePaths/audioPaths/textFilePaths)
-/// arrive as client-supplied absolute paths that the multimodal injector later
-/// opens, so every one must resolve inside the upload directory. These check
-/// that paths outside it — including a sibling directory that shares the root's
-/// name — are rejected.
+/// Web UI /api/chat attachment references (imagePaths/audioPaths/textFilePaths)
+/// are resolved by <see cref="ChatMessageParser.ResolveAttachmentPaths"/>: the
+/// canonical form is the bare server filename from /api/upload, while legacy
+/// absolute paths are accepted only when they resolve inside the upload
+/// directory. These check both forms, and that paths outside the root —
+/// including a sibling directory sharing the root's name — are rejected.
 /// </summary>
 public class ChatAttachmentPathGuardTests : IDisposable
 {
@@ -31,10 +32,22 @@ public class ChatAttachmentPathGuardTests : IDisposable
         new() { new ChatMessage { Role = "user", Content = "hi", ImagePaths = new List<string> { path } } };
 
     [Fact]
+    public void BareFileName_ResolvesUnderUploadRoot()
+    {
+        var messages = MessageWithImage("img.png");
+
+        Assert.Null(ChatMessageParser.ResolveAttachmentPaths(messages, _uploadRoot));
+        Assert.Equal(Path.Combine(Path.GetFullPath(_uploadRoot), "img.png"), messages[0].ImagePaths[0]);
+    }
+
+    [Fact]
     public void PathInsideUploadRoot_IsAccepted()
     {
         string inside = Path.Combine(_uploadRoot, "img.png");
-        Assert.Null(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage(inside), _uploadRoot));
+        var messages = MessageWithImage(inside);
+
+        Assert.Null(ChatMessageParser.ResolveAttachmentPaths(messages, _uploadRoot));
+        Assert.Equal(Path.GetFullPath(inside), messages[0].ImagePaths[0]);
     }
 
     [Fact]
@@ -43,14 +56,21 @@ public class ChatAttachmentPathGuardTests : IDisposable
         string secret = Path.Combine(_baseDir, "secret.png");
         File.WriteAllText(secret, "top secret");
 
-        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage(secret), _uploadRoot));
+        Assert.NotNull(ChatMessageParser.ResolveAttachmentPaths(MessageWithImage(secret), _uploadRoot));
     }
 
     [Fact]
     public void TraversalOutOfUploadRoot_IsRejected()
     {
         string traversal = Path.Combine(_uploadRoot, "..", "secret.png");
-        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage(traversal), _uploadRoot));
+        Assert.NotNull(ChatMessageParser.ResolveAttachmentPaths(MessageWithImage(traversal), _uploadRoot));
+    }
+
+    [Fact]
+    public void DotDotFileName_IsRejected()
+    {
+        Assert.NotNull(ChatMessageParser.ResolveAttachmentPaths(MessageWithImage(".."), _uploadRoot));
+        Assert.NotNull(ChatMessageParser.ResolveAttachmentPaths(MessageWithImage("."), _uploadRoot));
     }
 
     [Fact]
@@ -60,11 +80,11 @@ public class ChatAttachmentPathGuardTests : IDisposable
         Directory.CreateDirectory(sibling);
         string path = Path.Combine(sibling, "img.png");
 
-        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage(path), _uploadRoot));
+        Assert.NotNull(ChatMessageParser.ResolveAttachmentPaths(MessageWithImage(path), _uploadRoot));
     }
 
     [Fact]
-    public void AudioAndTextFilePaths_AreValidatedToo()
+    public void AudioAndTextFileReferences_AreResolvedToo()
     {
         string outside = Path.Combine(_baseDir, "outside.wav");
         var audio = new List<ChatMessage>
@@ -73,25 +93,26 @@ public class ChatAttachmentPathGuardTests : IDisposable
         };
         var text = new List<ChatMessage>
         {
-            new ChatMessage { Role = "user", Content = "hi", TextFilePaths = new List<string> { outside } }
+            new ChatMessage { Role = "user", Content = "hi", TextFilePaths = new List<string> { "doc.txt" } }
         };
 
-        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(audio, _uploadRoot));
-        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(text, _uploadRoot));
+        Assert.NotNull(ChatMessageParser.ResolveAttachmentPaths(audio, _uploadRoot));
+        Assert.Null(ChatMessageParser.ResolveAttachmentPaths(text, _uploadRoot));
+        Assert.Equal(Path.Combine(Path.GetFullPath(_uploadRoot), "doc.txt"), text[0].TextFilePaths[0]);
     }
 
     [Fact]
     public void NullOrEmptyPathEntry_IsRejected()
     {
-        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage(null), _uploadRoot));
-        Assert.NotNull(ChatMessageParser.ValidateAttachmentPaths(MessageWithImage("  "), _uploadRoot));
+        Assert.NotNull(ChatMessageParser.ResolveAttachmentPaths(MessageWithImage(null), _uploadRoot));
+        Assert.NotNull(ChatMessageParser.ResolveAttachmentPaths(MessageWithImage("  "), _uploadRoot));
     }
 
     [Fact]
     public void MessagesWithoutAttachments_AreAccepted()
     {
         var plain = new List<ChatMessage> { new ChatMessage { Role = "user", Content = "hi" } };
-        Assert.Null(ChatMessageParser.ValidateAttachmentPaths(plain, _uploadRoot));
-        Assert.Null(ChatMessageParser.ValidateAttachmentPaths(null, _uploadRoot));
+        Assert.Null(ChatMessageParser.ResolveAttachmentPaths(plain, _uploadRoot));
+        Assert.Null(ChatMessageParser.ResolveAttachmentPaths(null, _uploadRoot));
     }
 }

--- a/InferenceWeb.Tests/UploadFileReferenceTests.cs
+++ b/InferenceWeb.Tests/UploadFileReferenceTests.cs
@@ -1,0 +1,82 @@
+using TensorSharp.Server.RequestParsers;
+
+namespace InferenceWeb.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="UploadFileReference.TryResolve"/> — the shared
+/// resolver behind chat attachments, image-edit imagePath(s), and the Wan
+/// image-to-video conditioning image.
+/// </summary>
+public class UploadFileReferenceTests : IDisposable
+{
+    private readonly string _baseDir;
+    private readonly string _uploadRoot;
+
+    public UploadFileReferenceTests()
+    {
+        _baseDir = Path.Combine(Path.GetTempPath(), "ts-upload-ref-tests-" + Guid.NewGuid().ToString("N"));
+        _uploadRoot = Path.Combine(_baseDir, "uploads");
+        Directory.CreateDirectory(_uploadRoot);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void BareFileName_ResolvesUnderRoot()
+    {
+        Assert.True(UploadFileReference.TryResolve(_uploadRoot, "a1b2.png", out string full));
+        Assert.Equal(Path.Combine(Path.GetFullPath(_uploadRoot), "a1b2.png"), full);
+    }
+
+    [Fact]
+    public void AbsolutePathInsideRoot_IsAccepted()
+    {
+        string inside = Path.Combine(_uploadRoot, "a1b2.png");
+        Assert.True(UploadFileReference.TryResolve(_uploadRoot, inside, out string full));
+        Assert.Equal(Path.GetFullPath(inside), full);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(".")]
+    [InlineData("..")]
+    public void EmptyOrDotReferences_AreRejected(string reference)
+    {
+        Assert.False(UploadFileReference.TryResolve(_uploadRoot, reference, out _));
+    }
+
+    [Fact]
+    public void RelativeTraversal_IsRejected()
+    {
+        Assert.False(UploadFileReference.TryResolve(_uploadRoot, Path.Combine("..", "secret.png"), out _));
+        Assert.False(UploadFileReference.TryResolve(_uploadRoot, Path.Combine(_uploadRoot, "..", "secret.png"), out _));
+    }
+
+    [Fact]
+    public void AbsolutePathOutsideRoot_IsRejected()
+    {
+        Assert.False(UploadFileReference.TryResolve(_uploadRoot, Path.Combine(_baseDir, "secret.png"), out _));
+    }
+
+    [Fact]
+    public void SiblingDirectorySharingPrefix_IsRejected()
+    {
+        string sibling = Path.Combine(_baseDir, "uploads-evil");
+        Directory.CreateDirectory(sibling);
+        Assert.False(UploadFileReference.TryResolve(_uploadRoot, Path.Combine(sibling, "img.png"), out _));
+    }
+
+    [Fact]
+    public void NameWithSeparator_IsTreatedAsPathNotFileName()
+    {
+        // "sub/x.png" is not a bare filename; it resolves against the current
+        // directory, which is outside the temp upload root, so it is rejected
+        // rather than silently joined under the root.
+        Assert.False(UploadFileReference.TryResolve(_uploadRoot, "sub/x.png", out _));
+    }
+}

--- a/InferenceWeb.Tests/WanVideoParamsParserTests.cs
+++ b/InferenceWeb.Tests/WanVideoParamsParserTests.cs
@@ -85,6 +85,33 @@ public class WanVideoParamsParserTests : IDisposable
         Assert.Equal(0, parsed.Fps);
     }
 
+    [Fact]
+    public void Parse_ImagePathAsBareFileName_ResolvesUnderUploadDirectory()
+    {
+        var options = BuildOptions(81, 16);
+        File.WriteAllBytes(Path.Combine(options.UploadDirectory, "cond.png"), new byte[] { 1, 2, 3 });
+        using var doc = JsonDocument.Parse("""{"imagePath":"cond.png"}""");
+
+        var parsed = WanVideoParamsParser.Parse(doc.RootElement, options, out string error);
+
+        Assert.Null(error);
+        Assert.Equal(new byte[] { 1, 2, 3 }, parsed.ImageBytes);
+    }
+
+    [Fact]
+    public void Parse_ImagePathOutsideUploadDirectory_IsRejected()
+    {
+        var options = BuildOptions(81, 16);
+        string outside = Path.Combine(_baseDir, "outside.png");
+        File.WriteAllBytes(outside, new byte[] { 1 });
+        using var doc = JsonDocument.Parse($$"""{"imagePath":{{JsonSerializer.Serialize(outside)}}}""");
+
+        var parsed = WanVideoParamsParser.Parse(doc.RootElement, options, out string error);
+
+        Assert.NotNull(error);
+        Assert.Null(parsed.ImageBytes);
+    }
+
     private ServerHostingOptions BuildOptions(int frames, int fps)
     {
         return ServerOptionsBuilder.Build(

--- a/TensorSharp.Server/API_EXAMPLES.md
+++ b/TensorSharp.Server/API_EXAMPLES.md
@@ -755,9 +755,10 @@ the prior turn's KV cache) for the corresponding session.
 curl -X POST http://localhost:5000/api/upload -F "file=@report.pdf"
 ```
 
-Every response carries `ok, path, url, mediaType, fileName`; the media type is
-classified by file extension (image / video / audio / pdf / text). The client
-then references the stored server `path` in the next `/api/chat` request —
+Every response carries `ok, file, url, mediaType, fileName`; the media type is
+classified by file extension (image / video / audio / pdf / text). `file` is
+the server-assigned filename inside the upload directory. The client then
+references that `file` name in the next `/api/chat` request —
 images via `imagePaths`, extracted video frames via `isVideo: true` +
 `imagePaths`, audio via `audioPaths`, and text content by inlining the returned
 `textContent` into the message.
@@ -780,7 +781,7 @@ curl -N -X POST http://localhost:5000/api/chat \
     "messages": [{
       "role": "user",
       "content": "[File: report.pdf]\n<textContent from the upload response>\n[End of file]\nPlease analyze the attached PDF document and summarize its content.",
-      "textFilePaths": ["<path from the upload response>"]
+      "textFilePaths": ["<file from the upload response>"]
     }],
     "maxTokens": 500
   }'
@@ -789,8 +790,8 @@ curl -N -X POST http://localhost:5000/api/chat \
 - **Scanned / image-only PDF**: if a vision-capable model is loaded (`--mmproj`
   present or the model has a built-in vision encoder), pages are rendered to
   images and returned like video frames (`renderedAsImages: true`, `frames[]`,
-  `frameUrls[]`, `framePaths[]`); pass the `framePaths` as `imagePaths` on the
-  next `/api/chat` request. Without a vision model the response instead carries
+  `frameUrls[]`); pass the `frames` names as `imagePaths` on the next
+  `/api/chat` request. Without a vision model the response instead carries
   `needsVision: true` plus a `warning` asking for a restart with a
   vision-capable model.
 
@@ -818,15 +819,16 @@ Response:
 {"ok": true, "url": "/uploads/edit-<guid>.png", "width": 1184, "height": 544, "elapsedSeconds": 40.4}
 ```
 
-A JSON body `{ "imagePath": "<server path from /api/upload>", "prompt": "...",
-"steps": 0, "cfg": 0, "seed": 42 }` is also accepted (`imagePath` must
-reference a previously uploaded file inside the upload directory). The
+A JSON body `{ "imagePath": "<file from /api/upload>", "prompt": "...",
+"steps": 0, "cfg": 0, "seed": 42 }` is also accepted (`imagePath` is the
+server filename of a previously uploaded file; absolute paths inside the
+upload directory are still accepted for older clients). The
 streaming variant emits SSE progress with live denoising previews:
 
 ```bash
 curl -N -X POST http://localhost:5000/api/image-edit/stream \
   -H "Content-Type: application/json" \
-  -d '{"imagePath": "<path from /api/upload>", "prompt": "Replace the background with a sunny beach", "seed": 42}'
+  -d '{"imagePath": "<file from /api/upload>", "prompt": "Replace the background with a sunny beach", "seed": 42}'
 ```
 
 Per-step events look like

--- a/TensorSharp.Server/API_EXAMPLES_zh-cn.md
+++ b/TensorSharp.Server/API_EXAMPLES_zh-cn.md
@@ -742,9 +742,9 @@ OpenAI 的 `usage.prompt_tokens_details.cached_tokens` 含义一致 —— 都�
 curl -X POST http://localhost:5000/api/upload -F "file=@report.pdf"
 ```
 
-每个响应都携带 `ok, path, url, mediaType, fileName`；媒体类型按文件扩展名分类
+每个响应都携带 `ok, file, url, mediaType, fileName`；媒体类型按文件扩展名分类
 （image / video / audio / pdf / text）。客户端随后在下一次 `/api/chat` 请求中
-引用服务端存储的 `path` —— 图像通过 `imagePaths`，抽取出的视频帧通过
+引用服务端返回的 `file` 文件名 —— 图像通过 `imagePaths`，抽取出的视频帧通过
 `isVideo: true` + `imagePaths`，音频通过 `audioPaths`，文本内容则把返回的
 `textContent` 内联进消息。
 
@@ -763,7 +763,7 @@ curl -N -X POST http://localhost:5000/api/chat \
     "messages": [{
       "role": "user",
       "content": "[File: report.pdf]\n<textContent from the upload response>\n[End of file]\nPlease analyze the attached PDF document and summarize its content.",
-      "textFilePaths": ["<上传响应中的 path>"]
+      "textFilePaths": ["<上传响应中的 file>"]
     }],
     "maxTokens": 500
   }'
@@ -771,8 +771,8 @@ curl -N -X POST http://localhost:5000/api/chat \
 
 - **扫描版 / 纯图像 PDF**：如果加载了具备视觉能力的模型（存在 `--mmproj` 或模
   型内置视觉编码器），页面会被渲染为图像并按视频帧的形式返回
-  （`renderedAsImages: true`、`frames[]`、`frameUrls[]`、`framePaths[]`）；在下
-  一次 `/api/chat` 请求中把 `framePaths` 作为 `imagePaths` 传入。没有视觉模型
+  （`renderedAsImages: true`、`frames[]`、`frameUrls[]`）；在下
+  一次 `/api/chat` 请求中把 `frames` 文件名作为 `imagePaths` 传入。没有视觉模型
   时，响应会携带 `needsVision: true` 和一条 `warning`，提示需用具备视觉能力的
   模型重启服务。
 
@@ -798,14 +798,14 @@ curl -X POST http://localhost:5000/api/image-edit \
 {"ok": true, "url": "/uploads/edit-<guid>.png", "width": 1184, "height": 544, "elapsedSeconds": 40.4}
 ```
 
-也接受 JSON body `{ "imagePath": "<server path from /api/upload>", "prompt": "...",
-"steps": 0, "cfg": 0, "seed": 42 }`（`imagePath` 必须引用上传目录内先前上传过的
+也接受 JSON body `{ "imagePath": "<file from /api/upload>", "prompt": "...",
+"steps": 0, "cfg": 0, "seed": 42 }`（`imagePath` 为先前上传文件的服务端文件名；为兼容旧客户端也接受上传目录内的
 文件）。流式变体通过 SSE 发送进度事件与实时去噪预览：
 
 ```bash
 curl -N -X POST http://localhost:5000/api/image-edit/stream \
   -H "Content-Type: application/json" \
-  -d '{"imagePath": "<path from /api/upload>", "prompt": "Replace the background with a sunny beach", "seed": 42}'
+  -d '{"imagePath": "<file from /api/upload>", "prompt": "Replace the background with a sunny beach", "seed": 42}'
 ```
 
 每步事件形如

--- a/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
+++ b/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
@@ -276,13 +276,12 @@ namespace TensorSharp.Server.ProtocolAdapters
                 return Results.Json(new
                 {
                     ok = true,
-                    path = savePath,
+                    file = safeFileName,
                     url = uploadUrl,
                     mediaType,
                     fileName = file.FileName,
                     frames = frames.Select(f => Path.GetFileName(f)).ToList(),
                     frameUrls = frames.Select(f => BuildUploadUrl(Path.GetFileName(f))).ToList(),
-                    framePaths = frames,
                 });
             }
 
@@ -294,7 +293,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                 return Results.Json(new
                 {
                     ok = true,
-                    path = savePath,
+                    file = safeFileName,
                     url = uploadUrl,
                     mediaType,
                     fileName = file.FileName,
@@ -351,7 +350,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                     return Results.Json(new
                     {
                         ok = true,
-                        path = savePath,
+                        file = safeFileName,
                         url = uploadUrl,
                         mediaType,
                         fileName = file.FileName,
@@ -382,7 +381,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                     return Results.Json(new
                     {
                         ok = true,
-                        path = savePath,
+                        file = safeFileName,
                         url = uploadUrl,
                         mediaType,
                         fileName = file.FileName,
@@ -417,7 +416,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                     return Results.Json(new
                     {
                         ok = true,
-                        path = savePath,
+                        file = safeFileName,
                         url = uploadUrl,
                         mediaType,
                         fileName = file.FileName,
@@ -451,7 +450,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                 return Results.Json(new
                 {
                     ok = true,
-                    path = savePath,
+                    file = safeFileName,
                     url = uploadUrl,
                     mediaType,
                     fileName = file.FileName,
@@ -462,7 +461,6 @@ namespace TensorSharp.Server.ProtocolAdapters
                     warning = incompleteWarning,
                     frames = frameNames,
                     frameUrls,
-                    framePaths,
                     note = $"This PDF has no selectable text; {framePaths.Count} page image(s) were attached for the vision model to read.",
                 });
             }
@@ -490,7 +488,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                     return Results.Json(new
                     {
                         ok = true,
-                        path = savePath,
+                        file = safeFileName,
                         url = uploadUrl,
                         previewUrl = BuildUploadUrl(previewName),
                         mediaType,
@@ -505,7 +503,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                 }
             }
 
-            return Results.Json(new { ok = true, path = savePath, url = uploadUrl, mediaType, fileName = file.FileName });
+            return Results.Json(new { ok = true, file = safeFileName, url = uploadUrl, mediaType, fileName = file.FileName });
         }
 
         // ---- Image editing (Qwen-Image-Edit) ---------------------------------
@@ -596,8 +594,10 @@ namespace TensorSharp.Server.ProtocolAdapters
 
         /// <summary>
         /// Read the referenced upload(s) from a JSON edit request into <paramref name="images"/>:
-        /// <c>imagePaths</c> (array, multi-image) or legacy <c>imagePath</c> (single). Every path
-        /// must resolve inside the upload directory. Returns an error message, or null on success.
+        /// <c>imagePaths</c> (array, multi-image) or legacy <c>imagePath</c> (single). References
+        /// are the bare server filenames returned by <c>/api/upload</c>; absolute paths from older
+        /// clients are accepted when they resolve inside the upload directory. Returns an error
+        /// message, or null on success.
         /// </summary>
         internal async Task<string> ReadUploadedImagesAsync(JsonElement root, List<byte[]> images, CancellationToken ct)
         {
@@ -611,11 +611,9 @@ namespace TensorSharp.Server.ProtocolAdapters
             if (paths.Count == 0)
                 return "imagePath (or imagePaths) must reference a previously uploaded file.";
 
-            string uploadRoot = Path.GetFullPath(_options.UploadDirectory);
             foreach (var path in paths)
             {
-                string full = path == null ? null : Path.GetFullPath(path);
-                if (full == null || !UploadPathGuard.IsInsideDirectory(uploadRoot, full) || !File.Exists(full))
+                if (!UploadFileReference.TryResolve(_options.UploadDirectory, path, out string full) || !File.Exists(full))
                     return "imagePath must reference a previously uploaded file.";
                 images.Add(await File.ReadAllBytesAsync(full, ct));
             }
@@ -1152,7 +1150,7 @@ namespace TensorSharp.Server.ProtocolAdapters
 
             var messages = ChatMessageParser.ParseWebUi(messagesEl);
 
-            string attachmentError = ChatMessageParser.ValidateAttachmentPaths(messages, _options.UploadDirectory);
+            string attachmentError = ChatMessageParser.ResolveAttachmentPaths(messages, _options.UploadDirectory);
             if (attachmentError != null)
             {
                 webUiLogger.LogWarning(LogEventIds.HttpRequestRejected,

--- a/TensorSharp.Server/RequestParsers/ChatMessageParser.cs
+++ b/TensorSharp.Server/RequestParsers/ChatMessageParser.cs
@@ -66,53 +66,42 @@ namespace TensorSharp.Server.RequestParsers
         }
 
         /// <summary>
-        /// Validate that every client-supplied attachment path resolves inside
-        /// the upload directory. Returns an error message, or null when all
-        /// paths are acceptable.
+        /// Resolve every client-supplied attachment reference (imagePaths /
+        /// audioPaths / textFilePaths) to a full path inside the upload
+        /// directory, rewriting the lists in place. The Web UI sends the bare
+        /// server filenames returned by <c>/api/upload</c>; absolute paths from
+        /// older clients are still accepted when they resolve inside the upload
+        /// directory. Returns an error message, or null when everything
+        /// resolved.
         /// </summary>
-        public static string ValidateAttachmentPaths(List<ChatMessage> messages, string uploadRoot)
+        public static string ResolveAttachmentPaths(List<ChatMessage> messages, string uploadRoot)
         {
             if (messages == null)
                 return null;
 
-            string root = Path.GetFullPath(uploadRoot);
-
             foreach (var msg in messages)
             {
-                string error = ValidatePathList(msg?.ImagePaths, root)
-                    ?? ValidatePathList(msg?.AudioPaths, root)
-                    ?? ValidatePathList(msg?.TextFilePaths, root);
+                string error = ResolvePathList(msg?.ImagePaths, uploadRoot)
+                    ?? ResolvePathList(msg?.AudioPaths, uploadRoot)
+                    ?? ResolvePathList(msg?.TextFilePaths, uploadRoot);
                 if (error != null)
                     return error;
             }
             return null;
         }
 
-        private static string ValidatePathList(List<string> paths, string root)
+        private static string ResolvePathList(List<string> paths, string uploadRoot)
         {
             if (paths == null)
                 return null;
 
-            foreach (var path in paths)
+            for (int i = 0; i < paths.Count; i++)
             {
-                if (string.IsNullOrWhiteSpace(path) || !IsInsideDirectory(root, path))
+                if (!UploadFileReference.TryResolve(uploadRoot, paths[i], out string full))
                     return "Attachment path must reference a previously uploaded file.";
+                paths[i] = full;
             }
             return null;
-        }
-
-        /// <summary>
-        /// True when <paramref name="path"/> resolves inside <paramref name="root"/>.
-        /// Traversal and a sibling directory that merely shares the root's name
-        /// both resolve outside and are rejected. <paramref name="root"/> must
-        /// already be a full path.
-        /// </summary>
-        private static bool IsInsideDirectory(string root, string path)
-        {
-            string relative = Path.GetRelativePath(root, path);
-            return relative != ".."
-                && !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
-                && !Path.IsPathRooted(relative);
         }
 
         /// <summary>

--- a/TensorSharp.Server/RequestParsers/UploadFileReference.cs
+++ b/TensorSharp.Server/RequestParsers/UploadFileReference.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+
+namespace TensorSharp.Server.RequestParsers
+{
+    /// <summary>
+    /// Resolves a client-supplied upload reference to a full path inside the
+    /// upload directory. The canonical form is the bare server filename that
+    /// <c>/api/upload</c> returns as <c>file</c>; an absolute path is still
+    /// accepted for compatibility with older clients, but must resolve inside
+    /// the upload directory — traversal and a sibling directory that merely
+    /// shares the root's name are both rejected.
+    /// </summary>
+    internal static class UploadFileReference
+    {
+        public static bool TryResolve(string uploadRoot, string reference, out string fullPath)
+        {
+            fullPath = null;
+            if (string.IsNullOrWhiteSpace(reference))
+                return false;
+
+            string root = Path.GetFullPath(uploadRoot);
+
+            // A name with no directory component joins under the root with no
+            // escape route, so it needs no further containment check.
+            if (IsBareFileName(reference))
+            {
+                fullPath = Path.Combine(root, reference);
+                return true;
+            }
+
+            string full;
+            try
+            {
+                full = Path.GetFullPath(reference);
+            }
+            catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+            {
+                return false;
+            }
+
+            if (!IsInsideDirectory(root, full))
+                return false;
+
+            fullPath = full;
+            return true;
+        }
+
+        private static bool IsBareFileName(string reference)
+        {
+            return reference.IndexOf('/') < 0
+                && reference.IndexOf('\\') < 0
+                && reference != "."
+                && reference != ".."
+                && !Path.IsPathRooted(reference);
+        }
+
+        /// <summary>
+        /// True when <paramref name="path"/> resolves inside <paramref name="root"/>.
+        /// Built on <see cref="Path.GetRelativePath(string, string)"/> rather than a
+        /// string prefix comparison so traversal and a sibling directory sharing the
+        /// root's name both land outside. Both arguments must already be full paths.
+        /// </summary>
+        private static bool IsInsideDirectory(string root, string path)
+        {
+            string relative = Path.GetRelativePath(root, path);
+            return relative != ".."
+                && !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                && !Path.IsPathRooted(relative);
+        }
+    }
+}

--- a/TensorSharp.Server/RequestParsers/WanVideoParamsParser.cs
+++ b/TensorSharp.Server/RequestParsers/WanVideoParamsParser.cs
@@ -55,14 +55,14 @@ namespace TensorSharp.Server.RequestParsers
                 p.CfgCacheStride = ccv;
 
             // Conditioning image for Wan 2.2 image-to-video: either a previously uploaded
-            // file ("imagePath", Web UI flow) or inline base64 ("image", API flow; a
-            // data:...;base64, prefix is accepted).
+            // file ("imagePath" — the bare server filename from /api/upload, or a legacy
+            // absolute path inside the upload directory) or inline base64 ("image", API
+            // flow; a data:...;base64, prefix is accepted).
             if (root.TryGetProperty("imagePath", out var ip) && ip.ValueKind == JsonValueKind.String
                 && !string.IsNullOrWhiteSpace(ip.GetString()))
             {
-                string uploadRoot = Path.GetFullPath(options.UploadDirectory);
-                string full = Path.GetFullPath(ip.GetString());
-                if (!UploadPathGuard.IsInsideDirectory(uploadRoot, full) || !File.Exists(full))
+                if (!UploadFileReference.TryResolve(options.UploadDirectory, ip.GetString(), out string full)
+                    || !File.Exists(full))
                 {
                     error = "imagePath must reference a previously uploaded file.";
                     return p;

--- a/TensorSharp.Server/wwwroot/index.html
+++ b/TensorSharp.Server/wwwroot/index.html
@@ -1153,26 +1153,26 @@ async function sendMessage() {
 
   attachmentsCopy.forEach(att => {
     if (att.mediaType === 'image') {
-      imagePaths.push(att.path);
+      imagePaths.push(att.file);
     } else if (att.mediaType === 'video') {
       isVideo = true;
-      if (att.framePaths) att.framePaths.forEach(f => imagePaths.push(f));
+      if (att.frames) att.frames.forEach(f => imagePaths.push(f));
     } else if (att.mediaType === 'audio') {
-      audioPaths.push(att.path);
+      audioPaths.push(att.file);
     } else if (att.mediaType === 'text' && att.textContent) {
       textParts.push(`[File: ${att.fileName}]\n${att.textContent}\n[End of file]`);
-      if (att.path) textFilePaths.push(att.path);
+      if (att.file) textFilePaths.push(att.file);
     } else if (att.mediaType === 'pdf') {
       if (att.textContent) {
         // Born-digital PDF: inline the extracted text.
         textParts.push(`[File: ${att.fileName}]\n${att.textContent}\n[End of file]`);
-        if (att.path) textFilePaths.push(att.path);
-      } else if (att.framePaths && att.framePaths.length) {
+        if (att.file) textFilePaths.push(att.file);
+      } else if (att.frames && att.frames.length) {
         // Scanned / image-only PDF: send its page images to the vision model.
-        // Keep the original PDF path as document provenance too, so the server
+        // Keep the original PDF file as document provenance too, so the server
         // never silently trims pages if the expanded vision prompt is too large.
-        if (att.path) textFilePaths.push(att.path);
-        att.framePaths.forEach(f => imagePaths.push(f));
+        if (att.file) textFilePaths.push(att.file);
+        att.frames.forEach(f => imagePaths.push(f));
       }
     }
   });
@@ -1781,7 +1781,7 @@ function uploadUrlForAttachment(att) {
   // Formats the browser can't render (HEIC/HEIF) get a server-generated PNG preview.
   if (att && att.previewUrl) return att.previewUrl;
   if (att && att.url) return att.url;
-  const raw = String((att && (att.path || att.fileName)) || '');
+  const raw = String((att && (att.file || att.fileName)) || '');
   if (!raw) return '';
   const normalized = raw.replace(/\\/g, '/');
   const fileName = normalized.split('/').filter(Boolean).pop() || raw;


### PR DESCRIPTION
`/api/upload` returns the saved file's absolute host path as `path` (and extracted video/PDF page images as `framePaths`), and the Web UI round-trips those into `/api/chat`, `/api/image-edit`, and `/api/video-generate`. That leaks the server's filesystem layout (install location, user name, OS) to every client for no functional reason.

The upload response now carries `file` — the server-assigned filename — alongside the existing `frames` names; `path` and `framePaths` are gone. On the accept side, a shared `UploadFileReference` resolver handles all three sites (chat attachments, image-edit `imagePath(s)`, Wan i2v conditioning image): the canonical form is the bare filename joined under the upload directory, and absolute paths from older clients are still accepted when they resolve inside the upload directory — the same containment rule as #146/#152, which this builds on.

**API contract change:** clients reading `path`/`framePaths` from the upload response must switch to `file`/`frames`. The accept side stays backward-compatible. Both API_EXAMPLES documents are updated.

Verified locally: new `UploadFileReferenceTests` + updated guard tests; environment-independent lane 1156 passed / 0 failed on current main.

Touches some of the same server files as #160/#161 (opened alongside) — happy to rebase promptly as the others land.
