### PR TITLE
This corrects a problem of resource cleanup (file deletion) in unit tests.

### DIFF
--- a/InferenceWeb.Tests/ModelReloadRollbackTests.cs
+++ b/InferenceWeb.Tests/ModelReloadRollbackTests.cs
@@ -28,7 +28,7 @@ public class ModelReloadRollbackTests : IDisposable
     public void MissingFile_IsRejectedWithCurrentModelStillLoaded()
     {
         var factory = new ScriptedFactory();
-        var svc = NewService(factory);
+        using var svc = NewService(factory);
         string pathA = WriteMinimalGguf("model-a.gguf");
         factory.Enqueue(p => new FakeModel(p));
         svc.LoadModel(pathA, null, "cpu");
@@ -47,7 +47,7 @@ public class ModelReloadRollbackTests : IDisposable
     public void NonGgufFile_IsRejectedWithCurrentModelStillLoaded()
     {
         var factory = new ScriptedFactory();
-        var svc = NewService(factory);
+        using var svc = NewService(factory);
         string pathA = WriteMinimalGguf("model-a.gguf");
         factory.Enqueue(p => new FakeModel(p));
         svc.LoadModel(pathA, null, "cpu");
@@ -66,7 +66,7 @@ public class ModelReloadRollbackTests : IDisposable
     public void TruncatedGguf_IsRejectedWithCurrentModelStillLoaded()
     {
         var factory = new ScriptedFactory();
-        var svc = NewService(factory);
+        using var svc = NewService(factory);
         string pathA = WriteMinimalGguf("model-a.gguf");
         factory.Enqueue(p => new FakeModel(p));
         svc.LoadModel(pathA, null, "cpu");
@@ -84,7 +84,7 @@ public class ModelReloadRollbackTests : IDisposable
     public void TruncatedMmProj_IsRejectedWithCurrentModelStillLoaded()
     {
         var factory = new ScriptedFactory();
-        var svc = NewService(factory);
+        using var svc = NewService(factory);
         string pathA = WriteMinimalGguf("model-a.gguf");
         factory.Enqueue(p => new FakeModel(p));
         svc.LoadModel(pathA, null, "cpu");
@@ -103,7 +103,7 @@ public class ModelReloadRollbackTests : IDisposable
     public void FailedLoad_RestoresPreviousModel()
     {
         var factory = new ScriptedFactory();
-        var svc = NewService(factory);
+        using var svc = NewService(factory);
         string pathA = WriteMinimalGguf("model-a.gguf");
         string pathB = WriteMinimalGguf("model-b.gguf");
         factory.Enqueue(p => new FakeModel(p));
@@ -162,7 +162,7 @@ public class ModelReloadRollbackTests : IDisposable
     public void SuccessfulReload_SwapsAndDisposesPreviousModel()
     {
         var factory = new ScriptedFactory();
-        var svc = NewService(factory);
+        using var svc = NewService(factory);
         string pathA = WriteMinimalGguf("model-a.gguf");
         string pathB = WriteMinimalGguf("model-b.gguf");
         factory.Enqueue(p => new FakeModel(p));

--- a/TensorSharp.Runtime/GgufReader.cs
+++ b/TensorSharp.Runtime/GgufReader.cs
@@ -91,9 +91,20 @@ namespace TensorSharp.Runtime
         {
             _path = path;
             _stream = File.OpenRead(path);
-            Parse();
-            if (!isShard)
-                OpenSiblingShards();
+            try
+            {
+                Parse();
+                if (!isShard)
+                    OpenSiblingShards();
+            }
+            catch
+            {
+                // in case of exceptions, the constructor doesn't complete and Dispose won't be called, so we need to clean up here
+                // We need to call Dispose() and not just close the stream, since the shards may have been opened and need to be disposed as well.
+                Dispose();
+                // rethrow the original exception to preserve the stack trace
+                throw;
+            }
         }
 
         /// <summary>Every file this model is stored in, starting with this one.</summary>


### PR DESCRIPTION
This corrects a problem in 6 unit tests:

- `MissingFile_IsRejectedWithCurrentModelStillLoaded`
- `SuccessfulReload_SwapsAndDisposesPreviousModel`
- `TruncatedGguf_IsRejectedWithCurrentModelStillLoaded`
- `TruncatedMmProj_IsRejectedWithCurrentModelStillLoaded`
- `FailedLoad_RestoresPreviousModel`
- `NonGgufFile_IsRejectedWithCurrentModelStillLoaded`

... which fail while executing `Directory.Delete(_dir, recursive: true)` with the error:

~~~
"System.IO.IOException: The process cannot access the file '...' because it is being used by another process"
~~~

The reason is that for all tests except `NonGgufFile_IsRejectedWithCurrentModelStillLoaded`, files are kept open by the `ModelLifecycleService`  which is not disposed in the tests. For `NonGgufFile_IsRejectedWithCurrentModelStillLoaded`, the `GgufReader` constructor might throw an exception during parsing, which causes `Dispose()` never to be called and therefore the file never to be closed.