### PR TITLE
Add --no-webui / TS_NO_WEBUI to run the server API-only

### DIFF
--- a/InferenceWeb.Tests/ServerOptionsBuilderTests.cs
+++ b/InferenceWeb.Tests/ServerOptionsBuilderTests.cs
@@ -1044,4 +1044,44 @@ public class ServerOptionsBuilderTests : IDisposable
         var ex = Assert.Throws<ArgumentException>(() => BuildListenUrls("--prot", "8080"));
         Assert.Contains("--port", ex.Message);
     }
+
+    [Fact]
+    public void Build_Default_WebUiEnabled()
+    {
+        _env.Set("TS_NO_WEBUI", null);
+        var options = ServerOptionsBuilder.Build(Array.Empty<string>(), _baseDir);
+        Assert.True(options.WebUiEnabled);
+    }
+
+    [Fact]
+    public void Build_NoWebUiFlag_DisablesWebUi()
+    {
+        _env.Set("TS_NO_WEBUI", null);
+        var options = ServerOptionsBuilder.Build(new[] { "--no-webui" }, _baseDir);
+        Assert.False(options.WebUiEnabled);
+    }
+
+    [Fact]
+    public void Build_NoWebUiEnvVar_DisablesWebUi()
+    {
+        _env.Set("TS_NO_WEBUI", "1");
+        var options = ServerOptionsBuilder.Build(Array.Empty<string>(), _baseDir);
+        Assert.False(options.WebUiEnabled);
+    }
+
+    [Fact]
+    public void Build_NoWebUiEnvVarZero_KeepsWebUiEnabled()
+    {
+        _env.Set("TS_NO_WEBUI", "0");
+        var options = ServerOptionsBuilder.Build(Array.Empty<string>(), _baseDir);
+        Assert.True(options.WebUiEnabled);
+    }
+
+    [Fact]
+    public void Build_NoWebUiFlag_OverridesEnvVarZero()
+    {
+        _env.Set("TS_NO_WEBUI", "0");
+        var options = ServerOptionsBuilder.Build(new[] { "--no-webui" }, _baseDir);
+        Assert.False(options.WebUiEnabled);
+    }
 }

