### PR TITLE
Added support for explicit cache markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,15 @@ benchmarks/engine_comparison/__pycache__/
 benchmarks/engine_comparison/results/
 /.vs
 /TensorSharp.Server/Properties/launchSettings.json
+
+# Local model weights. GGUF/safetensors checkpoints are multi-GB and are
+# downloaded per-machine, never committed.
+models/
+*.gguf
+*.safetensors
+
+# JetBrains Rider / IntelliJ per-user project settings.
+.idea/
+
+# Local scratch prompts used when driving the CLI by hand.
+prompt.txt

--- a/InferenceWeb.Tests/ContinuousBatchSchedulerTests.cs
+++ b/InferenceWeb.Tests/ContinuousBatchSchedulerTests.cs
@@ -433,6 +433,103 @@ public class ContinuousBatchSchedulerTests
         Assert.True(seq.Status.IsFinished());
     }
 
+    [Fact]
+    public void Scheduler_ExplicitBreakpoint_RegistersOnlyBlocksInsideTheMarkedPrefix()
+    {
+        const string fingerprint = "fp-explicit-breakpoint";
+        var pool = NewPool(numBlocks: 8);
+        var sched = NewScheduler(pool, fingerprint);
+
+        // 4 full blocks of prompt, with the client marking the end of block 1.
+        int[] prompt = Enumerable.Range(1, 4 * BlockSize).ToArray();
+        var seq = new SequenceState(
+            "bp", prompt.ToList(), maxNewTokens: 1, BlockSize, SamplingConfig.Default,
+            cacheBreakpoints: new List<int> { 2 * BlockSize });
+
+        var blocks = pool.AllocateNew(4);
+        foreach (var b in blocks)
+            seq.BlockTable.AppendBlock(b);
+        seq.AdvanceComputedTokens(prompt.Length);
+
+        sched.OnBlocksCommitted(seq, previousTokens: 0);
+
+        var hashes = KvBlockHasher.ComputeBlockHashes(prompt.ToList(), BlockSize, fingerprint);
+
+        // Blocks 0 and 1 end at or before the breakpoint and are cacheable.
+        Assert.True(pool.TryFindByHash(hashes[0], out _), "Block 0 should be registered.");
+        Assert.True(pool.TryFindByHash(hashes[1], out _), "Block 1 should be registered.");
+
+        // Blocks 2 and 3 lie past it and must stay out of the index.
+        Assert.False(pool.TryFindByHash(hashes[2], out _), "Block 2 is past the breakpoint.");
+        Assert.False(pool.TryFindByHash(hashes[3], out _), "Block 3 is past the breakpoint.");
+    }
+
+    [Fact]
+    public void Scheduler_ExplicitBreakpointMidBlock_DropsTheStraddlingBlock()
+    {
+        const string fingerprint = "fp-breakpoint-midblock";
+        var pool = NewPool(numBlocks: 8);
+        var sched = NewScheduler(pool, fingerprint);
+
+        int[] prompt = Enumerable.Range(1, 3 * BlockSize).ToArray();
+        // A breakpoint halfway through block 1: the index is block-granular, so
+        // block 1 holds tokens from both sides of the mark and is not cacheable.
+        var seq = new SequenceState(
+            "bp-mid", prompt.ToList(), maxNewTokens: 1, BlockSize, SamplingConfig.Default,
+            cacheBreakpoints: new List<int> { BlockSize + (BlockSize / 2) });
+
+        var blocks = pool.AllocateNew(3);
+        foreach (var b in blocks)
+            seq.BlockTable.AppendBlock(b);
+        seq.AdvanceComputedTokens(prompt.Length);
+
+        sched.OnBlocksCommitted(seq, previousTokens: 0);
+
+        var hashes = KvBlockHasher.ComputeBlockHashes(prompt.ToList(), BlockSize, fingerprint);
+        Assert.True(pool.TryFindByHash(hashes[0], out _), "Block 0 ends before the breakpoint.");
+        Assert.False(pool.TryFindByHash(hashes[1], out _), "Block 1 straddles the breakpoint.");
+        Assert.False(pool.TryFindByHash(hashes[2], out _), "Block 2 is past the breakpoint.");
+    }
+
+    [Fact]
+    public void Scheduler_NoExplicitBreakpoints_RegistersEveryFullBlock()
+    {
+        const string fingerprint = "fp-no-breakpoint";
+        var pool = NewPool(numBlocks: 8);
+        var sched = NewScheduler(pool, fingerprint);
+
+        int[] prompt = Enumerable.Range(1, 3 * BlockSize).ToArray();
+        var seq = NewSequenceFromTokens("no-bp", prompt, maxNew: 1);
+
+        var blocks = pool.AllocateNew(3);
+        foreach (var b in blocks)
+            seq.BlockTable.AppendBlock(b);
+        seq.AdvanceComputedTokens(prompt.Length);
+
+        sched.OnBlocksCommitted(seq, previousTokens: 0);
+
+        var hashes = KvBlockHasher.ComputeBlockHashes(prompt.ToList(), BlockSize, fingerprint);
+        for (int i = 0; i < 3; i++)
+            Assert.True(pool.TryFindByHash(hashes[i], out _), $"Block {i} should be registered.");
+    }
+
+    [Fact]
+    public void SequenceState_CopiesCacheBreakpoints_SoLaterCallerEditsCannotDrift()
+    {
+        var supplied = new List<int> { 2 * BlockSize };
+        var seq = new SequenceState(
+            "copy", Enumerable.Range(1, 4 * BlockSize).ToList(), maxNewTokens: 1,
+            BlockSize, SamplingConfig.Default, cacheBreakpoints: supplied);
+
+        // The pipeline hands over the same List it edited while truncating; a
+        // later edit must not move the limit the scheduler already read.
+        supplied.Clear();
+        supplied.Add(99 * BlockSize);
+
+        Assert.Equal(2 * BlockSize, seq.CacheBreakpointLimit);
+        Assert.Equal(new[] { 2 * BlockSize }, seq.CacheBreakpoints);
+    }
+
     // ----------------------- helpers -----------------------
 
     private static BlockPool NewPool(int numBlocks)

--- a/InferenceWeb.Tests/KVCachePromptRendererTests.cs
+++ b/InferenceWeb.Tests/KVCachePromptRendererTests.cs
@@ -586,6 +586,214 @@ public class KVCachePromptRendererTests
         Assert.Equal(noThink, KVCachePromptRenderer.StripEmptyThinkBlockBeforePlaceholders(noThink));
     }
 
