### PR TITLE
Only madvise file-backed quantized weight views on release

### DIFF
--- a/TensorSharp.Models/ModelBase.cs
+++ b/TensorSharp.Models/ModelBase.cs
@@ -216,10 +216,16 @@ namespace TensorSharp.Models
                 return;
 
             IntPtr currentData = _data;
-            bool wasExternalView = !_ownsBuffer && _ownerToken != null;
+            // Page-out advice is only valid for views into the GgufFile mmap,
+            // where MADV_DONTNEED just drops clean file-backed pages. On views
+            // into another weight's heap buffer (per-expert views of a stacked
+            // 3D tensor, TP shard views) the same call ZEROES the anonymous
+            // pages in place — including malloc metadata of whatever else
+            // shares them — and the next free() aborts the process.
+            bool wasFileBackedView = !_ownsBuffer && _ownerToken is GgufFile;
             if (_ownsBuffer)
                 FreeBuffer(currentData);
-            else if (wasExternalView)
+            else if (wasFileBackedView)
                 AdviseExternalViewCanBePagedOut(currentData, RawBytes);
 
             if (CacheKey == currentData)


### PR DESCRIPTION
The CI lane added in #156 currently aborts on main: `GlmDsa_Quantized_MatchesLlamaCpp` crashes the test host with `free(): invalid size`, taking the whole unit-tests job down (visible on #161's checks).

`QuantizedWeight.ReleaseHostData` issues `madvise(MADV_DONTNEED)` for every external-view weight. For views into the GgufFile mmap that just drops clean file-backed pages. But the per-expert views split out of a stacked 3D `_exps` tensor on the non-mmap path point into a heap allocation, and on anonymous memory the same call zeroes the pages in place — including allocator metadata on pages the view range touches — so the process aborts in `free()` at Dispose. This affects any quantized MoE model on a backend outside the mmap allow-list; the new glm-dsa quantized test is the first CPU-lane test to hit it.

Fix: gate the advice on the owner actually being the GgufFile mmap.

Verified locally: the full `Category!=Bench&Requires!=Cuda&Requires!=Mlx&Requires!=Models` lane goes from aborting mid-run to 1197 passed / 0 failed.