### PR TITLE
Add opt-in storage limits for the upload directory

### DIFF
--- a/InferenceWeb.Tests/ApiModelsResponseTests.cs
+++ b/InferenceWeb.Tests/ApiModelsResponseTests.cs
@@ -48,6 +48,7 @@ public class ApiModelsResponseTests : IDisposable
                 logDirectory: Path.Combine(_baseDir, "logs"),
                 fileLoggingEnabled: false,
                 samplingDefaults: null),
+            new UploadStoragePolicy(_baseDir),
             NullLoggerFactory.Instance);
 
         var result = adapter.GetModels();

--- a/InferenceWeb.Tests/ResponsesApiTests.cs
+++ b/InferenceWeb.Tests/ResponsesApiTests.cs
@@ -7,6 +7,7 @@ using TensorSharp.Models;
 using TensorSharp.Runtime;
 using TensorSharp.Server.RequestParsers;
 using TensorSharp.Server.ResponseSerializers;
+using TensorSharp.Server.Hosting;
 using TensorSharp.Server.Responses;
 
 namespace InferenceWeb.Tests;
@@ -19,7 +20,7 @@ public class ResponsesApiTests
     public void ParseResponsesInput_StringInput_BecomesSingleUserMessage()
     {
         using var doc = JsonDocument.Parse("\"hello there\"");
-        var messages = ChatMessageParser.ParseResponsesInput(doc.RootElement, null, Path.GetTempPath());
+        var messages = ChatMessageParser.ParseResponsesInput(doc.RootElement, null, new UploadStoragePolicy(Path.GetTempPath()));
 
         var msg = Assert.Single(messages);
         Assert.Equal("user", msg.Role);
@@ -30,7 +31,7 @@ public class ResponsesApiTests
     public void ParseResponsesInput_Instructions_PrependsSystemMessage()
     {
         using var doc = JsonDocument.Parse("\"hi\"");
-        var messages = ChatMessageParser.ParseResponsesInput(doc.RootElement, "be nice", Path.GetTempPath());
+        var messages = ChatMessageParser.ParseResponsesInput(doc.RootElement, "be nice", new UploadStoragePolicy(Path.GetTempPath()));
 
         Assert.Equal(2, messages.Count);
         Assert.Equal("system", messages[0].Role);
@@ -49,7 +50,7 @@ public class ResponsesApiTests
         ]
         """;
         using var doc = JsonDocument.Parse(body);
-        var messages = ChatMessageParser.ParseResponsesInput(doc.RootElement, null, Path.GetTempPath());
+        var messages = ChatMessageParser.ParseResponsesInput(doc.RootElement, null, new UploadStoragePolicy(Path.GetTempPath()));
 
         Assert.Equal(3, messages.Count);
         Assert.Equal(["user", "assistant", "user"], messages.ConvertAll(m => m.Role));
@@ -74,7 +75,7 @@ public class ResponsesApiTests
             ]
             """;
             using var doc = JsonDocument.Parse(body);
-            var messages = ChatMessageParser.ParseResponsesInput(doc.RootElement, null, tempDir);
+            var messages = ChatMessageParser.ParseResponsesInput(doc.RootElement, null, new UploadStoragePolicy(tempDir));
 
             var msg = Assert.Single(messages);
             Assert.Equal("what is this", msg.Content);
@@ -98,7 +99,7 @@ public class ResponsesApiTests
         ]
         """;
         using var doc = JsonDocument.Parse(body);
-        var messages = ChatMessageParser.ParseResponsesInput(doc.RootElement, null, Path.GetTempPath());
+        var messages = ChatMessageParser.ParseResponsesInput(doc.RootElement, null, new UploadStoragePolicy(Path.GetTempPath()));
 
         var msg = Assert.Single(messages);
         Assert.Equal("user", msg.Role);

--- a/InferenceWeb.Tests/ServerOptionsBuilderTests.cs
+++ b/InferenceWeb.Tests/ServerOptionsBuilderTests.cs
@@ -1045,6 +1045,59 @@ public class ServerOptionsBuilderTests : IDisposable
         Assert.Contains("--port", ex.Message);
     }
 
+    // ---- Upload storage limits -------------------------------------------
+
+    [Fact]
+    public void Build_NoUploadFlags_KeepsPermissiveDefaults()
+    {
+        var options = ServerOptionsBuilder.Build(Array.Empty<string>(), _baseDir);
+
+        Assert.Equal(500L * 1024 * 1024, options.UploadMaxFileBytes);
+        Assert.Equal(0, options.UploadQuotaBytes);
+        Assert.Null(options.UploadTtl);
+    }
+
+    [Fact]
+    public void Build_UploadFlags_ResolveToBytesAndTimeSpan()
+    {
+        var options = ServerOptionsBuilder.Build(
+            new[] { "--upload-max-mb", "25", "--upload-quota-mb", "2048", "--upload-ttl-hours", "1.5" },
+            _baseDir);
+
+        Assert.Equal(25L * 1024 * 1024, options.UploadMaxFileBytes);
+        Assert.Equal(2048L * 1024 * 1024, options.UploadQuotaBytes);
+        Assert.Equal(TimeSpan.FromMinutes(90), options.UploadTtl);
+    }
+
+    [Fact]
+    public void Build_UploadEnvVars_LayerUnderCliOverrides()
+    {
+        _env.Set("TS_UPLOAD_MAX_MB", "10");
+        _env.Set("TS_UPLOAD_QUOTA_MB", "512");
+        _env.Set("TS_UPLOAD_TTL_HOURS", "24");
+
+        var options = ServerOptionsBuilder.Build(new[] { "--upload-max-mb", "50" }, _baseDir);
+
+        // CLI wins over env for the per-file cap.
+        Assert.Equal(50L * 1024 * 1024, options.UploadMaxFileBytes);
+        // No CLI for the others -> env values applied.
+        Assert.Equal(512L * 1024 * 1024, options.UploadQuotaBytes);
+        Assert.Equal(TimeSpan.FromHours(24), options.UploadTtl);
+    }
+
+    [Theory]
+    [InlineData("--upload-max-mb", "0")]
+    [InlineData("--upload-max-mb", "abc")]
+    [InlineData("--upload-quota-mb", "-5")]
+    [InlineData("--upload-ttl-hours", "0")]
+    [InlineData("--upload-ttl-hours", "soon")]
+    public void Build_InvalidUploadValues_ThrowArgumentException(string flag, string value)
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => ServerOptionsBuilder.Build(new[] { flag, value }, _baseDir));
+        Assert.Contains(flag, ex.Message);
+    }
+
     [Fact]
     public void Build_Default_WebUiEnabled()
     {

--- a/InferenceWeb.Tests/UploadRootConfinementTests.cs
+++ b/InferenceWeb.Tests/UploadRootConfinementTests.cs
@@ -169,6 +169,7 @@ public class UploadRootConfinementTests : IDisposable
         new InferenceQueue(),
         new SessionManager(),
         Options(),
+        new UploadStoragePolicy(_uploadRoot),
         NullLoggerFactory.Instance);
 
     private static JsonElement VideoRequest(string imagePath) =>

--- a/InferenceWeb.Tests/UploadStoragePolicyTests.cs
+++ b/InferenceWeb.Tests/UploadStoragePolicyTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using TensorSharp.Server.Hosting;
+using TensorSharp.Server.RequestParsers;
+
+namespace InferenceWeb.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="UploadStoragePolicy"/> (per-file cap, quota
+/// reservation, TTL cleanup) and for its enforcement inside the base64
+/// materialisation path of <see cref="ChatMessageParser"/>.
+/// </summary>
+public class UploadStoragePolicyTests : IDisposable
+{
+    private readonly string _dir;
+
+    public UploadStoragePolicyTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "ts-upload-policy-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private string WriteFile(string name, int bytes)
+    {
+        string path = Path.Combine(_dir, name);
+        File.WriteAllBytes(path, new byte[bytes]);
+        return path;
+    }
+
+    [Fact]
+    public void Constructor_ScansExistingFilesIntoUsedBytes()
+    {
+        WriteFile("a.png", 100);
+        WriteFile("b.mp4", 250);
+
+        var policy = new UploadStoragePolicy(_dir);
+
+        Assert.Equal(350, policy.UsedBytes);
+    }
+
+    [Fact]
+    public void Defaults_ArePermissive()
+    {
+        var policy = new UploadStoragePolicy(_dir);
+
+        Assert.Equal(500L * 1024 * 1024, policy.MaxFileBytes);
+        Assert.False(policy.QuotaEnabled);
+        Assert.Null(policy.Ttl);
+        Assert.True(policy.TryReserveClientWrite(100L * 1024 * 1024, out _, out _));
+        Assert.True(policy.HasQuotaHeadroom(out _));
+    }
+
+    [Fact]
+    public void TryReserveClientWrite_FileOverCap_Rejects413()
+    {
+        var policy = new UploadStoragePolicy(_dir, maxFileBytes: 1024);
+
+        Assert.False(policy.TryReserveClientWrite(2048, out string error, out int status));
+        Assert.Equal(413, status);
+        Assert.Contains("too large", error);
+        // A rejected file must not consume quota.
+        Assert.Equal(0, policy.UsedBytes);
+    }
+
+    [Fact]
+    public void TryReserveClientWrite_QuotaExhausted_Rejects507()
+    {
+        var policy = new UploadStoragePolicy(_dir, quotaBytes: 1000);
+
+        Assert.True(policy.TryReserveClientWrite(800, out _, out _));
+        Assert.False(policy.TryReserveClientWrite(300, out string error, out int status));
+        Assert.Equal(507, status);
+        Assert.Contains("quota", error);
+        // The failed attempt must not have reserved anything.
+        Assert.Equal(800, policy.UsedBytes);
+        // A write that still fits is admitted.
+        Assert.True(policy.TryReserveClientWrite(200, out _, out _));
+    }
+
+    [Fact]
+    public void Release_ReturnsReservedBytes()
+    {
+        var policy = new UploadStoragePolicy(_dir, quotaBytes: 1000);
+
+        Assert.True(policy.TryReserveClientWrite(900, out _, out _));
+        policy.Release(900);
+
+        Assert.Equal(0, policy.UsedBytes);
+        Assert.True(policy.TryReserveClientWrite(900, out _, out _));
+    }
+
+    [Fact]
+    public void HasQuotaHeadroom_FalseOnceQuotaReached()
+    {
+        WriteFile("existing.bin", 1000);
+        var policy = new UploadStoragePolicy(_dir, quotaBytes: 1000);
+
+        Assert.False(policy.HasQuotaHeadroom(out string error));
+        Assert.Contains("quota", error);
+    }
+
+    [Fact]
+    public void RecordFile_AddsActualSize_IgnoresMissing()
+    {
+        var policy = new UploadStoragePolicy(_dir);
+        string path = WriteFile("generated.png", 640);
+
+        policy.RecordFile(path);
+        policy.RecordFile(Path.Combine(_dir, "missing.png"));
+
+        Assert.Equal(640, policy.UsedBytes);
+    }
+
+    [Fact]
+    public void CleanupExpired_DeletesOnlyFilesOlderThanTtl_AndUpdatesUsedBytes()
+    {
+        string oldFile = WriteFile("old.png", 300);
+        string newFile = WriteFile("new.png", 200);
+        File.SetLastWriteTimeUtc(oldFile, DateTime.UtcNow.AddHours(-3));
+
+        var policy = new UploadStoragePolicy(_dir, ttl: TimeSpan.FromHours(1));
+        int deleted = policy.CleanupExpired(out long freed);
+
+        Assert.Equal(1, deleted);
+        Assert.Equal(300, freed);
+        Assert.False(File.Exists(oldFile));
+        Assert.True(File.Exists(newFile));
+        Assert.Equal(200, policy.UsedBytes);
+    }
+
+    [Fact]
+    public void CleanupExpired_NoTtl_IsNoOp()
+    {
+        string oldFile = WriteFile("old.png", 300);
+        File.SetLastWriteTimeUtc(oldFile, DateTime.UtcNow.AddYears(-1));
+
+        var policy = new UploadStoragePolicy(_dir);
+
+        Assert.Equal(0, policy.CleanupExpired(out long freed));
+        Assert.Equal(0, freed);
+        Assert.True(File.Exists(oldFile));
+    }
+
+    // ---- Enforcement inside the chat parsers ------------------------------
+
+    private static JsonDocument OllamaImagesBody(int imageBytes)
+    {
+        string b64 = Convert.ToBase64String(new byte[imageBytes]);
+        return JsonDocument.Parse($$"""{"images": ["{{b64}}"]}""");
+    }
+
+    [Fact]
+    public void DecodeBase64Images_OverPerFileCap_ThrowsWith413()
+    {
+        var policy = new UploadStoragePolicy(_dir, maxFileBytes: 16);
+        using var doc = OllamaImagesBody(imageBytes: 64);
+
+        var ex = Assert.Throws<UploadLimitExceededException>(
+            () => ChatMessageParser.DecodeBase64Images(doc.RootElement, policy));
+        Assert.Equal(413, ex.StatusCode);
+        Assert.Empty(Directory.GetFiles(_dir));
+    }
+
+    [Fact]
+    public void DecodeBase64Images_QuotaExhausted_ThrowsWith507()
+    {
+        WriteFile("existing.bin", 100);
+        var policy = new UploadStoragePolicy(_dir, quotaBytes: 110);
+        using var doc = OllamaImagesBody(imageBytes: 64);
+
+        var ex = Assert.Throws<UploadLimitExceededException>(
+            () => ChatMessageParser.DecodeBase64Images(doc.RootElement, policy));
+        Assert.Equal(507, ex.StatusCode);
+    }
+
+    [Fact]
+    public void DecodeBase64Images_WithinLimits_WritesAndCountsBytes()
+    {
+        var policy = new UploadStoragePolicy(_dir, maxFileBytes: 1024, quotaBytes: 1024);
+        using var doc = OllamaImagesBody(imageBytes: 64);
+
+        var paths = ChatMessageParser.DecodeBase64Images(doc.RootElement, policy);
+
+        string path = Assert.Single(paths);
+        Assert.True(File.Exists(path));
+        Assert.Equal(64, policy.UsedBytes);
+    }
+}

--- a/TensorSharp.Runtime/Logging/LogEventIds.cs
+++ b/TensorSharp.Runtime/Logging/LogEventIds.cs
@@ -86,6 +86,7 @@ namespace TensorSharp.Runtime.Logging
         // Uploads / media --------------------------------------------------
         public static readonly EventId UploadReceived = new(1600, nameof(UploadReceived));
         public static readonly EventId UploadRejected = new(1601, nameof(UploadRejected));
+        public static readonly EventId UploadCleanup = new(1602, nameof(UploadCleanup));
 
         // CLI --------------------------------------------------------------
         public static readonly EventId CliStarted = new(1700, nameof(CliStarted));

--- a/TensorSharp.Server/Hosting/ServerHostingOptions.cs
+++ b/TensorSharp.Server/Hosting/ServerHostingOptions.cs
@@ -47,6 +47,9 @@ namespace TensorSharp.Server.Hosting
             bool fileLoggingEnabled,
             SamplingDefaults samplingDefaults,
             string listenUrls = DefaultListenUrls,
+            long uploadMaxFileBytes = UploadStoragePolicy.DefaultMaxFileBytes,
+            long uploadQuotaBytes = 0,
+            TimeSpan? uploadTtl = null,
             bool webUiEnabled = true)
         {
             WebUiEnabled = webUiEnabled;
@@ -66,6 +69,9 @@ namespace TensorSharp.Server.Hosting
             LogDirectory = logDirectory;
             FileLoggingEnabled = fileLoggingEnabled;
             SamplingDefaults = samplingDefaults ?? new SamplingDefaults(new SamplingConfig());
+            UploadMaxFileBytes = uploadMaxFileBytes;
+            UploadQuotaBytes = uploadQuotaBytes;
+            UploadTtl = uploadTtl;
         }
 
         /// <summary>
@@ -132,6 +138,27 @@ namespace TensorSharp.Server.Hosting
 
         /// <summary>Absolute path to the directory used for user uploads.</summary>
         public string UploadDirectory { get; }
+
+        /// <summary>
+        /// Per-file cap in bytes on client-originated upload-directory writes,
+        /// from <c>--upload-max-mb</c> / <c>TS_UPLOAD_MAX_MB</c>. Defaults to
+        /// the 500 MB request-body limit, i.e. no additional restriction.
+        /// </summary>
+        public long UploadMaxFileBytes { get; }
+
+        /// <summary>
+        /// Total upload-directory budget in bytes, from <c>--upload-quota-mb</c>
+        /// / <c>TS_UPLOAD_QUOTA_MB</c>. 0 (the default) disables the quota.
+        /// </summary>
+        public long UploadQuotaBytes { get; }
+
+        /// <summary>
+        /// Age after which upload-directory files are deleted, from
+        /// <c>--upload-ttl-hours</c> / <c>TS_UPLOAD_TTL_HOURS</c>. Null (the
+        /// default) disables cleanup: chat sessions reference attachments by
+        /// path and may legitimately reuse them much later.
+        /// </summary>
+        public TimeSpan? UploadTtl { get; }
 
         /// <summary>Resolved log directory (used by the file logger when it is enabled).</summary>
         public string LogDirectory { get; }

--- a/TensorSharp.Server/Hosting/ServerOptionsBuilder.cs
+++ b/TensorSharp.Server/Hosting/ServerOptionsBuilder.cs
@@ -42,6 +42,7 @@ namespace TensorSharp.Server.Hosting
                 out SamplingOverrides configuredSampling,
                 out SamplingPrecedence? configuredPrecedence,
                 out ListenOverrides configuredListen,
+                out UploadLimitOverrides configuredUploads,
                 out bool configuredNoWebUi);
 
             if (!string.IsNullOrWhiteSpace(configuredMmProj) && string.IsNullOrWhiteSpace(configuredModel))
@@ -88,6 +89,12 @@ namespace TensorSharp.Server.Hosting
 
             string listenUrls = ResolveListenUrls(configuredListen);
 
+            long uploadMaxFileBytes = ResolveUploadMb(
+                configuredUploads.MaxFileMb, "TS_UPLOAD_MAX_MB", UploadStoragePolicy.DefaultMaxFileBytes);
+            long uploadQuotaBytes = ResolveUploadMb(
+                configuredUploads.QuotaMb, "TS_UPLOAD_QUOTA_MB", 0);
+            TimeSpan? uploadTtl = ResolveUploadTtl(configuredUploads.TtlHours, "TS_UPLOAD_TTL_HOURS");
+
             // TS_NO_WEBUI follows the TENSORSHARP_LOG_FILE convention: set to
             // anything but "0" counts as on.
             string noWebUiEnv = Environment.GetEnvironmentVariable("TS_NO_WEBUI");
@@ -108,14 +115,49 @@ namespace TensorSharp.Server.Hosting
                 fileLoggingEnabled,
                 defaultSampling,
                 listenUrls,
+                uploadMaxFileBytes,
+                uploadQuotaBytes,
+                uploadTtl,
                 webUiEnabled);
         }
 
         /// <summary>Backend originally requested via <c>--backend</c> / <c>BACKEND</c> (without the OS-default fallback).</summary>
         public static string ReadConfiguredBackendInput(string[] args)
         {
-            ParseArgs(args, out _, out _, out string configuredBackend, out _, out _, out _, out _, out _, out _, out _);
+            ParseArgs(args, out _, out _, out string configuredBackend, out _, out _, out _, out _, out _, out _, out _, out _);
             return configuredBackend ?? Environment.GetEnvironmentVariable("BACKEND");
+        }
+
+        /// <summary>Upload storage-limit overrides captured from the CLI (see <see cref="UploadStoragePolicy"/>).</summary>
+        private struct UploadLimitOverrides
+        {
+            public int? MaxFileMb;
+            public int? QuotaMb;
+            public double? TtlHours;
+        }
+
+        /// <summary>Resolve one MB-denominated upload limit: CLI flag, then env var, then <paramref name="fallbackBytes"/>.</summary>
+        private static long ResolveUploadMb(int? cliMb, string envVar, long fallbackBytes)
+        {
+            if (cliMb.HasValue)
+                return cliMb.Value * 1024L * 1024L;
+            if (TryReadEnvInt(envVar, out int envMb) && envMb > 0)
+                return envMb * 1024L * 1024L;
+            return fallbackBytes;
+        }
+
+        private static TimeSpan? ResolveUploadTtl(double? cliHours, string envVar)
+        {
+            if (cliHours.HasValue)
+                return TimeSpan.FromHours(cliHours.Value);
+            string raw = Environment.GetEnvironmentVariable(envVar);
+            if (!string.IsNullOrWhiteSpace(raw)
+                && double.TryParse(raw.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double hours)
+                && hours > 0)
+            {
+                return TimeSpan.FromHours(hours);
+            }
+            return null;
         }
 
         /// <summary>Listen address overrides captured from the CLI.</summary>
@@ -806,6 +848,7 @@ namespace TensorSharp.Server.Hosting
             out SamplingOverrides configuredSampling,
             out SamplingPrecedence? configuredPrecedence,
             out ListenOverrides configuredListen,
+            out UploadLimitOverrides configuredUploads,
             out bool configuredNoWebUi)
         {
             configuredModel = null;
@@ -817,6 +860,7 @@ namespace TensorSharp.Server.Hosting
             configuredSampling = default;
             configuredPrecedence = null;
             configuredListen = default;
+            configuredUploads = default;
             configuredNoWebUi = false;
 
             for (int i = 0; i < args.Length; i++)
@@ -959,9 +1003,39 @@ namespace TensorSharp.Server.Hosting
                     continue;
                 }
 
+                if (TryReadOption(args, ref i, "--upload-max-mb", out string uploadMaxOption))
+                {
+                    if (!TryParsePositiveInt(uploadMaxOption, out int parsedUploadMax))
+                        throw new ArgumentException(
+                            $"Invalid value for --upload-max-mb: '{uploadMaxOption}'. Expected a positive number of megabytes.");
+                    configuredUploads.MaxFileMb = parsedUploadMax;
+                    continue;
+                }
+
+                if (TryReadOption(args, ref i, "--upload-quota-mb", out string uploadQuotaOption))
+                {
+                    if (!TryParsePositiveInt(uploadQuotaOption, out int parsedUploadQuota))
+                        throw new ArgumentException(
+                            $"Invalid value for --upload-quota-mb: '{uploadQuotaOption}'. Expected a positive number of megabytes.");
+                    configuredUploads.QuotaMb = parsedUploadQuota;
+                    continue;
+                }
+
                 if (string.Equals(args[i], "--no-webui", StringComparison.OrdinalIgnoreCase))
                 {
                     configuredNoWebUi = true;
+                    continue;
+                }
+
+                if (TryReadOption(args, ref i, "--upload-ttl-hours", out string uploadTtlOption))
+                {
+                    if (!double.TryParse(uploadTtlOption, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsedTtlHours)
+                        || parsedTtlHours <= 0)
+                    {
+                        throw new ArgumentException(
+                            $"Invalid value for --upload-ttl-hours: '{uploadTtlOption}'. Expected a positive number of hours.");
+                    }
+                    configuredUploads.TtlHours = parsedTtlHours;
                     continue;
                 }
 
@@ -1137,6 +1211,7 @@ namespace TensorSharp.Server.Hosting
                 "--offload-cpu",
                 "--kv-cache-dtype", "--gpu-device", "--list-gpus", "--help",
                 "--tp", "--tp-node-id", "--tp-peers",
+                "--upload-max-mb", "--upload-quota-mb", "--upload-ttl-hours",
                 "--config",
             };
             string best = null;

--- a/TensorSharp.Server/Hosting/ServerUsage.cs
+++ b/TensorSharp.Server/Hosting/ServerUsage.cs
@@ -328,6 +328,24 @@ namespace TensorSharp.Server.Hosting
                     "also auto-resolves the second high/low-noise expert GGUF by name (TS_WAN_DIT2).",
                     "--wan-te umt5-xxl-encoder-Q8_0.gguf"),
             }),
+            ("Upload storage (the uploads/ directory next to the server binary)", new[]
+            {
+                new OptionHelp("--upload-max-mb <N>",
+                    "Per-file cap in MB on client-originated writes: multipart /api/upload files and base64 " +
+                    "attachments decoded out of chat requests. Default: 500, the request-body limit " +
+                    "(TS_UPLOAD_MAX_MB env var overrides).",
+                    "--upload-max-mb 25"),
+                new OptionHelp("--upload-quota-mb <N>",
+                    "Total budget in MB for the upload directory, counting client uploads, decoded attachments, " +
+                    "and generated outputs (edited images, videos). Requests that would exceed it are rejected " +
+                    "up front — before any model work runs. Default: off (TS_UPLOAD_QUOTA_MB env var overrides).",
+                    "--upload-quota-mb 2048"),
+                new OptionHelp("--upload-ttl-hours <N>",
+                    "Delete upload-directory files older than this many hours (fractions allowed). Default: off, " +
+                    "because chat sessions reference attachments by path and may reuse them later; enable it when " +
+                    "the server is reachable by untrusted clients (TS_UPLOAD_TTL_HOURS env var overrides).",
+                    "--upload-ttl-hours 24"),
+            }),
             ("Configuration file", new[]
             {
                 new OptionHelp("--config <path>",

--- a/TensorSharp.Server/Hosting/UploadCleanupService.cs
+++ b/TensorSharp.Server/Hosting/UploadCleanupService.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TensorSharp.Runtime.Logging;
+
+namespace TensorSharp.Server.Hosting
+{
+    /// <summary>
+    /// Periodic sweep behind <c>--upload-ttl-hours</c>: deletes upload-directory
+    /// files older than the TTL via <see cref="UploadStoragePolicy.CleanupExpired"/>.
+    /// Registered only when a TTL is configured. The sweep interval is TTL/4
+    /// clamped to [1, 15] minutes, so short TTLs stay timely without a hot loop;
+    /// one sweep also runs at startup to clear files that expired while the
+    /// server was down.
+    /// </summary>
+    internal sealed class UploadCleanupService : BackgroundService
+    {
+        private readonly UploadStoragePolicy _uploads;
+        private readonly ILogger _logger;
+
+        public UploadCleanupService(UploadStoragePolicy uploads, ILoggerFactory loggerFactory)
+        {
+            _uploads = uploads ?? throw new ArgumentNullException(nameof(uploads));
+            _logger = loggerFactory.CreateLogger("TensorSharp.Server.UploadCleanup");
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (_uploads.Ttl is not TimeSpan ttl)
+                return;
+
+            var period = TimeSpan.FromMinutes(Math.Clamp(ttl.TotalMinutes / 4, 1, 15));
+            using var timer = new PeriodicTimer(period);
+            try
+            {
+                do
+                {
+                    int deleted = _uploads.CleanupExpired(out long freedBytes);
+                    if (deleted > 0)
+                    {
+                        _logger.LogInformation(LogEventIds.UploadCleanup,
+                            "Upload TTL sweep: deleted {Deleted} file(s) older than {TtlHours:0.##} h, freed {FreedMB} MB ({UsedMB} MB in use)",
+                            deleted, ttl.TotalHours, freedBytes / (1024 * 1024), _uploads.UsedBytes / (1024 * 1024));
+                    }
+                }
+                while (await timer.WaitForNextTickAsync(stoppingToken));
+            }
+            catch (OperationCanceledException)
+            {
+                // Host shutdown.
+            }
+        }
+    }
+}

--- a/TensorSharp.Server/Hosting/UploadStoragePolicy.cs
+++ b/TensorSharp.Server/Hosting/UploadStoragePolicy.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+
+namespace TensorSharp.Server.Hosting
+{
+    /// <summary>
+    /// Enforces the operator-configured storage limits on the upload directory:
+    /// a per-file cap on client-originated writes (<c>--upload-max-mb</c>), a
+    /// total directory budget (<c>--upload-quota-mb</c>), and a file age limit
+    /// (<c>--upload-ttl-hours</c>). Usage is an in-memory tally seeded by one
+    /// directory scan at construction; admission reserves bytes up front so
+    /// concurrent writes cannot overshoot the quota, and the TTL sweep returns
+    /// what it deletes. Files removed behind the server's back are only
+    /// reconciled at the next restart.
+    /// </summary>
+    internal sealed class UploadStoragePolicy
+    {
+        /// <summary>Default per-file cap; equals the Kestrel request-body limit, so it changes nothing until lowered.</summary>
+        public const long DefaultMaxFileBytes = 500L * 1024 * 1024;
+
+        private long _usedBytes;
+
+        public UploadStoragePolicy(
+            string uploadDirectory,
+            long maxFileBytes = DefaultMaxFileBytes,
+            long quotaBytes = 0,
+            TimeSpan? ttl = null)
+        {
+            if (string.IsNullOrEmpty(uploadDirectory)) throw new ArgumentNullException(nameof(uploadDirectory));
+            DirectoryPath = uploadDirectory;
+            MaxFileBytes = maxFileBytes;
+            QuotaBytes = quotaBytes;
+            Ttl = ttl;
+            _usedBytes = ScanDirectory(uploadDirectory);
+        }
+
+        /// <summary>Absolute path of the upload directory this policy governs.</summary>
+        public string DirectoryPath { get; }
+
+        /// <summary>Largest single client-originated file accepted, in bytes.</summary>
+        public long MaxFileBytes { get; }
+
+        /// <summary>Total budget for the directory in bytes; 0 disables the quota.</summary>
+        public long QuotaBytes { get; }
+
+        /// <summary>Age after which the cleanup sweep deletes a file; null disables TTL cleanup.</summary>
+        public TimeSpan? Ttl { get; }
+
+        public bool QuotaEnabled => QuotaBytes > 0;
+
+        /// <summary>Bytes currently attributed to the directory (startup scan + reservations - deletions).</summary>
+        public long UsedBytes => Interlocked.Read(ref _usedBytes);
+
+        /// <summary>
+        /// Admit a client-originated write of known size (a multipart upload or
+        /// a decoded base64 attachment) and reserve its bytes against the
+        /// quota. On failure <paramref name="statusCode"/> is 413 (file over
+        /// the per-file cap) or 507 (directory quota exhausted). A successful
+        /// reservation must be paired with <see cref="Release"/> if the write
+        /// subsequently fails.
+        /// </summary>
+        public bool TryReserveClientWrite(long bytes, out string error, out int statusCode)
+        {
+            if (bytes > MaxFileBytes)
+            {
+                error = string.Format(CultureInfo.InvariantCulture,
+                    "File is too large ({0:0.#} MB); this server accepts at most {1:0.#} MB per file.",
+                    bytes / (1024.0 * 1024.0), MaxFileBytes / (1024.0 * 1024.0));
+                statusCode = 413;
+                return false;
+            }
+
+            if (!TryReserve(bytes))
+            {
+                error = QuotaExhaustedMessage;
+                statusCode = 507;
+                return false;
+            }
+
+            error = null;
+            statusCode = 0;
+            return true;
+        }
+
+        /// <summary>
+        /// <see cref="TryReserveClientWrite"/> as a throw, for the base64
+        /// materialisation paths inside the chat parsers where a status code
+        /// cannot be returned; adapters translate the exception into their
+        /// protocol's error shape.
+        /// </summary>
+        public void ReserveClientWriteOrThrow(long bytes)
+        {
+            if (!TryReserveClientWrite(bytes, out string error, out int statusCode))
+                throw new UploadLimitExceededException(error, statusCode);
+        }
+
+        /// <summary>Return a reservation whose write failed (or whose file was removed).</summary>
+        public void Release(long bytes) => Interlocked.Add(ref _usedBytes, -bytes);
+
+        /// <summary>
+        /// Gate for requests that generate output files of unknown size (image
+        /// edits, videos). Checked at request start so a full directory fails
+        /// in milliseconds instead of after minutes of GPU work; the produced
+        /// bytes are counted afterwards via <see cref="RecordFile"/>, so a
+        /// request admitted with little headroom can finish slightly over
+        /// budget rather than being killed mid-generation.
+        /// </summary>
+        public bool HasQuotaHeadroom(out string error)
+        {
+            if (QuotaEnabled && Interlocked.Read(ref _usedBytes) >= QuotaBytes)
+            {
+                error = QuotaExhaustedMessage;
+                return false;
+            }
+            error = null;
+            return true;
+        }
+
+        /// <summary>Count a file written outside the reservation path (generated output, extracted frame). Missing paths are ignored.</summary>
+        public void RecordFile(string path)
+        {
+            var info = new FileInfo(path);
+            if (info.Exists)
+                Interlocked.Add(ref _usedBytes, info.Length);
+        }
+
+        public void RecordFiles(IEnumerable<string> paths)
+        {
+            foreach (string path in paths)
+                RecordFile(path);
+        }
+
+        /// <summary>
+        /// Delete files whose last write is older than <see cref="Ttl"/>.
+        /// Files that cannot be deleted (in use, permissions) are left for the
+        /// next sweep. No-op when no TTL is configured. Returns the number of
+        /// files deleted; <paramref name="freedBytes"/> reports their total size.
+        /// </summary>
+        public int CleanupExpired(out long freedBytes)
+        {
+            freedBytes = 0;
+            if (Ttl is not TimeSpan ttl)
+                return 0;
+
+            DateTime cutoffUtc = DateTime.UtcNow - ttl;
+            int deleted = 0;
+            foreach (string path in Directory.EnumerateFiles(DirectoryPath))
+            {
+                try
+                {
+                    var info = new FileInfo(path);
+                    if (!info.Exists || info.LastWriteTimeUtc >= cutoffUtc)
+                        continue;
+                    long length = info.Length;
+                    info.Delete();
+                    Interlocked.Add(ref _usedBytes, -length);
+                    freedBytes += length;
+                    deleted++;
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    // Locked or in use; retried on the next sweep.
+                }
+            }
+            return deleted;
+        }
+
+        private bool TryReserve(long bytes)
+        {
+            if (!QuotaEnabled)
+            {
+                Interlocked.Add(ref _usedBytes, bytes);
+                return true;
+            }
+
+            while (true)
+            {
+                long used = Interlocked.Read(ref _usedBytes);
+                if (used + bytes > QuotaBytes)
+                    return false;
+                if (Interlocked.CompareExchange(ref _usedBytes, used + bytes, used) == used)
+                    return true;
+            }
+        }
+
+        // Deliberately does not disclose the configured budget: the quota is
+        // operator configuration a client cannot act on, and its size is a
+        // config detail unauthenticated clients have no need to learn. The
+        // number is in the startup "Upload storage limits" log line. The
+        // per-file cap IS stated in its 413 message, because that one is
+        // client-actionable (shrink the file and retry).
+        private const string QuotaExhaustedMessage =
+            "Upload storage quota exceeded; the server cannot accept more uploads until space is freed.";
+
+        private static long ScanDirectory(string directory)
+        {
+            long total = 0;
+            if (!Directory.Exists(directory))
+                return 0;
+            // Every server write site targets the directory root, so the scan
+            // is deliberately non-recursive.
+            foreach (string path in Directory.EnumerateFiles(directory))
+            {
+                try { total += new FileInfo(path).Length; }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
+            }
+            return total;
+        }
+    }
+
+    /// <summary>
+    /// Thrown by <see cref="UploadStoragePolicy.ReserveClientWriteOrThrow"/>
+    /// when a decoded attachment violates an upload limit. Carries the HTTP
+    /// status (413 or 507) the adapter should answer with.
+    /// </summary>
+    internal sealed class UploadLimitExceededException : Exception
+    {
+        public UploadLimitExceededException(string message, int statusCode) : base(message)
+        {
+            StatusCode = statusCode;
+        }
+
+        public int StatusCode { get; }
+    }
+}

--- a/TensorSharp.Server/Program.cs
+++ b/TensorSharp.Server/Program.cs
@@ -123,6 +123,16 @@ builder.Services.Configure<FormOptions>(options =>
 });
 
 builder.Services.AddSingleton(hostingOptions);
+// Constructed eagerly: the constructor scans the upload directory once so the
+// quota tally starts from what is already on disk.
+var uploadPolicy = new UploadStoragePolicy(
+    hostingOptions.UploadDirectory,
+    hostingOptions.UploadMaxFileBytes,
+    hostingOptions.UploadQuotaBytes,
+    hostingOptions.UploadTtl);
+builder.Services.AddSingleton(uploadPolicy);
+if (hostingOptions.UploadTtl.HasValue)
+    builder.Services.AddHostedService<UploadCleanupService>();
 builder.Services.AddSingleton<ModelService>();
 builder.Services.AddSingleton<InferenceQueue>();
 builder.Services.AddSingleton<SessionManager>();
@@ -238,6 +248,18 @@ if (qwenImageFlagsApplied)
         Environment.GetEnvironmentVariable("TS_QWEN_IMAGE_VAE") ?? "(scan)",
         Environment.GetEnvironmentVariable("TS_QWEN_IMAGE_TE") ?? "(scan)",
         Environment.GetEnvironmentVariable("TS_QWEN_IMAGE_MMPROJ") ?? "(scan)");
+}
+
+if (hostingOptions.UploadMaxFileBytes != UploadStoragePolicy.DefaultMaxFileBytes
+    || uploadPolicy.QuotaEnabled
+    || hostingOptions.UploadTtl.HasValue)
+{
+    startupLogger.LogInformation(LogEventIds.HostConfiguration,
+        "Upload storage limits: maxFileMB={MaxFileMB} quotaMB={QuotaMB} ttlHours={TtlHours} usedMB={UsedMB}",
+        hostingOptions.UploadMaxFileBytes / (1024 * 1024),
+        uploadPolicy.QuotaEnabled ? (hostingOptions.UploadQuotaBytes / (1024 * 1024)).ToString() : "(off)",
+        hostingOptions.UploadTtl.HasValue ? hostingOptions.UploadTtl.Value.TotalHours.ToString("0.##") : "(off)",
+        uploadPolicy.UsedBytes / (1024 * 1024));
 }
 
 StartupBanner.EmitBackendFallback(startupLogger, hostingOptions, configuredBackendInput);

--- a/TensorSharp.Server/ProtocolAdapters/OllamaAdapter.cs
+++ b/TensorSharp.Server/ProtocolAdapters/OllamaAdapter.cs
@@ -41,17 +41,20 @@ namespace TensorSharp.Server.ProtocolAdapters
         private readonly ModelService _svc;
         private readonly InferenceQueue _queue;
         private readonly ServerHostingOptions _options;
+        private readonly UploadStoragePolicy _uploads;
         private readonly ILoggerFactory _loggerFactory;
 
         public OllamaAdapter(
             ModelService svc,
             InferenceQueue queue,
             ServerHostingOptions options,
+            UploadStoragePolicy uploads,
             ILoggerFactory loggerFactory)
         {
             _svc = svc ?? throw new ArgumentNullException(nameof(svc));
             _queue = queue ?? throw new ArgumentNullException(nameof(queue));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _uploads = uploads ?? throw new ArgumentNullException(nameof(uploads));
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         }
 
@@ -142,7 +145,19 @@ namespace TensorSharp.Server.ProtocolAdapters
                     ? SamplingConfigParser.ReadRequestedMaxTokens(opts, "num_predict")
                     : null);
 
-            var imagePaths = ChatMessageParser.DecodeBase64Images(body, _options.UploadDirectory);
+            List<string> imagePaths;
+            try
+            {
+                imagePaths = ChatMessageParser.DecodeBase64Images(body, _uploads);
+            }
+            catch (UploadLimitExceededException ex)
+            {
+                generateLogger.LogWarning(LogEventIds.UploadRejected,
+                    "/api/generate attachment rejected: {Reason}", ex.Message);
+                ctx.Response.StatusCode = ex.StatusCode;
+                await ctx.Response.WriteAsJsonAsync(new { error = ex.Message });
+                return;
+            }
 
             generateLogger.LogInformation(LogEventIds.ChatStarted,
                 "/api/generate request: model={Model} stream={Stream} maxTokens={MaxTokens} images={ImageCount} promptChars={PromptLength} prompt=\"{Prompt}\"",
@@ -286,7 +301,19 @@ namespace TensorSharp.Server.ProtocolAdapters
                     ? SamplingConfigParser.ReadRequestedMaxTokens(opts, "num_predict")
                     : null);
 
-            var messages = ChatMessageParser.ParseOllama(messagesEl, _options.UploadDirectory);
+            List<ChatMessage> messages;
+            try
+            {
+                messages = ChatMessageParser.ParseOllama(messagesEl, _uploads);
+            }
+            catch (UploadLimitExceededException ex)
+            {
+                ollamaLogger.LogWarning(LogEventIds.UploadRejected,
+                    "/api/chat/ollama attachment rejected: {Reason}", ex.Message);
+                ctx.Response.StatusCode = ex.StatusCode;
+                await ctx.Response.WriteAsJsonAsync(new { error = ex.Message });
+                return;
+            }
             var ollamaTools = ToolFunctionParser.ParseOllama(body);
             bool ollamaThink = body.TryGetProperty("think", out var thinkProp) && thinkProp.GetBoolean();
 

--- a/TensorSharp.Server/ProtocolAdapters/OpenAIChatAdapter.cs
+++ b/TensorSharp.Server/ProtocolAdapters/OpenAIChatAdapter.cs
@@ -42,17 +42,20 @@ namespace TensorSharp.Server.ProtocolAdapters
         private readonly ModelService _svc;
         private readonly InferenceQueue _queue;
         private readonly ServerHostingOptions _options;
+        private readonly UploadStoragePolicy _uploads;
         private readonly ILoggerFactory _loggerFactory;
 
         public OpenAIChatAdapter(
             ModelService svc,
             InferenceQueue queue,
             ServerHostingOptions options,
+            UploadStoragePolicy uploads,
             ILoggerFactory loggerFactory)
         {
             _svc = svc ?? throw new ArgumentNullException(nameof(svc));
             _queue = queue ?? throw new ArgumentNullException(nameof(queue));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _uploads = uploads ?? throw new ArgumentNullException(nameof(uploads));
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         }
 
@@ -104,7 +107,27 @@ namespace TensorSharp.Server.ProtocolAdapters
             int maxTokens = _options.ResolveMaxTokens(
                 SamplingConfigParser.ReadRequestedMaxTokens(body, "max_tokens", "max_completion_tokens"));
             var samplingConfig = SamplingConfigParser.ParseOpenAI(body, _options.SamplingDefaults);
-            var messages = ChatMessageParser.ParseOpenAI(messagesEl, _options.UploadDirectory);
+            List<ChatMessage> messages;
+            try
+            {
+                messages = ChatMessageParser.ParseOpenAI(messagesEl, _uploads);
+            }
+            catch (UploadLimitExceededException ex)
+            {
+                openaiLogger.LogWarning(LogEventIds.UploadRejected,
+                    "/v1/chat/completions attachment rejected: {Reason}", ex.Message);
+                ctx.Response.StatusCode = ex.StatusCode;
+                await ctx.Response.WriteAsJsonAsync(new
+                {
+                    error = new
+                    {
+                        message = ex.Message,
+                        // 413 (file over the cap) is the client's doing; 507 (quota) is server state.
+                        type = ex.StatusCode == 413 ? "invalid_request_error" : "server_error",
+                    },
+                });
+                return;
+            }
             string requestId = OpenAIResponseFactory.NewRequestId();
 
             var openaiTools = ToolFunctionParser.ParseOpenAI(body);

--- a/TensorSharp.Server/ProtocolAdapters/OpenAIResponsesAdapter.cs
+++ b/TensorSharp.Server/ProtocolAdapters/OpenAIResponsesAdapter.cs
@@ -39,6 +39,7 @@ namespace TensorSharp.Server.ProtocolAdapters
         private readonly ModelService _svc;
         private readonly InferenceQueue _queue;
         private readonly ServerHostingOptions _options;
+        private readonly UploadStoragePolicy _uploads;
         private readonly ILoggerFactory _loggerFactory;
         private readonly IResponsesStore _store;
 
@@ -46,12 +47,14 @@ namespace TensorSharp.Server.ProtocolAdapters
             ModelService svc,
             InferenceQueue queue,
             ServerHostingOptions options,
+            UploadStoragePolicy uploads,
             ILoggerFactory loggerFactory,
             IResponsesStore store)
         {
             _svc = svc ?? throw new ArgumentNullException(nameof(svc));
             _queue = queue ?? throw new ArgumentNullException(nameof(queue));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _uploads = uploads ?? throw new ArgumentNullException(nameof(uploads));
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _store = store ?? throw new ArgumentNullException(nameof(store));
         }
@@ -110,7 +113,18 @@ namespace TensorSharp.Server.ProtocolAdapters
             int maxOutputTokens = _options.ResolveMaxTokens(requestedOutputTokens);
 
             var samplingConfig = SamplingConfigParser.ParseOpenAI(body, _options.SamplingDefaults);
-            var messages = ChatMessageParser.ParseResponsesInput(inputEl, instructions, _options.UploadDirectory);
+            List<ChatMessage> messages;
+            try
+            {
+                messages = ChatMessageParser.ParseResponsesInput(inputEl, instructions, _uploads);
+            }
+            catch (UploadLimitExceededException ex)
+            {
+                logger.LogWarning(LogEventIds.UploadRejected,
+                    "/v1/responses attachment rejected: {Reason}", ex.Message);
+                await WriteErrorAsync(ctx, ex.StatusCode, ex.Message);
+                return;
+            }
             var tools = ToolFunctionParser.ParseOpenAIResponses(body);
             bool enableThinking = body.TryGetProperty("reasoning", out var reasoningEl) && reasoningEl.ValueKind == JsonValueKind.Object;
 

--- a/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
+++ b/TensorSharp.Server/ProtocolAdapters/WebUiAdapter.cs
@@ -50,6 +50,7 @@ namespace TensorSharp.Server.ProtocolAdapters
         private readonly InferenceQueue _queue;
         private readonly SessionManager _sessions;
         private readonly ServerHostingOptions _options;
+        private readonly UploadStoragePolicy _uploads;
         private readonly ILoggerFactory _loggerFactory;
 
         public WebUiAdapter(
@@ -57,12 +58,14 @@ namespace TensorSharp.Server.ProtocolAdapters
             InferenceQueue queue,
             SessionManager sessions,
             ServerHostingOptions options,
+            UploadStoragePolicy uploads,
             ILoggerFactory loggerFactory)
         {
             _svc = svc ?? throw new ArgumentNullException(nameof(svc));
             _queue = queue ?? throw new ArgumentNullException(nameof(queue));
             _sessions = sessions ?? throw new ArgumentNullException(nameof(sessions));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _uploads = uploads ?? throw new ArgumentNullException(nameof(uploads));
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         }
 
@@ -238,6 +241,13 @@ namespace TensorSharp.Server.ProtocolAdapters
                 return Results.BadRequest(new { error = "No file uploaded" });
             }
 
+            if (!_uploads.TryReserveClientWrite(file.Length, out string limitError, out int limitStatus))
+            {
+                uploadLogger.LogWarning(LogEventIds.UploadRejected,
+                    "Upload rejected: {Reason} (name={FileName} bytes={Length})", limitError, file.FileName, file.Length);
+                return Results.Json(new { error = limitError }, statusCode: limitStatus);
+            }
+
             string ext = Path.GetExtension(file.FileName).ToLowerInvariant();
             // Classify before anything touches disk: an upload with an extension
             // outside the allow-list is rejected without ever being written, so
@@ -260,8 +270,17 @@ namespace TensorSharp.Server.ProtocolAdapters
             string savePath = Path.Combine(_options.UploadDirectory, safeFileName);
             string uploadUrl = BuildUploadUrl(safeFileName);
 
-            using (var stream = File.Create(savePath))
-                await file.CopyToAsync(stream);
+            try
+            {
+                using (var stream = File.Create(savePath))
+                    await file.CopyToAsync(stream);
+            }
+            catch
+            {
+                _uploads.Release(file.Length);
+                try { File.Delete(savePath); } catch { /* best effort */ }
+                throw;
+            }
 
             // Include the full saved path and the classified media type so this entry
             // is self-sufficient for tracing back from the per-turn chat log
@@ -273,6 +292,7 @@ namespace TensorSharp.Server.ProtocolAdapters
             if (mediaType == "video")
             {
                 var frames = MediaHelper.ExtractVideoFrames(savePath);
+                _uploads.RecordFiles(frames);
                 return Results.Json(new
                 {
                     ok = true,
@@ -409,6 +429,8 @@ namespace TensorSharp.Server.ProtocolAdapters
                     return Results.BadRequest(new { ok = false, error = "Could not read the PDF: " + ex.Message });
                 }
 
+                _uploads.RecordFiles(pdfImages.ImagePaths);
+
                 if (pdfImages.ImagePaths.Count == 0)
                 {
                     uploadLogger.LogWarning(LogEventIds.UploadReceived,
@@ -485,6 +507,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                             img = TensorSharp.Models.QwenImage.ImageIO.ResizeToArea(img, previewArea, multiple: 1);
                         TensorSharp.Models.QwenImage.ImageIO.SavePng(previewPath, img);
                     });
+                    _uploads.RecordFile(previewPath);
                     return Results.Json(new
                     {
                         ok = true,
@@ -522,6 +545,14 @@ namespace TensorSharp.Server.ProtocolAdapters
             var logger = _loggerFactory.CreateLogger("TensorSharp.Server.ImageEdit");
             if (_svc.Model is not TensorSharp.Models.QwenImage.QwenImageModel editModel)
                 return Results.BadRequest(new { error = "The loaded model is not a Qwen-Image-Edit model." });
+
+            // Fail before the (slow) diffusion runs, not after: the result PNG
+            // has nowhere to go once the upload quota is exhausted.
+            if (!_uploads.HasQuotaHeadroom(out string editQuotaError))
+            {
+                logger.LogWarning(LogEventIds.UploadRejected, "Image edit rejected: {Reason}", editQuotaError);
+                return Results.Json(new { error = editQuotaError }, statusCode: 507);
+            }
 
             string prompt; int steps; float cfg; long seed; long targetArea = 0;
             var imageBytesList = new List<byte[]>();
@@ -585,6 +616,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                 }
             });
             sw.Stop();
+            _uploads.RecordFile(outPath);
 
             string url = BuildUploadUrl(outName);
             logger.LogInformation(LogEventIds.UploadReceived,
@@ -666,6 +698,12 @@ namespace TensorSharp.Server.ProtocolAdapters
             if (imgError != null)
                 return Results.BadRequest(new { error = imgError });
 
+            if (!_uploads.HasQuotaHeadroom(out string videoQuotaError))
+            {
+                logger.LogWarning(LogEventIds.UploadRejected, "Video generate rejected: {Reason}", videoQuotaError);
+                return Results.Json(new { error = videoQuotaError }, statusCode: 507);
+            }
+
             string outName = $"video-{Guid.NewGuid():N}.mp4";
             string outPath = Path.Combine(_options.UploadDirectory, outName);
             logger.LogInformation(LogEventIds.UploadReceived,
@@ -683,6 +721,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                 }
             });
             sw.Stop();
+            _uploads.RecordFile(outPath);
 
             string url = BuildUploadUrl(outName);
             logger.LogInformation(LogEventIds.UploadReceived,
@@ -718,6 +757,13 @@ namespace TensorSharp.Server.ProtocolAdapters
             var p = ParseVideoParams(root, out string imgError);
             if (imgError != null)
                 return Results.BadRequest(new { error = new { message = imgError, type = "invalid_request_error" } });
+
+            if (!_uploads.HasQuotaHeadroom(out string oaiVideoQuotaError))
+            {
+                logger.LogWarning(LogEventIds.UploadRejected, "OpenAI video generation rejected: {Reason}", oaiVideoQuotaError);
+                return Results.Json(new { error = new { message = oaiVideoQuotaError, type = "server_error" } }, statusCode: 507);
+            }
+
             if (root.TryGetProperty("size", out var sz) && sz.ValueKind == JsonValueKind.String)
             {
                 var parts = (sz.GetString() ?? "").Split('x');
@@ -745,6 +791,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                 }
             });
             sw.Stop();
+            _uploads.RecordFile(outPath);
 
             string url = BuildUploadUrl(outName);
             logger.LogInformation(LogEventIds.UploadReceived,
@@ -808,6 +855,13 @@ namespace TensorSharp.Server.ProtocolAdapters
                 return;
             }
 
+            if (!_uploads.HasQuotaHeadroom(out string videoStreamQuotaError))
+            {
+                logger.LogWarning(LogEventIds.UploadRejected, "Video generate (stream) rejected: {Reason}", videoStreamQuotaError);
+                await SseWriter.WriteEventAsync(ctx.Response, new { done = true, error = videoStreamQuotaError }, ct);
+                return;
+            }
+
             string outName = $"video-{Guid.NewGuid():N}.mp4";
             string outPath = Path.Combine(_options.UploadDirectory, outName);
             logger.LogInformation(LogEventIds.UploadReceived,
@@ -840,6 +894,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                         });
                         var video = videoModel.GenerateVideo(prompt, p);
                         string codec = TensorSharp.Models.WanVideo.VideoIO.SaveMp4(outPath, video.Frames, video.Fps);
+                        _uploads.RecordFile(outPath);
                         channel.Writer.TryWrite(new VideoFrame
                         {
                             Final = true, Url = BuildUploadUrl(outName),
@@ -926,6 +981,13 @@ namespace TensorSharp.Server.ProtocolAdapters
                 return;
             }
 
+            if (!_uploads.HasQuotaHeadroom(out string editStreamQuotaError))
+            {
+                logger.LogWarning(LogEventIds.UploadRejected, "Image edit (stream) rejected: {Reason}", editStreamQuotaError);
+                await SseWriter.WriteEventAsync(ctx.Response, new { done = true, error = editStreamQuotaError }, ct);
+                return;
+            }
+
             // Parse the Web UI JSON body (mirrors the JSON branch of ImageEditAsync).
             string prompt; int steps; float cfg; long seed; long targetArea = 0;
             var imageBytesList = new List<byte[]>();
@@ -1004,6 +1066,7 @@ namespace TensorSharp.Server.ProtocolAdapters
                         if (targetArea > 0) p.TargetArea = targetArea;
                         var output = editModel.EditImage(prompt, inputs, p);
                         TensorSharp.Models.QwenImage.ImageIO.SavePng(outPath, output);
+                        _uploads.RecordFile(outPath);
                         channel.Writer.TryWrite(new EditFrame
                         {
                             Final = true, Url = BuildUploadUrl(outName),

--- a/TensorSharp.Server/RequestParsers/ChatMessageParser.cs
+++ b/TensorSharp.Server/RequestParsers/ChatMessageParser.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using TensorSharp.Models;
+using TensorSharp.Server.Hosting;
 
 namespace TensorSharp.Server.RequestParsers
 {
@@ -109,7 +110,7 @@ namespace TensorSharp.Server.RequestParsers
         /// base64 array under <c>"images"</c>; we materialise each one as a PNG
         /// in the upload directory and reference them by absolute path.
         /// </summary>
-        public static List<ChatMessage> ParseOllama(JsonElement messagesEl, string uploadDir)
+        public static List<ChatMessage> ParseOllama(JsonElement messagesEl, UploadStoragePolicy uploads)
         {
             var messages = new List<ChatMessage>();
             foreach (var msgEl in messagesEl.EnumerateArray())
@@ -129,7 +130,7 @@ namespace TensorSharp.Server.RequestParsers
                         if (string.IsNullOrEmpty(b64))
                             continue;
 
-                        string path = WriteBase64Image(b64, uploadDir);
+                        string path = WriteBase64Image(b64, uploads);
                         msg.ImagePaths.Add(path);
                     }
                 }
@@ -144,7 +145,7 @@ namespace TensorSharp.Server.RequestParsers
         /// either a plain string content, or an array of parts where each part
         /// is either text or an image (data URL or external URL).
         /// </summary>
-        public static List<ChatMessage> ParseOpenAI(JsonElement messagesEl, string uploadDir)
+        public static List<ChatMessage> ParseOpenAI(JsonElement messagesEl, UploadStoragePolicy uploads)
         {
             var messages = new List<ChatMessage>();
             foreach (var msgEl in messagesEl.EnumerateArray())
@@ -182,7 +183,7 @@ namespace TensorSharp.Server.RequestParsers
                                     if (commaIdx > 0)
                                     {
                                         string b64 = url.Substring(commaIdx + 1);
-                                        string path = WriteBase64Image(b64, uploadDir);
+                                        string path = WriteBase64Image(b64, uploads);
                                         msg.ImagePaths.Add(path);
                                     }
                                 }
@@ -193,7 +194,7 @@ namespace TensorSharp.Server.RequestParsers
                                 string path = WriteBase64Audio(
                                     audioEl.TryGetProperty("data", out var aData) ? aData.GetString() : null,
                                     audioEl.TryGetProperty("format", out var aFmt) ? aFmt.GetString() : null,
-                                    uploadDir);
+                                    uploads);
                                 if (path != null)
                                     msg.AudioPaths.Add(path);
                             }
@@ -203,7 +204,7 @@ namespace TensorSharp.Server.RequestParsers
                                 string url = audioUrl.ValueKind == JsonValueKind.String
                                     ? audioUrl.GetString()
                                     : (audioUrl.TryGetProperty("url", out var au) ? au.GetString() : null);
-                                string path = WriteBase64AudioDataUri(url, uploadDir);
+                                string path = WriteBase64AudioDataUri(url, uploads);
                                 if (path != null)
                                     msg.AudioPaths.Add(path);
                             }
@@ -217,7 +218,7 @@ namespace TensorSharp.Server.RequestParsers
 
                 // Message-level base64 audio array (the same shorthand Ollama uses
                 // for images), accepted alongside the OpenAI content-part form.
-                AppendMessageLevelAudios(msgEl, msg, uploadDir);
+                AppendMessageLevelAudios(msgEl, msg, uploads);
 
                 messages.Add(msg);
             }
@@ -232,7 +233,7 @@ namespace TensorSharp.Server.RequestParsers
         /// string is prepended as a system message, matching how the real API
         /// folds it into the model's system prompt.
         /// </summary>
-        public static List<ChatMessage> ParseResponsesInput(JsonElement inputEl, string instructions, string uploadDir)
+        public static List<ChatMessage> ParseResponsesInput(JsonElement inputEl, string instructions, UploadStoragePolicy uploads)
         {
             var messages = new List<ChatMessage>();
 
@@ -294,7 +295,7 @@ namespace TensorSharp.Server.RequestParsers
                             string audioPath = WriteBase64Audio(
                                 audioEl.TryGetProperty("data", out var aData) ? aData.GetString() : null,
                                 audioEl.TryGetProperty("format", out var aFmt) ? aFmt.GetString() : null,
-                                uploadDir);
+                                uploads);
                             if (audioPath != null)
                                 msg.AudioPaths.Add(audioPath);
                         }
@@ -309,7 +310,7 @@ namespace TensorSharp.Server.RequestParsers
                                 if (commaIdx > 0)
                                 {
                                     string b64 = url.Substring(commaIdx + 1);
-                                    msg.ImagePaths.Add(WriteBase64Image(b64, uploadDir));
+                                    msg.ImagePaths.Add(WriteBase64Image(b64, uploads));
                                 }
                             }
                         }
@@ -331,7 +332,7 @@ namespace TensorSharp.Server.RequestParsers
         /// <c>/api/generate</c>. Returns null when no images are present so the
         /// downstream code path can short-circuit cleanly.
         /// </summary>
-        public static List<string> DecodeBase64Images(JsonElement body, string uploadDir)
+        public static List<string> DecodeBase64Images(JsonElement body, UploadStoragePolicy uploads)
         {
             if (!body.TryGetProperty("images", out var imgs) || imgs.ValueKind != JsonValueKind.Array)
                 return null;
@@ -343,16 +344,25 @@ namespace TensorSharp.Server.RequestParsers
                 if (string.IsNullOrEmpty(b64))
                     continue;
 
-                paths.Add(WriteBase64Image(b64, uploadDir));
+                paths.Add(WriteBase64Image(b64, uploads));
             }
             return paths.Count > 0 ? paths : null;
         }
 
-        private static string WriteBase64Image(string base64, string uploadDir)
+        private static string WriteBase64Image(string base64, UploadStoragePolicy uploads)
         {
             byte[] imgData = Convert.FromBase64String(base64);
-            string path = Path.Combine(uploadDir, $"{Guid.NewGuid():N}.png");
-            File.WriteAllBytes(path, imgData);
+            uploads.ReserveClientWriteOrThrow(imgData.Length);
+            string path = Path.Combine(uploads.DirectoryPath, $"{Guid.NewGuid():N}.png");
+            try
+            {
+                File.WriteAllBytes(path, imgData);
+            }
+            catch
+            {
+                uploads.Release(imgData.Length);
+                throw;
+            }
             return path;
         }
 
@@ -363,7 +373,7 @@ namespace TensorSharp.Server.RequestParsers
         /// mapped to one — falling back to sniffing the container header when it
         /// is missing or unrecognised. Returns null for empty/invalid content.
         /// </summary>
-        private static string WriteBase64Audio(string base64, string format, string uploadDir)
+        private static string WriteBase64Audio(string base64, string format, UploadStoragePolicy uploads)
         {
             if (string.IsNullOrWhiteSpace(base64))
                 return null;
@@ -389,16 +399,25 @@ namespace TensorSharp.Server.RequestParsers
             if (data.Length == 0)
                 return null;
 
-            string path = Path.Combine(uploadDir, $"{Guid.NewGuid():N}{AudioExtension(format, data)}");
-            File.WriteAllBytes(path, data);
+            uploads.ReserveClientWriteOrThrow(data.Length);
+            string path = Path.Combine(uploads.DirectoryPath, $"{Guid.NewGuid():N}{AudioExtension(format, data)}");
+            try
+            {
+                File.WriteAllBytes(path, data);
+            }
+            catch
+            {
+                uploads.Release(data.Length);
+                throw;
+            }
             return path;
         }
 
-        private static string WriteBase64AudioDataUri(string url, string uploadDir)
+        private static string WriteBase64AudioDataUri(string url, UploadStoragePolicy uploads)
         {
             if (string.IsNullOrEmpty(url) || !url.StartsWith("data:"))
                 return null;
-            return WriteBase64Audio(url, null, uploadDir);
+            return WriteBase64Audio(url, null, uploads);
         }
 
         private static string MimeToAudioFormat(string mimeAndParams)
@@ -440,7 +459,7 @@ namespace TensorSharp.Server.RequestParsers
         /// Read a message-level <c>"audios"</c> array of base64 clips (optionally
         /// data URIs) and append them to the message's audio attachments.
         /// </summary>
-        private static void AppendMessageLevelAudios(JsonElement msgEl, ChatMessage msg, string uploadDir)
+        private static void AppendMessageLevelAudios(JsonElement msgEl, ChatMessage msg, UploadStoragePolicy uploads)
         {
             if (!msgEl.TryGetProperty("audios", out var auds) || auds.ValueKind != JsonValueKind.Array)
                 return;
@@ -452,7 +471,7 @@ namespace TensorSharp.Server.RequestParsers
                     : (audEl.TryGetProperty("data", out var d) ? d.GetString() : null);
                 string format = audEl.ValueKind == JsonValueKind.Object &&
                                 audEl.TryGetProperty("format", out var f) ? f.GetString() : null;
-                string path = WriteBase64Audio(b64, format, uploadDir);
+                string path = WriteBase64Audio(b64, format, uploads);
                 if (path == null)
                     continue;
                 (msg.AudioPaths ??= new List<string>()).Add(path);


### PR DESCRIPTION
The upload directory grows without bound: `/api/upload` accepts up to 500MB per request from any client, multimodal chat requests materialise base64 attachments to disk, generated outputs land there too, and nothing is ever deleted — any client can fill the disk, and honest use leaks storage indefinitely.

Three knobs, **all defaulting to today's behavior** (naming follows the responses-store precedent):

- `--upload-max-mb` / `TS_UPLOAD_MAX_MB` — per-file cap on client-originated writes (multipart uploads and decoded base64 attachments), checked before bytes hit disk; defaults to 500, the existing request-body limit. Rejected with 413 stating the cap.
- `--upload-quota-mb` / `TS_UPLOAD_QUOTA_MB` — total directory budget counting client writes and server-generated outputs; a startup scan seeds an in-memory tally, client writes reserve bytes atomically, generation endpoints gate at request start. Rejected with 507 (message deliberately does not disclose the budget).
- `--upload-ttl-hours` / `TS_UPLOAD_TTL_HOURS` — background sweep deleting files older than the TTL; off by default.

Verified live (413 / 200 / 507 across upload + Ollama/OpenAI base64 attachments) and environment-independent lane 1161 passed / 0 failed on current main.