+    // ---------------------------------------------------------------------
+    // Explicit prompt-cache breakpoints (cache_control / prompt_cache_breakpoint).
+    //
+    // The contract these tests pin down: a marker changes NOTHING about the
+    // token sequence handed to the model, and reports the token offset where
+    // the marked prefix ends. A breakpoint index is only useful if
+    // tokens[0..index] is exactly the prefix the client marked, so most of
+    // these assert that identity directly.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void RenderToTokens_NoCacheControl_ReportsNoBreakpoints()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+        var messages = new List<ChatMessage>
+        {
+            new() { Role = "system", Content = "sys" },
+            new() { Role = "user", Content = "Hi" },
+        };
+
+        var tokens = renderer.RenderToTokens(tokenizer, chatTemplate: null, messages,
+            architecture: "fake", addGenerationPrompt: true, out var breakpoints);
+
+        Assert.Null(breakpoints);
+
+        var expectedText = new FakeRenderer().Render(null, messages, addGenerationPrompt: true);
+        Assert.Equal(tokenizer.Encode(expectedText, addSpecial: true), tokens);
+    }
+
+    [Fact]
+    public void RenderToTokens_MessageCacheControl_LeavesTokenStreamIdentical()
+    {
+        var tokenizer = new CharTokenizer();
+        var messages = new List<ChatMessage>
+        {
+            new() { Role = "system", Content = "sys", CacheControl = new CacheControlMarker() },
+            new() { Role = "user", Content = "Hi" },
+        };
+        var unmarked = new List<ChatMessage>
+        {
+            new() { Role = "system", Content = "sys" },
+            new() { Role = "user", Content = "Hi" },
+        };
+
+        var marked = new KVCachePromptRenderer(new FakeRenderer()).RenderToTokens(
+            tokenizer, null, messages, "fake", addGenerationPrompt: true, out var breakpoints);
+        var plain = new KVCachePromptRenderer(new FakeRenderer()).RenderToTokens(
+            tokenizer, null, unmarked, "fake", addGenerationPrompt: true, out _);
+
+        // The marker must be invisible to the model: same tokens either way.
+        Assert.Equal(plain, marked);
+
+        // And no sentinel may survive into the prompt.
+        Assert.DoesNotContain(KVCachePromptRenderer.BreakpointSentinel, tokenizer.Decode(marked));
+
+        var bp = Assert.Single(breakpoints!);
+        Assert.InRange(bp, 1, marked.Count);
+    }
+
+    [Fact]
+    public void RenderToTokens_MessageCacheControl_BreakpointEndsTheMarkedPrefix()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+        var messages = new List<ChatMessage>
+        {
+            new() { Role = "system", Content = "sys", CacheControl = new CacheControlMarker() },
+            new() { Role = "user", Content = "Hi" },
+        };
+
+        var tokens = renderer.RenderToTokens(tokenizer, null, messages, "fake",
+            addGenerationPrompt: true, out var breakpoints);
+
+        int bp = Assert.Single(breakpoints!);
+
+        // The marker sits at the end of the system message's content, so the
+        // prefix it closes is everything the fake template emits up to and
+        // including "sys" - and not the "</system>" that follows it.
+        Assert.Equal("<|bos|><system>sys", tokenizer.Decode(tokens.GetRange(0, bp)));
+    }
+
+    [Fact]
+    public void RenderToTokens_MultipleCacheControls_AreReportedInAscendingOrder()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+        var messages = new List<ChatMessage>
+        {
+            new() { Role = "system", Content = "sys", CacheControl = new CacheControlMarker() },
+            new() { Role = "user", Content = "docs", CacheControl = new CacheControlMarker() },
+            new() { Role = "user", Content = "question" },
+        };
+
+        var tokens = renderer.RenderToTokens(tokenizer, null, messages, "fake",
+            addGenerationPrompt: true, out var breakpoints);
+
+        Assert.Equal(2, breakpoints!.Count);
+        Assert.True(breakpoints[0] < breakpoints[1],
+            $"Breakpoints must be in render order, got [{breakpoints[0]}, {breakpoints[1]}].");
+
+        Assert.Equal("<|bos|><system>sys", tokenizer.Decode(tokens.GetRange(0, breakpoints[0])));
+        Assert.Equal("<|bos|><system>sys</system>\n<user>docs",
+            tokenizer.Decode(tokens.GetRange(0, breakpoints[1])));
+    }
+
+    [Fact]
+    public void RenderToTokens_CacheControlOnMessageWithRawTokens_BreakpointFollowsSplicedTokens()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+        var rawTokens = new List<int> { 1001, 1002, 1003, 1004 };
+
+        var messages = new List<ChatMessage>
+        {
+            new() { Role = "user", Content = "Hi" },
+            new()
+            {
+                Role = "assistant",
+                Content = "IGNORED",
+                RawOutputTokens = rawTokens,
+                CacheControl = new CacheControlMarker(),
+            },
+            new() { Role = "user", Content = "again" },
+        };
+
+        var tokens = renderer.RenderToTokens(tokenizer, null, messages, "fake",
+            addGenerationPrompt: true, out var breakpoints);
+
+        int bp = Assert.Single(breakpoints!);
+
+        // The breakpoint must land AFTER the spliced raw tokens, not at the
+        // (much shorter) placeholder's position: the index is in the final
+        // array's coordinate space.
+        int rawStart = FindSubsequence(tokens, rawTokens);
+        Assert.True(rawStart >= 0, "Expected the raw tokens to be spliced into the output.");
+        Assert.Equal(rawStart + rawTokens.Count, bp);
+    }
+
+    [Fact]
+    public void RenderToTokens_ToolCacheControl_MarksPrefixAheadOfTheFirstMessageContent()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+        var tools = new List<ToolFunction>
+        {
+            new() { Name = "search", Description = "d", CacheControl = new CacheControlMarker() },
+        };
+        var messages = new List<ChatMessage>
+        {
+            new() { Role = "system", Content = "sys" },
+            new() { Role = "user", Content = "Hi" },
+        };
+
+        var tokens = renderer.RenderToTokens(tokenizer, null, messages, "fake",
+            addGenerationPrompt: true, out var breakpoints, tools: tools);
+
+        int bp = Assert.Single(breakpoints!);
+
+        // The tool block has nowhere else to anchor, so the breakpoint goes
+        // immediately before the first message's content. See the comment on
+        // needsToolsMarker in KVCachePromptRenderer for why this only lines up
+        // with the end of the tool block on templates that emit tools first.
+        Assert.Equal("<|bos|><system>", tokenizer.Decode(tokens.GetRange(0, bp)));
+        Assert.DoesNotContain(KVCachePromptRenderer.BreakpointSentinel, tokenizer.Decode(tokens));
+    }
+
+    [Fact]
+    public void RenderToTokens_ToolAndMessageCacheControl_ReportsBothInOrder()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+        var tools = new List<ToolFunction>
+        {
+            new() { Name = "search", Description = "d", CacheControl = new CacheControlMarker() },
+        };
+        var messages = new List<ChatMessage>
+        {
+            new() { Role = "system", Content = "sys", CacheControl = new CacheControlMarker() },
+            new() { Role = "user", Content = "Hi" },
+        };
+
+        var tokens = renderer.RenderToTokens(tokenizer, null, messages, "fake",
+            addGenerationPrompt: true, out var breakpoints, tools: tools);
+
+        Assert.Equal(2, breakpoints!.Count);
+        Assert.Equal("<|bos|><system>", tokenizer.Decode(tokens.GetRange(0, breakpoints[0])));
+        Assert.Equal("<|bos|><system>sys", tokenizer.Decode(tokens.GetRange(0, breakpoints[1])));
+    }
+
+    [Fact]
+    public void RenderToTokens_CacheControlOnLastMessage_DoesNotSwallowGenerationPrompt()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+        var messages = new List<ChatMessage>
+        {
+            new() { Role = "user", Content = "Hi", CacheControl = new CacheControlMarker() },
+        };
+
+        var tokens = renderer.RenderToTokens(tokenizer, null, messages, "fake",
+            addGenerationPrompt: true, out var breakpoints);
+
+        int bp = Assert.Single(breakpoints!);
+        Assert.Equal("<|bos|><user>Hi", tokenizer.Decode(tokens.GetRange(0, bp)));
+        Assert.True(bp < tokens.Count, "The generation prompt must fall outside the marked prefix.");
+    }
+
     private static string MakePlaceholder(int index)
     {
         // Mirrors KVCachePromptRenderer.MakePlaceholder so we don't have to expose it

--- a/InferenceWeb.Tests/KVCachePromptRendererTests.cs
+++ b/InferenceWeb.Tests/KVCachePromptRendererTests.cs
@@ -794,6 +794,134 @@ public class KVCachePromptRendererTests
         Assert.True(bp < tokens.Count, "The generation prompt must fall outside the marked prefix.");
     }
 