--- a/TensorSharp.Server/Endpoints/HealthEndpoints.cs
+++ b/TensorSharp.Server/Endpoints/HealthEndpoints.cs
@@ -31,16 +31,18 @@ namespace TensorSharp.Server.Endpoints
     {
         private const string LivenessMessage = "TensorSharp.Server is running";
 
-        public static IEndpointRouteBuilder MapHealthEndpoints(this IEndpointRouteBuilder endpoints, IWebHostEnvironment environment)
+        public static IEndpointRouteBuilder MapHealthEndpoints(
+            this IEndpointRouteBuilder endpoints, IWebHostEnvironment environment, bool webUiEnabled = true)
         {
             // UseDefaultFiles() cannot rewrite "/" to "/index.html" for us:
             // WebApplication runs routing ahead of the static-file middleware,
             // which then bails out because this endpoint is already selected.
             // Sending the file from the endpoint itself is what makes a bare
             // http://host:port/ open the UI instead of the liveness text.
+            // With the Web UI disabled, "/" always answers the liveness text.
             endpoints.MapGet("/", async ctx =>
             {
-                if (await TrySendIndexAsync(ctx, environment))
+                if (webUiEnabled && await TrySendIndexAsync(ctx, environment))
                     return;
                 await Results.Ok(LivenessMessage).ExecuteAsync(ctx);
             });
@@ -51,18 +53,23 @@ namespace TensorSharp.Server.Endpoints
 
             endpoints.MapFallback(async ctx =>
             {
-                if (await TrySendIndexAsync(ctx, environment))
+                if (webUiEnabled && await TrySendIndexAsync(ctx, environment))
                     return;
-                // The resolved web root goes to the server log for the operator
-                // diagnosing a misdeployed wwwroot; the response stays generic so
-                // clients don't learn host filesystem paths.
-                ctx.RequestServices.GetService<ILoggerFactory>()
-                    ?.CreateLogger("TensorSharp.Server.Health")
-                    .LogWarning(LogEventIds.HttpRequestRejected,
-                        "Fallback route hit but index.html is missing. WebRootPath: {WebRootPath}",
-                        environment.WebRootPath ?? "(null)");
+                // With the UI enabled, a fallback hit means index.html is
+                // missing: the resolved web root goes to the server log for the
+                // operator diagnosing a misdeployed wwwroot. The response stays
+                // generic either way so clients don't learn host filesystem
+                // paths.
+                if (webUiEnabled)
+                {
+                    ctx.RequestServices.GetService<ILoggerFactory>()
+                        ?.CreateLogger("TensorSharp.Server.Health")
+                        .LogWarning(LogEventIds.HttpRequestRejected,
+                            "Fallback route hit but index.html is missing. WebRootPath: {WebRootPath}",
+                            environment.WebRootPath ?? "(null)");
+                }
                 ctx.Response.StatusCode = 404;
-                await ctx.Response.WriteAsync("index.html not found.");
+                await ctx.Response.WriteAsync(webUiEnabled ? "index.html not found." : "Not found.");
             });
 
             return endpoints;

--- a/TensorSharp.Server/Hosting/ServerHostingOptions.cs
+++ b/TensorSharp.Server/Hosting/ServerHostingOptions.cs
@@ -46,8 +46,10 @@ namespace TensorSharp.Server.Hosting
             string logDirectory,
             bool fileLoggingEnabled,
             SamplingDefaults samplingDefaults,
-            string listenUrls = DefaultListenUrls)
+            string listenUrls = DefaultListenUrls,
+            bool webUiEnabled = true)
         {
+            WebUiEnabled = webUiEnabled;
             ListenUrls = string.IsNullOrWhiteSpace(listenUrls) ? DefaultListenUrls : listenUrls;
             StartupModelPath = startupModelPath;
             StartupMmProjPath = startupMmProjPath;
@@ -73,6 +75,16 @@ namespace TensorSharp.Server.Hosting
         /// <see cref="DefaultListenUrls"/>. Never null or empty.
         /// </summary>
         public string ListenUrls { get; }
+
+        /// <summary>
+        /// False when the operator passed <c>--no-webui</c> (or set
+        /// <c>TS_NO_WEBUI</c> to anything but <c>0</c>): the bundled wwwroot UI
+        /// is not served and <c>GET /</c> answers with the plain liveness text,
+        /// as on a headless deployment that ships no wwwroot content. Every
+        /// HTTP API endpoint (including <c>/uploads</c>, whose URLs the image
+        /// and video APIs return) stays up.
+        /// </summary>
+        public bool WebUiEnabled { get; }
 
         /// <summary>Absolute path of the model the server was launched with, or null when no model is hosted.</summary>
         public string StartupModelPath { get; }

--- a/TensorSharp.Server/Hosting/ServerOptionsBuilder.cs
+++ b/TensorSharp.Server/Hosting/ServerOptionsBuilder.cs
@@ -41,7 +41,8 @@ namespace TensorSharp.Server.Hosting
                 out int? configuredWanVideoFps,
                 out SamplingOverrides configuredSampling,
                 out SamplingPrecedence? configuredPrecedence,
-                out ListenOverrides configuredListen);
+                out ListenOverrides configuredListen,
+                out bool configuredNoWebUi);
 
             if (!string.IsNullOrWhiteSpace(configuredMmProj) && string.IsNullOrWhiteSpace(configuredModel))
                 throw new ArgumentException("--mmproj requires --model.");
@@ -87,6 +88,12 @@ namespace TensorSharp.Server.Hosting
 
             string listenUrls = ResolveListenUrls(configuredListen);
 
+            // TS_NO_WEBUI follows the TENSORSHARP_LOG_FILE convention: set to
+            // anything but "0" counts as on.
+            string noWebUiEnv = Environment.GetEnvironmentVariable("TS_NO_WEBUI");
+            bool webUiEnabled = !configuredNoWebUi
+                && (string.IsNullOrWhiteSpace(noWebUiEnv) || string.Equals(noWebUiEnv.Trim(), "0", StringComparison.Ordinal));
+
             return new ServerHostingOptions(
                 startupModelPath,
                 startupMmProjPath,
@@ -100,13 +107,14 @@ namespace TensorSharp.Server.Hosting
                 logDirectory,
                 fileLoggingEnabled,
                 defaultSampling,
-                listenUrls);
+                listenUrls,
+                webUiEnabled);
         }
 
         /// <summary>Backend originally requested via <c>--backend</c> / <c>BACKEND</c> (without the OS-default fallback).</summary>
         public static string ReadConfiguredBackendInput(string[] args)
         {
-            ParseArgs(args, out _, out _, out string configuredBackend, out _, out _, out _, out _, out _, out _);
+            ParseArgs(args, out _, out _, out string configuredBackend, out _, out _, out _, out _, out _, out _, out _);
             return configuredBackend ?? Environment.GetEnvironmentVariable("BACKEND");
         }
 
@@ -797,7 +805,8 @@ namespace TensorSharp.Server.Hosting
             out int? configuredWanVideoFps,
             out SamplingOverrides configuredSampling,
             out SamplingPrecedence? configuredPrecedence,