+    [Fact]
+    public void RenderToTokens_PartScopedMarker_BreaksInsideTheMessage_NotAtItsEnd()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+
+        // The shape a part-scoped marker exists for: a big cacheable document
+        // part, then a volatile question part in the SAME message. The
+        // breakpoint has to land between them.
+        var msg = new ChatMessage { Role = "user", Content = "DOC\nQ" };
+        msg.AddContentCacheBreakpoint(3); // end of "DOC"
+
+        var tokens = renderer.RenderToTokens(tokenizer, null, new List<ChatMessage> { msg },
+            "fake", addGenerationPrompt: true, out var breakpoints);
+
+        int bp = Assert.Single(breakpoints!);
+        Assert.Equal("<|bos|><user>DOC", tokenizer.Decode(tokens.GetRange(0, bp)));
+
+        // The question must fall OUTSIDE the marked prefix - collapsing the
+        // marker onto the message would have swallowed it.
+        Assert.DoesNotContain("Q", tokenizer.Decode(tokens.GetRange(0, bp)));
+    }
+
+    [Fact]
+    public void RenderToTokens_PartScopedMarkers_AreAllKept_AndDoNotAlterTheTokens()
+    {
+        var tokenizer = new CharTokenizer();
+
+        var marked = new ChatMessage { Role = "user", Content = "AAA\nBBB\nCCC" };
+        marked.AddContentCacheBreakpoint(3);  // end of "AAA"
+        marked.AddContentCacheBreakpoint(7);  // end of "BBB"
+
+        var tokens = new KVCachePromptRenderer(new FakeRenderer()).RenderToTokens(
+            tokenizer, null, new List<ChatMessage> { marked }, "fake",
+            addGenerationPrompt: true, out var breakpoints);
+
+        // An earlier marker must not be lost to a later one.
+        Assert.Equal(2, breakpoints!.Count);
+        Assert.Equal("<|bos|><user>AAA", tokenizer.Decode(tokens.GetRange(0, breakpoints[0])));
+        Assert.Equal("<|bos|><user>AAA\nBBB", tokenizer.Decode(tokens.GetRange(0, breakpoints[1])));
+
+        // And the prompt itself is untouched by the markers.
+        var plain = new KVCachePromptRenderer(new FakeRenderer()).RenderToTokens(
+            tokenizer, null,
+            new List<ChatMessage> { new() { Role = "user", Content = "AAA\nBBB\nCCC" } },
+            "fake", addGenerationPrompt: true, out _);
+        Assert.Equal(plain, tokens);
+    }
+
+    [Fact]
+    public void RenderToTokens_PartScopedAndMessageScopedMarkers_AreNumberedInTextOrder()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+        var tools = new List<ToolFunction>
+        {
+            new() { Name = "search", Description = "d", CacheControl = new CacheControlMarker() },
+        };
+
+        // All three anchors at once on the first message: the tool breakpoint in
+        // front of the content, a part breakpoint inside it, and a
+        // message-scoped one closing it.
+        var first = new ChatMessage
+        {
+            Role = "system",
+            Content = "DOC\nQ",
+            CacheControl = new CacheControlMarker(),
+        };
+        first.AddContentCacheBreakpoint(3);
+
+        var tokens = renderer.RenderToTokens(tokenizer, null, new List<ChatMessage> { first },
+            "fake", addGenerationPrompt: true, out var breakpoints, tools: tools);
+
+        Assert.Equal(3, breakpoints!.Count);
+        Assert.Equal("<|bos|><system>", tokenizer.Decode(tokens.GetRange(0, breakpoints[0])));
+        Assert.Equal("<|bos|><system>DOC", tokenizer.Decode(tokens.GetRange(0, breakpoints[1])));
+        Assert.Equal("<|bos|><system>DOC\nQ", tokenizer.Decode(tokens.GetRange(0, breakpoints[2])));
+
+        // Numbering must follow the text, so the reported list is ascending.
+        Assert.True(breakpoints[0] < breakpoints[1] && breakpoints[1] < breakpoints[2],
+            $"Expected ascending breakpoints, got [{string.Join(", ", breakpoints)}].");
+        Assert.DoesNotContain(KVCachePromptRenderer.BreakpointSentinel, tokenizer.Decode(tokens));
+    }
+
+    [Fact]
+    public void RenderToTokens_PartScopedMarkerOnSplicedAssistantTurn_IsDropped()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+        var rawTokens = new List<int> { 1001, 1002, 1003 };
+
+        // The content these offsets addressed is replaced wholesale by the raw
+        // tokens, so the offsets no longer refer to anything: they must be
+        // dropped rather than clamped onto the placeholder.
+        var assistant = new ChatMessage
+        {
+            Role = "assistant",
+            Content = "IGNORED",
+            RawOutputTokens = rawTokens,
+        };
+        assistant.AddContentCacheBreakpoint(3);
+
+        var tokens = renderer.RenderToTokens(tokenizer, null,
+            new List<ChatMessage> { new() { Role = "user", Content = "Hi" }, assistant },
+            "fake", addGenerationPrompt: true, out var breakpoints);
+
+        Assert.True(breakpoints == null || breakpoints.Count == 0,
+            "A part offset into content that was replaced by raw tokens must be dropped.");
+        Assert.True(FindSubsequence(tokens, rawTokens) >= 0);
+        Assert.DoesNotContain(KVCachePromptRenderer.BreakpointSentinel, tokenizer.Decode(tokens));
+    }
+
+    [Fact]
+    public void RenderToTokens_PartScopedMarkerPastEndOfContent_ClampsInsteadOfThrowing()
+    {
+        var renderer = new KVCachePromptRenderer(new FakeRenderer());
+        var tokenizer = new CharTokenizer();
+
+        var msg = new ChatMessage { Role = "user", Content = "Hi" };
+        msg.AddContentCacheBreakpoint(999);
+
+        var tokens = renderer.RenderToTokens(tokenizer, null, new List<ChatMessage> { msg },
+            "fake", addGenerationPrompt: true, out var breakpoints);
+
+        int bp = Assert.Single(breakpoints!);
+        Assert.Equal("<|bos|><user>Hi", tokenizer.Decode(tokens.GetRange(0, bp)));
+    }
+
     private static string MakePlaceholder(int index)
     {
         // Mirrors KVCachePromptRenderer.MakePlaceholder so we don't have to expose it

--- a/TensorSharp.Runtime/CacheControlMarker.cs
+++ b/TensorSharp.Runtime/CacheControlMarker.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Zhongkai Fu. All rights reserved.
+// https://github.com/zhongkaifu/TensorSharp
+//
+// This file is part of TensorSharp.
+//
+// TensorSharp is licensed under the BSD-3-Clause license found in the LICENSE file in the root directory of this source tree.
+//
+// TensorSharp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the BSD-3-Clause License for more details.
+
+namespace TensorSharp.Runtime
+{
+    /// <summary>
+    /// An explicit prompt-cache breakpoint attached to a message, a content part
+    /// or a tool declaration. Its presence is the whole signal — it marks the end
+    /// of a prefix the client wants kept in the prefix cache.
+    /// </summary>
+    public class CacheControlMarker
+    {
+        /// <summary>
+        /// The marker kind. Only <c>"ephemeral"</c> is currently specified, and
+        /// unrecognised kinds are carried through verbatim rather than rejected
+        /// so a newer client spelling degrades to a plain breakpoint.
+        /// </summary>
+        public string Type { get; set; } = "ephemeral";
+    }
+}

--- a/TensorSharp.Runtime/ChatTemplate.cs
+++ b/TensorSharp.Runtime/ChatTemplate.cs
@@ -60,9 +60,44 @@ namespace TensorSharp.Runtime
         /// </summary>
         public List<int>? RawOutputTokens { get; set; }
         /// <summary>
-        /// Explicit cache-control marker for prefix caching.
+        /// Explicit cache-control marker scoped to the whole message: a prefix
+        /// cache breakpoint at the END of <see cref="Content"/>. A marker on an
+        /// individual content part belongs in
+        /// <see cref="ContentCacheBreakpoints"/> instead, which can express a
+        /// position in the middle of the message.
         /// </summary>
         public CacheControlMarker? CacheControl { get; set; }
+
+        /// <summary>
+        /// Character offsets into <see cref="Content"/> at which a content part
+        /// carried its own <c>cache_control</c> marker, in ascending order.
+        /// <para>
+        /// A message assembled from parts concatenates them into one
+        /// <see cref="Content"/> string, so a marker on part <i>k</i> means "the
+        /// cacheable prefix ends where part <i>k</i> ends", not "at the end of
+        /// the message". Collapsing those onto <see cref="CacheControl"/> would
+        /// push the breakpoint to the end of the concatenated content and cache
+        /// more than the client marked, so the offsets are kept separately.
+        /// </para>
+        /// </summary>
+        public List<int>? ContentCacheBreakpoints { get; set; }
+
+        /// <summary>
+        /// Record a content-part breakpoint at <paramref name="offset"/> characters
+        /// into <see cref="Content"/>. Callers append in ascending order as they
+        /// concatenate the parts; a repeat of the previous offset (two markers with
+        /// no text between them) collapses into one.
+        /// </summary>
+        public void AddContentCacheBreakpoint(int offset)
+        {
+            ContentCacheBreakpoints ??= new List<int>();
+            if (ContentCacheBreakpoints.Count > 0 &&
+                ContentCacheBreakpoints[ContentCacheBreakpoints.Count - 1] == offset)
+            {
+                return;
+            }
+            ContentCacheBreakpoints.Add(offset);
+        }
     }
 
     public static class ChatTemplate

--- a/TensorSharp.Runtime/ChatTemplate.cs
+++ b/TensorSharp.Runtime/ChatTemplate.cs
@@ -59,6 +59,10 @@ namespace TensorSharp.Runtime
         /// reliable KV cache reuse across turns.
         /// </summary>
         public List<int>? RawOutputTokens { get; set; }
+        /// <summary>
+        /// Explicit cache-control marker for prefix caching.
+        /// </summary>
+        public CacheControlMarker? CacheControl { get; set; }
     }
 
     public static class ChatTemplate

--- a/TensorSharp.Runtime/KVCachePromptRenderer.cs
+++ b/TensorSharp.Runtime/KVCachePromptRenderer.cs
@@ -231,6 +231,8 @@ namespace TensorSharp.Runtime
                     && msg.RawOutputTokens.Count > 0;
 
                 bool hasMarker = msg?.CacheControl != null;
+                bool hasPartMarkers = msg?.ContentCacheBreakpoints != null
+                    && msg.ContentCacheBreakpoints.Count > 0;
 
                 // A tool-level marker can only be expressed by prefixing the
                 // first message's content, because the tool block itself is
@@ -248,7 +250,7 @@ namespace TensorSharp.Runtime
                 // template itself, which the Jinja path cannot express.
                 bool needsToolsMarker = toolsHasMarker && i == 0;
 
-                if (!hasRawTokens && !hasMarker && !needsToolsMarker)
+                if (!hasRawTokens && !hasMarker && !hasPartMarkers && !needsToolsMarker)
                 {
                     if (renderedMessages != null)
                         renderedMessages.Add(msg!);
@@ -272,15 +274,33 @@ namespace TensorSharp.Runtime
                     placeholderCount++;
                 }
 
-                if (needsToolsMarker)
+                // Breakpoints are NUMBERED in the order they appear in the text,
+                // which is what lets the strip pass walk them forwards and record
+                // final indices in one go. So claim the indices in that order too:
+                // the tool breakpoint sits in front of the content, the part
+                // offsets are interior and ascending, and the message-scoped
+                // marker closes the content.
+                string breakpointPrefix = needsToolsMarker
+                    ? MakeBreakpoint(breakpointCount++)
+                    : string.Empty;
+
+                if (hasPartMarkers && !hasRawTokens)
                 {
-                    newContent = MakeBreakpoint(breakpointCount++) + newContent;
+                    // Part-scoped markers address offsets into the ORIGINAL
+                    // content, so they only mean anything while that content is
+                    // still there. A message spliced from raw tokens has had its
+                    // content replaced by a placeholder, and an offset into that
+                    // placeholder would be meaningless, so they are dropped.
+                    newContent = InsertBreakpointsAtOffsets(
+                        newContent, msg.ContentCacheBreakpoints!, ref breakpointCount);
                 }
 
                 if (hasMarker)
                 {
                     newContent = newContent + MakeBreakpoint(breakpointCount++);
                 }
+
+                newContent = breakpointPrefix + newContent;
 
                 renderedMessages.Add(new ChatMessage
                 {
@@ -485,6 +505,33 @@ namespace TensorSharp.Runtime
         }
 
         /// <summary>
+        /// Splice a breakpoint sentinel into <paramref name="content"/> at each of
+        /// <paramref name="offsets"/>, which are character positions in ascending
+        /// order. Offsets are clamped into range and never allowed to move
+        /// backwards, so a marker whose offset does not fit the content (a caller
+        /// that rewrote the text after parsing it) degrades to a breakpoint at the
+        /// nearest legal position rather than throwing.
+        /// </summary>
+        private static string InsertBreakpointsAtOffsets(
+            string content, List<int> offsets, ref int breakpointCount)
+        {
+            var sb = new System.Text.StringBuilder(content.Length + offsets.Count * 8);
+            int copied = 0;
+            for (int i = 0; i < offsets.Count; i++)
+            {
+                int at = offsets[i];
+                if (at < copied) at = copied;
+                if (at > content.Length) at = content.Length;
+
+                sb.Append(content, copied, at - copied);
+                sb.Append(MakeBreakpoint(breakpointCount++));
+                copied = at;
+            }
+            sb.Append(content, copied, content.Length - copied);
+            return sb.ToString();
+        }
+
+        /// <summary>
         /// Tokenize <paramref name="text"/> as a SINGLE string (so the BPE/SentencePiece
         /// merging decisions at segment boundaries match exactly what the renderer would
         /// have produced for an entire turn-1-style prompt), then replace each occurrence
@@ -550,8 +597,12 @@ namespace TensorSharp.Runtime
             // Unlike a placeholder, a breakpoint that cannot be found is skipped
             // rather than fatal: a template is free to drop the content it was
             // attached to (Gemma 4's strip_thinking filter does exactly that),
-            // and a cache hint is not worth failing a completion over. The cost
-            // of a dropped hint is a shorter cached prefix, never a wrong one.
+            // and a cache hint is not worth failing a completion over. Dropping
+            // an interior breakpoint only shortens the marked region. Dropping
+            // the LAST one raises the ceiling to the next breakpoint down, and
+            // dropping every one of them leaves the request with no markers at
+            // all, which falls back to implicit caching - i.e. caching more than
+            // the client asked to have cached, not less.
             if (breakpointCount > 0)
             {
                 explicitBreakpoints = new List<int>(breakpointCount);

--- a/TensorSharp.Runtime/KVCachePromptRenderer.cs
+++ b/TensorSharp.Runtime/KVCachePromptRenderer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Zhongkai Fu. All rights reserved.
+// Copyright (c) Zhongkai Fu. All rights reserved.
 // https://github.com/zhongkaifu/TensorSharp
 //
 // This file is part of TensorSharp.
@@ -60,6 +60,9 @@ namespace TensorSharp.Runtime
         // order even if the chat template duplicates content (it doesn't today, but
         // numbering is cheap and defensive).
         internal const char PlaceholderSentinel = '\uE000';
+
+        // U+E001 is used for explicit cache breakpoints.
+        internal const char BreakpointSentinel = '\uE001';
 
         private readonly IPromptRenderer _innerRenderer;
 
@@ -180,6 +183,20 @@ namespace TensorSharp.Runtime
             List<ToolFunction>? tools = null,
             bool enableThinking = false)
         {
+            return RenderToTokens(tokenizer, chatTemplate, messages, architecture, addGenerationPrompt, out _, tools, enableThinking);
+        }
+
+        public List<int> RenderToTokens(
+            ITokenizer tokenizer,
+            string chatTemplate,
+            List<ChatMessage> messages,
+            string architecture,
+            bool addGenerationPrompt,
+            out List<int>? explicitBreakpoints,
+            List<ToolFunction>? tools = null,
+            bool enableThinking = false)
+        {
+            explicitBreakpoints = null;
             if (tokenizer == null)
                 throw new ArgumentNullException(nameof(tokenizer));
             if (messages == null)
@@ -191,6 +208,19 @@ namespace TensorSharp.Runtime
             List<ChatMessage>? renderedMessages = null;
             List<List<int>>? rawTokensByPlaceholderIndex = null;
             int placeholderCount = 0;
+            int breakpointCount = 0;
+
+            // A marker on any tool means "keep the tool block cached". The chat
+            // template renders the whole tool list as one unit, so a marker on
+            // one tool and a marker on all of them mean the same thing.
+            bool toolsHasMarker = false;
+            if (tools != null)
+            {
+                foreach (var t in tools)
+                {
+                    if (t.CacheControl != null) { toolsHasMarker = true; break; }
+                }
+            }
 
             for (int i = 0; i < messages.Count; i++)
             {
@@ -200,7 +230,25 @@ namespace TensorSharp.Runtime
                     && msg.RawOutputTokens != null
                     && msg.RawOutputTokens.Count > 0;
 
-                if (!hasRawTokens)
+                bool hasMarker = msg?.CacheControl != null;
+
+                // A tool-level marker can only be expressed by prefixing the
+                // first message's content, because the tool block itself is
+                // emitted by the chat template and there is nowhere else to put
+                // a sentinel. Where the template renders tools ahead of the
+                // messages (the hardcoded Qwen 3.5 path, which opens its own
+                // system turn for them) that lands the breakpoint just after the
+                // tool block, which is what the client asked for. Templates that
+                // render the tool list *inside* the first system message — which
+                // most Jinja templates do — put the tool JSON after that
+                // message's content, so the breakpoint lands before the tools
+                // and the tool block is left out of the cached prefix. The
+                // marker then under-caches rather than caching the wrong thing;
+                // placing it correctly needs the sentinel emitted by the
+                // template itself, which the Jinja path cannot express.
+                bool needsToolsMarker = toolsHasMarker && i == 0;
+
+                if (!hasRawTokens && !hasMarker && !needsToolsMarker)
                 {
                     if (renderedMessages != null)
                         renderedMessages.Add(msg!);
@@ -215,20 +263,36 @@ namespace TensorSharp.Runtime
                     rawTokensByPlaceholderIndex = new List<List<int>>();
                 }
 
+                string newContent = msg!.Content ?? "";
+
+                if (hasRawTokens)
+                {
+                    newContent = MakePlaceholder(placeholderCount);
+                    rawTokensByPlaceholderIndex!.Add(msg.RawOutputTokens!);
+                    placeholderCount++;
+                }
+
+                if (needsToolsMarker)
+                {
+                    newContent = MakeBreakpoint(breakpointCount++) + newContent;
+                }
+
+                if (hasMarker)
+                {
+                    newContent = newContent + MakeBreakpoint(breakpointCount++);
+                }
+
                 renderedMessages.Add(new ChatMessage
                 {
-                    Role = msg!.Role,
-                    Content = MakePlaceholder(placeholderCount),
+                    Role = msg.Role,
+                    Content = newContent,
                     // Don't carry Thinking through the template - the raw tokens already contain it.
-                    Thinking = null,
-                    ToolCalls = null,
+                    Thinking = hasRawTokens ? null : msg.Thinking,
+                    ToolCalls = hasRawTokens ? null : msg.ToolCalls,
                     ImagePaths = msg.ImagePaths,
                     AudioPaths = msg.AudioPaths,
                     IsVideo = msg.IsVideo,
                 });
-
-                rawTokensByPlaceholderIndex!.Add(msg.RawOutputTokens!);
-                placeholderCount++;
             }
 
             List<ChatMessage> messagesForRender = renderedMessages ?? messages;
@@ -241,8 +305,8 @@ namespace TensorSharp.Runtime
                 tools: tools,
                 enableThinking: enableThinking);
 
-            // Fast path: no placeholders -> just tokenize the whole rendered string.
-            if (placeholderCount == 0)
+            // Fast path: no placeholders and no breakpoints -> just tokenize the whole rendered string.
+            if (placeholderCount == 0 && breakpointCount == 0)
                 return tokenizer.Encode(text, addSpecial: true);
 
             // Some chat templates (notably Gemma 4) call a strip_thinking filter on
@@ -292,7 +356,7 @@ namespace TensorSharp.Runtime
             if (rendererStrippedTrailingWhitespace)
                 text = TrimWhitespaceBeforeEachPlaceholder(text);
 
-            return TokenizeAndReplacePlaceholderSpans(tokenizer, text, rawTokensByPlaceholderIndex!);
+            return TokenizeAndReplacePlaceholderSpans(tokenizer, text, rawTokensByPlaceholderIndex ?? new List<List<int>>(), breakpointCount, out explicitBreakpoints);
         }
 
         /// <summary>