-            out ListenOverrides configuredListen)
+            out ListenOverrides configuredListen,
+            out bool configuredNoWebUi)
         {
             configuredModel = null;
             configuredMmProj = null;
@@ -808,6 +817,7 @@ namespace TensorSharp.Server.Hosting
             configuredSampling = default;
             configuredPrecedence = null;
             configuredListen = default;
+            configuredNoWebUi = false;
 
             for (int i = 0; i < args.Length; i++)
             {
@@ -946,6 +956,12 @@ namespace TensorSharp.Server.Hosting
                 if (TryReadOption(args, ref i, "--sampling-precedence", out string precedenceOption))
                 {
                     configuredPrecedence = ParseSamplingPrecedence("--sampling-precedence", precedenceOption);
+                    continue;
+                }
+
+                if (string.Equals(args[i], "--no-webui", StringComparison.OrdinalIgnoreCase))
+                {
+                    configuredNoWebUi = true;
                     continue;
                 }
 
@@ -1106,7 +1122,7 @@ namespace TensorSharp.Server.Hosting
             string[] knownFlags = new[]
             {
                 "--model", "--mmproj", "--backend", "--max-tokens", "--video-frames", "--fps",
-                "--port", "--host", "--urls",
+                "--port", "--host", "--urls", "--no-webui",
                 "--temperature", "--top-k", "--top-p", "--min-p",
                 "--repeat-penalty", "--repeat-last-n", "--presence-penalty", "--frequency-penalty",
                 "--seed", "--stop", "--sampling-precedence",

--- a/TensorSharp.Server/Hosting/ServerUsage.cs
+++ b/TensorSharp.Server/Hosting/ServerUsage.cs
@@ -110,6 +110,10 @@ namespace TensorSharp.Server.Hosting
                     "binding several endpoints at once). Overridden by --port/--host when both are given; falls back " +
                     "to the ASPNETCORE_URLS env var.",
                     "--urls \"http://0.0.0.0:8080;https://0.0.0.0:8443\""),
+                new OptionHelp("--no-webui",
+                    "Do not serve the bundled web UI; GET / answers the plain liveness text instead. All HTTP API " +
+                    "endpoints (including /uploads) stay up. Default: UI on (TS_NO_WEBUI env var overrides).",
+                    "--no-webui"),
             }),
             ("Compute backend", new[]
             {

--- a/TensorSharp.Server/Program.cs
+++ b/TensorSharp.Server/Program.cs
@@ -256,9 +256,19 @@ app.UsePromptOverflowHandling();
 // Serve the bundled static UI. GET / sends index.html too (see
 // HealthEndpoints), so a bare http://host:port/ opens the chat UI; the plain
 // liveness response moved to GET /health and still answers / on headless
-// deployments that ship no wwwroot content.
-app.UseDefaultFiles();
-app.UseStaticFiles();
+// deployments that ship no wwwroot content. --no-webui skips the wwwroot
+// middleware entirely for API-only deployments; /uploads stays served below
+// because the image and video APIs return result URLs under it.
+if (hostingOptions.WebUiEnabled)
+{
+    app.UseDefaultFiles();
+    app.UseStaticFiles();
+}
+else
+{
+    startupLogger.LogInformation(LogEventIds.HostConfiguration,
+        "Web UI disabled (--no-webui / TS_NO_WEBUI): wwwroot is not served; API endpoints and /uploads remain available");
+}
 // /uploads holds user-supplied files, so its content types come from the
 // UploadContentPolicy allow-list: media keeps real types, text/code always
 // comes back as text/plain (an uploaded .html page must never execute in the
@@ -266,7 +276,7 @@ app.UseStaticFiles();
 // X-Content-Type-Options: nosniff.
 app.UseStaticFiles(UploadContentPolicy.BuildStaticFileOptions(hostingOptions.UploadDirectory));
 
-app.MapHealthEndpoints(app.Environment);
+app.MapHealthEndpoints(app.Environment, hostingOptions.WebUiEnabled);
 app.MapSessionEndpoints();
 app.MapUploadEndpoints();
 app.MapWebUiEndpoints();


### PR DESCRIPTION
The bundled wwwroot chat UI is served unconditionally; the only way to run API-only is deleting the wwwroot directory. `--no-webui` (or `TS_NO_WEBUI` set to anything but `0`) skips the wwwroot static-file middleware and has `GET /` answer the plain liveness text — the same behavior a headless deployment without wwwroot content already gets. Every HTTP API endpoint stays up, including `/uploads`, whose URLs the image and video APIs return. Mirrors llama-server's `--no-webui`.

Verified: 5 new `ServerOptionsBuilderTests` cases (default on, flag off, env off, env=0 on, flag beats env), plus a live no-model server in both modes (`--no-webui`: `/` is liveness text, `/index.html` 404, `/v1` + `/api` + `/uploads` all up; default: `/` serves the UI). Environment-independent lane 1146 passed / 0 failed on current main.