@@ -415,6 +479,11 @@ namespace TensorSharp.Runtime
             return $"{PlaceholderSentinel}R{index:D4}{PlaceholderSentinel}";
         }
 
+        internal static string MakeBreakpoint(int index)
+        {
+            return $"{BreakpointSentinel}B{index:D4}{BreakpointSentinel}";
+        }
+
         /// <summary>
         /// Tokenize <paramref name="text"/> as a SINGLE string (so the BPE/SentencePiece
         /// merging decisions at segment boundaries match exactly what the renderer would
@@ -433,8 +502,12 @@ namespace TensorSharp.Runtime
         private static List<int> TokenizeAndReplacePlaceholderSpans(
             ITokenizer tokenizer,
             string text,
-            List<List<int>> rawTokensByPlaceholderIndex)
+            List<List<int>> rawTokensByPlaceholderIndex,
+            int breakpointCount,
+            out List<int>? explicitBreakpoints)
         {
+            explicitBreakpoints = null;
+
             // Step 1: tokenize the rendered text as a whole.
             List<int> tokens = tokenizer.Encode(text, addSpecial: true);
 
@@ -456,6 +529,44 @@ namespace TensorSharp.Runtime
 
                 tokens.RemoveRange(spanStart, placeholderTokens.Count);
                 tokens.InsertRange(spanStart, rawTokensByPlaceholderIndex[i]);
+            }
+
+            // Step 3: strip the explicit cache breakpoints, recording where each
+            // one fell.
+            //
+            // Breakpoints are numbered in render order and walked FORWARDS, which
+            // is what makes the recorded indices final. Step 2 goes backwards
+            // because it splices raw tokens in place and needs the positions it
+            // has not reached yet to stay put; this loop only ever deletes, so
+            // the opposite holds. Removing breakpoint i shifts every later
+            // breakpoint left by its length, and going forwards means that shift
+            // has already been applied by the time we search for i+1 - while
+            // deletions after a recorded index cannot disturb it. Walking
+            // backwards instead records each index in the coordinate space of an
+            // array that still contains all the earlier breakpoints, leaving
+            // every breakpoint but the first too large by the length of the ones
+            // preceding it.
+            //
+            // Unlike a placeholder, a breakpoint that cannot be found is skipped
+            // rather than fatal: a template is free to drop the content it was
+            // attached to (Gemma 4's strip_thinking filter does exactly that),
+            // and a cache hint is not worth failing a completion over. The cost
+            // of a dropped hint is a shorter cached prefix, never a wrong one.
+            if (breakpointCount > 0)
+            {
+                explicitBreakpoints = new List<int>(breakpointCount);
+                for (int i = 0; i < breakpointCount; i++)
+                {
+                    string breakpoint = MakeBreakpoint(i);
+                    List<int> breakpointTokens = tokenizer.Encode(breakpoint, addSpecial: false);
+
+                    int spanStart = FindSubsequence(tokens, breakpointTokens);
+                    if (spanStart >= 0)
+                    {
+                        tokens.RemoveRange(spanStart, breakpointTokens.Count);
+                        explicitBreakpoints.Add(spanStart);
+                    }
+                }
             }
 
             return tokens;

--- a/TensorSharp.Runtime/OutputParser.cs
+++ b/TensorSharp.Runtime/OutputParser.cs
@@ -25,6 +25,7 @@ namespace TensorSharp.Runtime
         public string Description { get; set; } = string.Empty;
         public Dictionary<string, ToolParameter> Parameters { get; set; } = new();
         public List<string> Required { get; set; } = new();
+        public CacheControlMarker? CacheControl { get; set; }
 
         /// <summary>
         /// Parse a list of tool definitions from JSON, accepting every shape a

--- a/TensorSharp.Runtime/Scheduling/ContinuousBatchScheduler.cs
+++ b/TensorSharp.Runtime/Scheduling/ContinuousBatchScheduler.cs
@@ -609,6 +609,7 @@ namespace TensorSharp.Runtime.Scheduling
             {
                 var block = seq.BlockTable.Blocks[b];
                 if (block.ContentHash != null) continue;
+                if (!IsBlockAllowedByExplicitMarkers(seq, b)) continue;
                 // The recurrent batched-paged path keeps state in model-owned
                 // slot pools and does not populate PagedKvStorage. Only blocks
                 // explicitly extracted by CaptureNewlyFullBlocks are portable.
@@ -616,6 +617,29 @@ namespace TensorSharp.Runtime.Scheduling
                     continue;
                 _pool.RegisterFullBlock(block, hashes[b], _cfg.BlockSize);
             }
+        }
+
+        /// <summary>
+        /// Whether a full block may be registered in the prefix-cache index.
+        /// <para>
+        /// A request that carried explicit <c>cache_control</c> markers has told
+        /// us which prefix is worth keeping; blocks past the last breakpoint are
+        /// request-specific and are left out of the index so they cannot evict
+        /// the prefixes the client asked to keep. A block qualifies only when it
+        /// ends at or before that breakpoint — a block straddling it holds
+        /// tokens from both sides, and the index is block-granular, so it is
+        /// dropped (the floor-to-block-size loss the design accepts).
+        /// </para>
+        /// <para>
+        /// Sequences without markers — the overwhelming majority — return true
+        /// here and keep the default behaviour of caching every full block.
+        /// </para>
+        /// </summary>
+        private bool IsBlockAllowedByExplicitMarkers(SequenceState seq, int blockIndex)
+        {
+            int limit = seq.CacheBreakpointLimit;
+            if (limit <= 0) return true;
+            return (blockIndex + 1) * _cfg.BlockSize <= limit;
         }
 
         private void CacheFullBlocksForSequence(SequenceState seq)
@@ -635,6 +659,7 @@ namespace TensorSharp.Runtime.Scheduling
             {
                 var block = seq.BlockTable.Blocks[b];
                 if (block.ContentHash != null) continue;
+                if (!IsBlockAllowedByExplicitMarkers(seq, b)) continue;
                 // Only register blocks whose K/V was actually extracted into
                 // pool storage. CaptureNewlyFullBlocks sets Used==BlockSize
                 // after a successful TryExtractKVBlock; blocks where extract

--- a/TensorSharp.Runtime/Scheduling/SequenceState.cs
+++ b/TensorSharp.Runtime/Scheduling/SequenceState.cs
@@ -30,7 +30,8 @@ namespace TensorSharp.Runtime.Scheduling
             int blockSize,
             SamplingConfig samplingConfig,
             object userTag = null,
-            string mediaFingerprint = null)
+            string mediaFingerprint = null,
+            IReadOnlyList<int> cacheBreakpoints = null)
         {
             if (promptTokens == null) throw new ArgumentNullException(nameof(promptTokens));
             if (promptTokens.Count == 0) throw new ArgumentException("Prompt must be non-empty.", nameof(promptTokens));
@@ -40,6 +41,15 @@ namespace TensorSharp.Runtime.Scheduling
             RequestId = requestId ?? $"seq-{Sn:X}";
             BlockTable = new BlockTable(blockSize);
             PromptTokens = new List<int>(promptTokens);
+            CacheBreakpoints = cacheBreakpoints;
+            if (cacheBreakpoints != null)
+            {
+                for (int i = 0; i < cacheBreakpoints.Count; i++)
+                {
+                    if (cacheBreakpoints[i] > CacheBreakpointLimit)
+                        CacheBreakpointLimit = cacheBreakpoints[i];
+                }
+            }
             OutputTokens = new List<int>(capacity: Math.Min(maxNewTokens, 256));
             MaxNewTokens = maxNewTokens;
             SamplingConfig = samplingConfig ?? SamplingConfig.Default;
@@ -55,6 +65,24 @@ namespace TensorSharp.Runtime.Scheduling
 
         public string RequestId { get; }
         public List<int> PromptTokens { get; }
+
+        /// <summary>
+        /// Explicit token-index breakpoints requested by the client for prompt caching.
+        /// When present, the cache manager captures K/V state exactly up to these points
+        /// (rounded down to the nearest block) instead of opportunistically capturing
+        /// the entire prefix.
+        /// </summary>
+        public IReadOnlyList<int> CacheBreakpoints { get; }
+
+        /// <summary>
+        /// The furthest explicit breakpoint, or 0 when the request set none.
+        /// Only the last one bounds what gets cached — the earlier ones mark
+        /// segment boundaries inside a prefix that is cached in full anyway —
+        /// so the capture path compares against this instead of rescanning
+        /// <see cref="CacheBreakpoints"/> for every block.
+        /// </summary>
+        public int CacheBreakpointLimit { get; }
+
         public List<int> OutputTokens { get; }
         public int MaxNewTokens { get; }
         public SamplingConfig SamplingConfig { get; }

--- a/TensorSharp.Runtime/Scheduling/SequenceState.cs
+++ b/TensorSharp.Runtime/Scheduling/SequenceState.cs
@@ -41,14 +41,22 @@ namespace TensorSharp.Runtime.Scheduling
             RequestId = requestId ?? $"seq-{Sn:X}";
             BlockTable = new BlockTable(blockSize);
             PromptTokens = new List<int>(promptTokens);
-            CacheBreakpoints = cacheBreakpoints;
-            if (cacheBreakpoints != null)
+            // Snapshot rather than alias, exactly as PromptTokens does above. The
+            // caller builds this as a mutable List and edits it in place while
+            // truncating the prompt; keeping the reference would let a later edit
+            // (or another thread) drift CacheBreakpoints away from the
+            // CacheBreakpointLimit computed here and make caching nondeterministic.
+            if (cacheBreakpoints != null && cacheBreakpoints.Count > 0)
             {
+                var copy = new List<int>(cacheBreakpoints.Count);
                 for (int i = 0; i < cacheBreakpoints.Count; i++)
                 {
-                    if (cacheBreakpoints[i] > CacheBreakpointLimit)
-                        CacheBreakpointLimit = cacheBreakpoints[i];
+                    int bp = cacheBreakpoints[i];
+                    copy.Add(bp);
+                    if (bp > CacheBreakpointLimit)
+                        CacheBreakpointLimit = bp;
                 }
+                CacheBreakpoints = copy;
             }
             OutputTokens = new List<int>(capacity: Math.Min(maxNewTokens, 256));
             MaxNewTokens = maxNewTokens;

--- a/TensorSharp.Server/ChatGenerationPipeline.cs
+++ b/TensorSharp.Server/ChatGenerationPipeline.cs
@@ -201,6 +201,7 @@ namespace TensorSharp.Server
             var promptSw = Stopwatch.StartNew();
             List<int> inputTokens;
             int effectiveMaxTokens;
+            List<int> explicitBreakpoints = null;
             bool hasMultimodal = RequiresMultimodalPreparation(renderHistory);
             if (hasMultimodal)
             {
@@ -236,27 +237,40 @@ namespace TensorSharp.Server
                 {
                     inputTokens = _kvCacheRenderer.RenderToTokens(
                         model.Tokenizer, model.Config.ChatTemplate, renderHistory, arch,
-                        addGenerationPrompt: true, tools: tools, enableThinking: enableThinking);
+                        addGenerationPrompt: true, out _, tools: tools, enableThinking: enableThinking);
                     // ClearPreparedPromptState is safe when preparation fails
                     // before creating a bucket. Arm cleanup first so partial
                     // image/audio preparation cannot leak tensors on overflow
                     // or any other exception before engine submission.
                     injectorBucketCreated = true;
                     inputTokens = model.MultimodalInjector.ProcessPromptTokens(renderHistory, inputTokens, requestId);
+
+                    // ProcessPromptTokens expands each single placeholder token
+                    // (<|image_pad|>, the audio equivalent) into however many
+                    // tokens the encoded media actually occupies, so every
+                    // breakpoint index past the first attachment now points at
+                    // the wrong token. There is no mapping back from the
+                    // expanded prompt to the pre-expansion offsets, so the
+                    // markers are discarded (the renderer's out-parameter is
+                    // dropped above) rather than applied at bogus positions.
+                    // That falls back to the default implicit behaviour of
+                    // caching every full block, which is the safe direction:
+                    // the request caches at least as much as it would have,
+                    // never less.
                     inputTokens = TruncatePromptToContext(
                         session, inputTokens, maxTokens, out effectiveMaxTokens, requestId,
-                        preserveAttachedDocuments, engineContextLimit);
+                        preserveAttachedDocuments, engineContextLimit, explicitBreakpoints: null);
                 }
             }
             else
             {
                 inputTokens = _kvCacheRenderer.RenderToTokens(
                     model.Tokenizer, model.Config.ChatTemplate, renderHistory, arch,
-                    addGenerationPrompt: true, tools: tools, enableThinking: enableThinking);
+                    addGenerationPrompt: true, out explicitBreakpoints, tools: tools, enableThinking: enableThinking);
                 inputTokens = TruncatePromptToContext(
-                    session, inputTokens, maxTokens, out effectiveMaxTokens,
+                    session, inputTokens, maxTokens, out effectiveMaxTokens, null,
                     preserveAllInput: preserveAttachedDocuments,
-                    executionContextLimit: engineContextLimit);
+                    executionContextLimit: engineContextLimit, explicitBreakpoints: explicitBreakpoints);
             }
 
             int promptTokenCount = inputTokens.Count;
@@ -277,7 +291,8 @@ namespace TensorSharp.Server
                 blockSize: enginePoolStats.blockSize,
                 samplingConfig: cfg,
                 userTag: session,
-                mediaFingerprint: mediaFingerprint);
+                mediaFingerprint: mediaFingerprint,
+                cacheBreakpoints: explicitBreakpoints);
 
             promptSw.Stop();
             long promptNs = InferenceTelemetry.ToNanos(promptSw.ElapsedTicks);
@@ -595,7 +610,8 @@ namespace TensorSharp.Server
             out int effectiveMaxTokens,
             string requestId = null,
             bool preserveAllInput = false,
-            int executionContextLimit = 0)
+            int executionContextLimit = 0,
+            List<int> explicitBreakpoints = null)
         {
             var model = _lifecycle.Model;
             int maxCtx = model.MaxContextLength;
@@ -635,6 +651,24 @@ namespace TensorSharp.Server
                 inputTokens.Count, kept, maxCtx, effectiveMaxTokens, session?.Id ?? "(none)");
             model.MultimodalInjector.TrimPreparedPrompt(trimStart, requestId);
             session?.TrackedHistory.Clear();
+
+            // Dropping the first trimStart tokens renumbers everything that
+            // survives, so the breakpoints have to move with it (in place - the
+            // caller holds this list and passes it on to the sequence). A
+            // breakpoint at or before the cut marked a prefix that no longer
+            // exists in the prompt at all and is discarded; if that empties the
+            // list the request simply falls back to implicit caching.
+            if (explicitBreakpoints != null && explicitBreakpoints.Count > 0)
+            {
+                for (int i = explicitBreakpoints.Count - 1; i >= 0; i--)
+                {
+                    if (explicitBreakpoints[i] <= trimStart)
+                        explicitBreakpoints.RemoveAt(i);
+                    else
+                        explicitBreakpoints[i] -= trimStart;
+                }
+            }
+
             return inputTokens.GetRange(trimStart, kept);
         }
 

--- a/TensorSharp.Server/RequestParsers/CacheControlParser.cs
+++ b/TensorSharp.Server/RequestParsers/CacheControlParser.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Zhongkai Fu. All rights reserved.
+// https://github.com/zhongkaifu/TensorSharp
+//
+// This file is part of TensorSharp.
+//
+// TensorSharp is licensed under the BSD-3-Clause license found in the LICENSE file in the root directory of this source tree.
+//
+// TensorSharp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the BSD-3-Clause License for more details.
+
+using System.Text.Json;
+using TensorSharp.Runtime;
+
+namespace TensorSharp.Server.RequestParsers
+{
+    /// <summary>
+    /// Reads an explicit prompt-cache breakpoint off a message, a content part
+    /// or a tool declaration. Two spellings are accepted in the same slot:
+    /// <c>"cache_control": {"type": "ephemeral"}</c> (Anthropic/DashScope shape)
+    /// and the bare <c>"prompt_cache_breakpoint": true</c> flag.
+    /// <para>
+    /// Like the rest of <c>RequestParsers</c>, nothing here throws: a field of an
+    /// unexpected kind means "no marker", not a failed request.
+    /// </para>
+    /// </summary>
+    internal static class CacheControlParser
+    {
+        /// <summary>
+        /// True when <paramref name="el"/> carries a cache breakpoint, with
+        /// <paramref name="marker"/> set to the parsed marker.
+        /// </summary>
+        public static bool TryParse(JsonElement el, out CacheControlMarker marker)
+        {
+            marker = null;
+            if (el.ValueKind != JsonValueKind.Object)
+                return false;
+
+            if (el.TryGetProperty("cache_control", out var ccEl) && ccEl.ValueKind == JsonValueKind.Object)
+            {
+                marker = new CacheControlMarker { Type = ReadType(ccEl) };
+                return true;
+            }
+
+            if (el.TryGetProperty("prompt_cache_breakpoint", out var flagEl) && flagEl.ValueKind == JsonValueKind.True)
+            {
+                marker = new CacheControlMarker();
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The marker's <c>type</c>, defaulting to <c>"ephemeral"</c> when absent
+        /// or not a string — every currently specified marker is ephemeral, and a
+        /// null <see cref="CacheControlMarker.Type"/> would only push the check
+        /// onto every consumer.
+        /// </summary>
+        private static string ReadType(JsonElement ccEl)
+        {
+            if (ccEl.TryGetProperty("type", out var typeEl) &&
+                typeEl.ValueKind == JsonValueKind.String)
+            {
+                string type = typeEl.GetString();
+                if (!string.IsNullOrEmpty(type))
+                    return type;
+            }
+            return "ephemeral";
+        }
+    }
+}

--- a/TensorSharp.Server/RequestParsers/ChatMessageParser.cs
+++ b/TensorSharp.Server/RequestParsers/ChatMessageParser.cs
@@ -169,15 +169,23 @@ namespace TensorSharp.Server.RequestParsers
                         var textParts = new List<string>();
                         msg.ImagePaths = new List<string>();
                         msg.AudioPaths = new List<string>();
+                        // Running length of the string.Join("\n", textParts) built
+                        // below, so a part's cache_control marker can be recorded at
+                        // the offset where that part ends rather than at the end of
+                        // the whole message.
+                        int joinedLength = 0;
 
                         foreach (var part in contentEl.EnumerateArray())
                         {
                             string type = part.TryGetProperty("type", out var t) ? t.GetString() : "";
                             if (type == "text" && part.TryGetProperty("text", out var txt))
                             {
-                                textParts.Add(txt.GetString());
-                                if (CacheControlParser.TryParse(part, out var partMarker))
-                                    msg.CacheControl = partMarker;
+                                string text = txt.GetString() ?? string.Empty;
+                                if (textParts.Count > 0) joinedLength++; // the "\n" separator
+                                joinedLength += text.Length;
+                                textParts.Add(text);
+                                if (CacheControlParser.TryParse(part, out _))
+                                    msg.AddContentCacheBreakpoint(joinedLength);
                             }
                             else if (type == "image_url" && part.TryGetProperty("image_url", out var imgUrl))
                             {
@@ -289,6 +297,9 @@ namespace TensorSharp.Server.RequestParsers
                     var textParts = new List<string>();
                     msg.ImagePaths = new List<string>();
                     msg.AudioPaths = new List<string>();
+                    // See the equivalent loop in ParseOpenAI: the offset of a
+                    // part-scoped marker is the running length of the join.
+                    int joinedLength = 0;
 
                     foreach (var part in contentEl.EnumerateArray())
                     {
@@ -296,9 +307,12 @@ namespace TensorSharp.Server.RequestParsers
                         if ((partType == "input_text" || partType == "output_text") &&
                             part.TryGetProperty("text", out var txt))
                         {
-                            textParts.Add(txt.GetString());
-                            if (CacheControlParser.TryParse(part, out var partMarker))
-                                msg.CacheControl = partMarker;
+                            string text = txt.GetString() ?? string.Empty;
+                            if (textParts.Count > 0) joinedLength++; // the "\n" separator
+                            joinedLength += text.Length;
+                            textParts.Add(text);
+                            if (CacheControlParser.TryParse(part, out _))
+                                msg.AddContentCacheBreakpoint(joinedLength);
                         }
                         else if (partType == "input_audio" && part.TryGetProperty("input_audio", out var audioEl))
                         {

--- a/TensorSharp.Server/RequestParsers/ChatMessageParser.cs
+++ b/TensorSharp.Server/RequestParsers/ChatMessageParser.cs
@@ -155,6 +155,9 @@ namespace TensorSharp.Server.RequestParsers
                     Role = msgEl.TryGetProperty("role", out var r) ? r.GetString() : "user"
                 };
 
+                if (CacheControlParser.TryParse(msgEl, out var msgMarker))
+                    msg.CacheControl = msgMarker;
+
                 if (msgEl.TryGetProperty("content", out var contentEl))
                 {
                     if (contentEl.ValueKind == JsonValueKind.String)
@@ -173,6 +176,8 @@ namespace TensorSharp.Server.RequestParsers
                             if (type == "text" && part.TryGetProperty("text", out var txt))
                             {
                                 textParts.Add(txt.GetString());
+                                if (CacheControlParser.TryParse(part, out var partMarker))
+                                    msg.CacheControl = partMarker;
                             }
                             else if (type == "image_url" && part.TryGetProperty("image_url", out var imgUrl))
                             {
@@ -263,6 +268,9 @@ namespace TensorSharp.Server.RequestParsers
                     Role = itemEl.TryGetProperty("role", out var r) ? r.GetString() : "user",
                 };
 
+                if (CacheControlParser.TryParse(itemEl, out var itemMarker))
+                    msg.CacheControl = itemMarker;
+
                 if (!itemEl.TryGetProperty("content", out var contentEl))
                 {
                     messages.Add(msg);
@@ -289,6 +297,8 @@ namespace TensorSharp.Server.RequestParsers
                             part.TryGetProperty("text", out var txt))
                         {
                             textParts.Add(txt.GetString());
+                            if (CacheControlParser.TryParse(part, out var partMarker))
+                                msg.CacheControl = partMarker;
                         }
                         else if (partType == "input_audio" && part.TryGetProperty("input_audio", out var audioEl))
                         {

--- a/TensorSharp.Server/RequestParsers/ToolFunctionParser.cs
+++ b/TensorSharp.Server/RequestParsers/ToolFunctionParser.cs
@@ -56,7 +56,7 @@ namespace TensorSharp.Server.RequestParsers
             {
                 if (!TryGetObject(toolEl, "function", out var fnEl))
                     continue;
-                tools.Add(ParseFunction(fnEl));
+                tools.Add(ParseFunction(fnEl, toolEl));
             }
             return tools.Count > 0 ? tools : null;
         }
@@ -72,7 +72,7 @@ namespace TensorSharp.Server.RequestParsers
                 if (!IsFunctionTool(toolEl)) continue;
                 if (!TryGetObject(toolEl, "function", out var fnEl)) continue;
 
-                tools.Add(ParseFunction(fnEl));
+                tools.Add(ParseFunction(fnEl, toolEl));
             }
             return tools.Count > 0 ? tools : null;
         }
@@ -123,14 +123,27 @@ namespace TensorSharp.Server.RequestParsers
         /// <summary>
         /// Parse one function declaration — <c>{name, description, parameters}</c>,
         /// where <c>parameters</c> is a JSON Schema object. Never returns null.
+        /// <para>
+        /// <paramref name="wrapperEl"/> is the enclosing <c>{type, function}</c>
+        /// entry where the protocol nests one (Chat Completions and Ollama), and
+        /// default/undefined for the Responses API's flat shape. A cache
+        /// breakpoint is read from either level because clients place it on
+        /// both; the inner declaration wins when they disagree.
+        /// </para>
         /// </summary>
-        private static ToolFunction ParseFunction(JsonElement fnEl)
+        private static ToolFunction ParseFunction(JsonElement fnEl, JsonElement wrapperEl = default)
         {
             var tf = new ToolFunction
             {
                 Name = ReadString(fnEl, "name") ?? string.Empty,
                 Description = ReadString(fnEl, "description") ?? string.Empty
             };
+
+            if (CacheControlParser.TryParse(fnEl, out var marker) ||
+                CacheControlParser.TryParse(wrapperEl, out marker))
+            {
+                tf.CacheControl = marker;
+            }
 
             // "parameters": null on an argument-less tool is common, and so is
             // omitting it entirely; both leave the defaults from ToolFunction.

--- a/docs/EXPLICIT_CACHE_MARKERS_DESIGN.md
+++ b/docs/EXPLICIT_CACHE_MARKERS_DESIGN.md
@@ -1,0 +1,85 @@
+# Explicit Prompt Cache Markers - TensorSharp2 Implementation Design
+
+This document outlines the design for implementing explicit prompt-cache markers in TensorSharp2, ensuring full compatibility with explicit caching specifications based on `cache_control` markers.
+
+## 1. Overview
+
+TensorSharp2 currently relies on implicit, automatic prefix caching via `PagedKvCacheManager`, which splits prompts into fixed-size blocks and hashes them. This design introduces support for **explicit caching**, where the client dictates the exact boundaries of cacheable segments using `cache_control` markers.
+
+The implementation will span the API layer (headers and JSON parsing), the prompt rendering layer (tracking markers to exact token indices without leaking them into the prompt), the caching layer (prioritizing/capturing based on markers), and the response serialization layer (reporting `cached_tokens`).
+
+## 2. API & Data Model Changes
+
+### 2.1 Request Parsing
+* **Headers**: Update `SessionEndpoints.cs` and `OpenAIChatAdapter.cs` to check for the presence of the `X-Prompt-Cache-Control` or `X-DashScope-CacheControl` headers.
+* **DTOs**: Update `ChatMessage.cs` (or the underlying DTOs) and `ToolFunction.cs` to include a `CacheControl` property:
+  ```csharp
+  public class CacheControlMarker
+  {
+      public string Type { get; set; } // "ephemeral"
+  }
+  ```
+* **JSON Parsers**: Update `ChatMessageParser.cs` and `ToolFunctionParser.cs` to deserialize the `cache_control` block. Since markers can be on content parts, the `ChatMessage` parser must inspect `type: "text"` parts for `cache_control` objects. Support is also provided for `prompt_cache_breakpoint: true` in these same locations to remain forward-compatible with emerging endpoint proposals.
+
+### 2.2 Opt-In Semantics
+* A request is considered to have explicit caching enabled if the header is present (`enable`), OR if any `cache_control` or `prompt_cache_breakpoint` marker is found during request parsing.
+* If explicit caching is enabled, TensorSharp2 will transition from *automatic* caching (capturing everything) to *explicit* caching (capturing only up to marked boundaries) for that request.
+
+## 3. Prompt Rendering & Marker Tracking
+
+The spec mandates that markers must not affect the rendered prompt (token sequence must remain identical). However, the engine needs to know the exact token offsets of these markers.
+
+### 3.1 Tracking in `KVCachePromptRenderer`
+`KVCachePromptRenderer` currently uses a sentinel strategy (`PlaceholderSentinel`) to splice raw tokens. We will extend this strategy to track explicit breakpoints:
+1. **Injection**: When formatting the prompt, if a content part or tool has a `cache_control` marker, insert a unique, invisible breakpoint sentinel (e.g., `\uE001B{index}\uE001`) at the exact location of the marker.
+2. **Tokenization**: Tokenize the entire text string.
+3. **Extraction & Stripping**: Iterate through the resulting tokens. Locate the breakpoint sentinels. Record their token indices, and then **remove** the sentinel tokens from the sequence so they never reach the model.
+4. **Result**: The renderer outputs the clean `List<int>` of input tokens, plus a `List<int>` of token indices representing the explicit breakpoints (`[m1, m2, m3]`).
+
+## 4. Cache Manager & Engine Integration
+
+### 4.1 Capturing Segments
+Currently, `PagedKvCacheManager.Capture` tries to snapshot all available tokens rounded down to a block boundary.
+* With explicit markers, we pass the breakpoint indices `[m1, m2, m3]` to the engine/cache manager.
+* `PagedKvCacheManager.Capture` will capture prefixes **up to the provided breakpoints**. 
+* **Block Alignment**: Because `PagedKvCacheManager` uses fixed blocks (e.g., 256 tokens), a marker at token `M` might not align with a block boundary. 
+  * *Option A (Strict)*: We only capture full blocks up to `M` (e.g., `M / 256` blocks). This loses the tail end of the segment but maintains fixed-block simplicity.
+  * *Option B (Padded/Variable)*: We store the partial block. However, GPU kernels heavily rely on uniform block sizes.
+  * *Decision*: Proceed with Option A for phase 1. The spec acknowledges: *"block-based caches naturally floor at their block size... losing the tail of a matching prefix"*. Capturing `Math.Floor(M / BlockSize)` blocks is acceptable and safe.
+
+### 4.2 Retention Priority (Future Enhancement)
+The spec suggests giving retention priority to explicitly marked segments.
+* We can augment `PagedKvBlockStore` to distinguish between "automatic" blocks and "explicit" blocks.
+* Explicit blocks can bypass standard LRU eviction until all automatic blocks have been evicted, protecting long-lived agent conversations from background noise.
+
+## 5. Usage Reporting (Mandatory)
+
+Client applications and agents rely on `cached_tokens` to measure cache effectiveness. If it's missing, they may assume the cache is unmeasurable.
+
+### 5.1 Telemetry
+* `InferenceCompletion.PrefixCacheReusedTokens` already records how many tokens were restored from the cache.
+* This is piped through `ChatGenerationPipeline` to `kvCacheReusedTokens`.
+
+### 5.2 Response Serializers
+* Update `OpenAIResponseFactory.cs` and `OpenAIResponsesFactory.cs`.
+* In the `usage` block of the JSON output, add the `prompt_tokens_details` (or `input_tokens_details` for Responses API) object:
+  ```json
+  "usage": {
+    "prompt_tokens": 1000,
+    "completion_tokens": 50,
+    "total_tokens": 1050,
+    "prompt_tokens_details": {
+      "cached_tokens": 768
+    }
+  }
+  ```
+* Ensure this is populated for **both** the standard (non-streaming) response and the final chunk of a streaming response.
+* Always emit the `prompt_tokens_details` object, even if `cached_tokens` is 0.
+
+## 6. Execution Plan
+
+1. **Parser Layer**: Update JSON parsers in `RequestParsers/` to extract `cache_control` and populate the DTOs.
+2. **Rendering Layer**: Modify `KVCachePromptRenderer.cs` to inject, locate, and strip breakpoint sentinels, returning a list of breakpoint indices.
+3. **Engine Layer**: Update `SequenceState` to carry `CacheBreakpoints`. Modify `InferenceEngine` to pass these breakpoints to `PagedKvCacheManager.Capture`.
+4. **Serialization Layer**: Update `OpenAIResponseFactory` and streaming writers to format the `prompt_tokens_details.cached_tokens` block accurately.
+5. **Tests**: Add unit tests replicating the conformance vectors (V1-V8) from the specification.


### PR DESCRIPTION
This is for clients that know exactly what data needs to be cached and do not want the performance hit or eviction risk of caching their following RAG blocks for example, or are batch processing uncacheable content over and over (or want to have fallback to a specific point consistently).

Note that using this without a precise reason will reduce the amount of cache hits, you need to have a special reason like the above to benefit from it.

This is compatible with OpenAI/Azure/Dashscope explicit cache breakpoint support.