### PR TITLE
Fix the three AgentHost tests failing on Linux CI (fixes #191, unblocks #190)

### DIFF
--- a/InferenceWeb.Tests/ShellRegressionTests.cs
+++ b/InferenceWeb.Tests/ShellRegressionTests.cs
@@ -301,21 +301,83 @@ public class ShellRegressionTests : IDisposable
     }
 
     [Fact]
-    public void AnEnvironmentValueWithANewline_DoesNotBreakTheNextCommand()
+    public void AnEnvironmentValueWithANewline_LeavesTheValueWholeOrGone_NeverHalf()
     {
         if (!HaveShell) return;
 
-        // `export -p` emits a multi-line record for such a value; the save-side filter
-        // cut it in half and left a dangling quote, which under sh aborted every later
-        // command and under bash silently swallowed the rest of the file.
+        // Under sh/dash `export -p` emits a MULTI-LINE record for such a value; the
+        // save-side line filter dropped only the line that matched (`PATH=b'`), and the
+        // dangling quote left behind aborted every later command under sh and silently
+        // swallowed the rest of the file under bash.
+        //
+        // What the shell does with that value is NOT the same on every POSIX host, which
+        // is why this asserts the outcome rather than the repair: bash 4.4 and newer
+        // write the whole value on ONE line, ANSI-C quoted as $'a\nPATH=b' (also under
+        // --posix), so nothing is ever cut and nothing is ever reset there, while dash
+        // and older bash take the multi-line path and the saved environment is thrown
+        // away. Asserting "was reset" here therefore only passed on a POSIX host with no
+        // modern bash: it failed on this repo's own Linux CI. The reset itself is pinned
+        // deterministically by the next test.
+        //
+        // What must hold on EVERY host: the next command still runs, the value comes
+        // back whole or not at all but never half, and the record's second line never
+        // becomes PATH.
         _runner.Run(
             new ShellRequest("export NOTE=\"$(printf 'a\\nPATH=b')\"; echo ok"), _workspace);
+        CodeExecResult after = _runner.Run(new ShellRequest(
+            "echo still-working; n=\"${NOTE-MISSING}\"; "
+            + "case \"$n\" in MISSING|\"\") echo NOTE=gone ;; a) echo NOTE=half ;; "
+            + "*) if [ \"$n\" = \"$(printf 'a\\nPATH=b')\" ]; then echo NOTE=whole; "
+            + "else echo NOTE=other; fi ;; esac; "
+            + "case \"$PATH\" in b) echo PATH_B=yes ;; *) echo PATH_B=no ;; esac"), _workspace);
+
+        Assert.True(after.Ok, after.Content);
+        Assert.Contains("still-working", after.Content, StringComparison.Ordinal);
+        // The half of the record that survives the filter is `PATH=b`, so a filter that
+        // let it through would hand the next command a one-letter PATH.
+        Assert.Contains("PATH_B=no", after.Content, StringComparison.Ordinal);
+        // "NOTE=half" IS the original defect: the value cut at the newline.
+        Assert.DoesNotContain("NOTE=half", after.Content, StringComparison.Ordinal);
+        Assert.DoesNotContain("NOTE=other", after.Content, StringComparison.Ordinal);
+        Assert.True(
+            after.Content.Contains("NOTE=whole", StringComparison.Ordinal)
+            || after.Content.Contains("NOTE=gone", StringComparison.Ordinal),
+            after.Content);
+    }
+
+    [Fact]
+    public void ACorruptSavedEnvironment_IsResetAndSaidOutLoud()
+    {
+        if (!HaveShell) return;
+
+        // The repair path itself — the wrapper's trial source in a subshell — pinned
+        // without depending on how THIS host's shell happens to quote a newline. The
+        // seeded file is exactly what the sh/dash save-side filter used to leave behind:
+        // a record cut in half, with a dangling quote. Sourcing that fails on bash and
+        // on dash alike, so the reset fires on every POSIX host.
+        //
+        // Resetting silently would mean a variable the model exported two calls ago is
+        // simply gone, with no way to tell that from having mistyped the name, so the
+        // note is the contract here rather than an implementation detail.
+        _runner.Run(new ShellRequest("export KEEP=1; echo ok"), _workspace);
+
+        string envFile = _runner.SessionFor(_workspace).EnvironmentFilePath;
+        Assert.True(File.Exists(envFile), envFile);
+        string marker = envFile + ".reset";
+        if (File.Exists(marker)) File.Delete(marker);
+        File.WriteAllText(envFile, "export NOTE='a\n");
+
         CodeExecResult after = _runner.Run(new ShellRequest("echo still-working"), _workspace);
 
         Assert.True(after.Ok, after.Content);
         Assert.Contains("still-working", after.Content, StringComparison.Ordinal);
-        // And the reset is stated rather than left as a variable that quietly vanished.
         Assert.Contains("was reset", after.Content, StringComparison.Ordinal);
+
+        // Once, not on every later call: the unusable file is replaced, not left to fail
+        // again. (The same command's EXIT trap rewrites it from a fresh `export -p`, so
+        // there is nothing to assert about it being left empty.)
+        CodeExecResult third = _runner.Run(new ShellRequest("echo again"), _workspace);
+        Assert.DoesNotContain("was reset", third.Content, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/InferenceWeb.Tests/SkillCrossPlatformTests.cs
+++ b/InferenceWeb.Tests/SkillCrossPlatformTests.cs
@@ -303,11 +303,21 @@ public class SkillCrossPlatformTests : IDisposable
         };
 
         string profile = SeatbeltSandbox.BuildProfile(request);
-        Assert.Contains("(allow file-read* (literal \"" + ca, profile, StringComparison.Ordinal);
-        Assert.Contains("(deny file-write* (literal \"" + ca, profile, StringComparison.Ordinal);
-        Assert.Contains("(allow file-read* file-write* (subpath \"" + state,
+        // Every path reaches the profile through SeatbeltSandbox.Quote, which doubles
+        // backslashes — so the raw host spelling of a Windows path never appears in it,
+        // and an assertion written against that spelling failed there while passing on
+        // every platform whose separator is not itself the escape character. Build the
+        // expected rule with the production quoter, and pin the WHOLE rule, closing
+        // parens included, so a truncated tail cannot satisfy Contains either. The
+        // quoting itself is pinned by value in the next test, so the two cannot drift
+        // into agreeing about something wrong.
+        Assert.Contains("(allow file-read* (literal " + SeatbeltSandbox.Quote(ca) + "))",
             profile, StringComparison.Ordinal);
-        Assert.Contains("(allow network-bind (local unix-socket (subpath \"" + state,
+        Assert.Contains("(deny file-write* (literal " + SeatbeltSandbox.Quote(ca) + "))",
+            profile, StringComparison.Ordinal);
+        Assert.Contains("(allow file-read* file-write* (subpath " + SeatbeltSandbox.Quote(state) + "))",
+            profile, StringComparison.Ordinal);
+        Assert.Contains("(allow network-bind (local unix-socket (subpath " + SeatbeltSandbox.Quote(state) + ")))",
             profile, StringComparison.Ordinal);
 
         IReadOnlyList<string> arguments = BubblewrapSandbox.BuildArguments(request);
@@ -316,6 +326,22 @@ public class SkillCrossPlatformTests : IDisposable
         int chdir = arguments.ToList().IndexOf("--chdir");
         Assert.InRange(chdir, 0, arguments.Count - 2);
         Assert.Equal(skill, arguments[chdir + 1]);
+    }
+
+    [Fact]
+    public void SbplPathQuoting_EscapesBackslashesBeforeQuotes()
+    {
+        // A profile rule is a string literal: a backslash has to be doubled and an
+        // embedded quote escaped, or a path ends the literal early, truncates the
+        // profile and silently WIDENS the sandbox. Pinned by value because on Linux and
+        // macOS a real path contains neither character, so nothing else on those hosts
+        // exercises the escaping at all.
+        Assert.Equal("\"/tmp/plain\"", SeatbeltSandbox.Quote("/tmp/plain"));
+        Assert.Equal("\"C:\\\\x\\\\y\"", SeatbeltSandbox.Quote(@"C:\x\y"));
+        Assert.Equal("\"a\\\"b\"", SeatbeltSandbox.Quote("a\"b"));
+        // Order matters: escaping quotes FIRST would turn \" into \\" and re-open the
+        // literal. Only a path carrying both characters catches a swapped pair.
+        Assert.Equal("\"a\\\\b\\\"c\"", SeatbeltSandbox.Quote("a\\b\"c"));
     }
 
     [Fact]

--- a/InferenceWeb.Tests/SkillSandboxTests.cs
+++ b/InferenceWeb.Tests/SkillSandboxTests.cs
@@ -309,6 +309,26 @@ public class SkillSandboxTests : IDisposable
     }
 
     [Fact]
+    public void TheNoSandboxSummary_CarriesTheGreppablePhrase_OnEveryPlatform()
+    {
+        // DescribeHost's no-sandbox branch runs only on a host that HAS no sandbox, so
+        // its wording goes unexercised everywhere else — which is how the Linux spelling
+        // drifted to "no SAFE OS sandbox available" without any test noticing, and why
+        // the test above passed on macOS and on Linux-with-bubblewrap while failing on
+        // the one host shape it describes. Both spellings are pinned by value here,
+        // where every platform runs them.
+        Assert.Equal(
+            "no OS sandbox available on this platform",
+            SkillSandboxFactory.NoSandboxSummary(string.Empty));
+        Assert.Equal(
+            "no OS sandbox available: bwrap (bubblewrap) is not installed on this host",
+            SkillSandboxFactory.NoSandboxSummary("bwrap (bubblewrap) is not installed on this host"));
+        // A reason must never replace the phrase, only follow it.
+        Assert.StartsWith(
+            "no OS sandbox", SkillSandboxFactory.NoSandboxSummary("anything"), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ADetectedSandbox_DescribesWhatItActuallyEnforces()
     {
         ISkillSandbox? sandbox = SkillSandboxFactory.Detect();

--- a/InferenceWeb.Tests/SpawnedProcessTests.cs
+++ b/InferenceWeb.Tests/SpawnedProcessTests.cs
@@ -268,10 +268,27 @@ public class SpawnedProcessTests
                 : null;
             if (setsid == null)
                 return;
-            command = setsid + " sleep 30 & echo child:$!; echo done";
+
+            // The escape is ASYNCHRONOUS, and the shell must outlive it. `sh -c` runs
+            // without job control, so the background job is forked INTO the launch group
+            // and only leaves it once it has exec'd setsid(1) and that has called
+            // setsid(2) — while StartReaper SIGKILLs the whole launch group the instant
+            // this shell exits. Written as `setsid sleep 30 & echo done`, the two race,
+            // and on a host where the reaper wins the grandchild dies, both pipes reach
+            // EOF, and the drain "succeeds" for a reason that has nothing to do with what
+            // is being tested. That is not hypothetical: it is why this test failed on
+            // Linux CI and passed locally.
+            //
+            // `sleep 1` is a FOREGROUND child, so the shell blocks on it for about a
+            // second — three orders of magnitude longer than execve + ld.so + setsid(2).
+            // `$$` inside the setsid'd sh is its post-setsid pid and `exec` keeps it, so
+            // the pid reported is the process that actually holds the pipe.
+            command = setsid + " /bin/sh -c 'echo child:$$; exec sleep 30' & sleep 1; echo done";
         }
         else if (OperatingSystem.IsMacOS())
         {
+            // Job control puts the job in its own group in the PARENT before it runs, so
+            // there is no window for the reaper here.
             command = "set -m; sleep 30 & echo child:$!; echo done";
         }
         else
@@ -280,20 +297,29 @@ public class SpawnedProcessTests
         }
 
         var lines = new ConcurrentQueue<string>();
+        var errors = new ConcurrentQueue<string>();
         Assert.True(
             SpawnedProcess.TryStart(
                 Request("/bin/sh", new[] { "-c", command },
-                    onOut: lines.Enqueue),
+                    onOut: lines.Enqueue, onErr: errors.Enqueue),
                 out SpawnedProcess? p, out string error),
             error);
 
         int escaped = -1;
         try
         {
-            Assert.True(p!.WaitForExit(20_000), "the shell itself should exit immediately");
-            Assert.True(SpinWait.SpinUntil(() => lines.Count >= 2, 5000));
+            Assert.True(p!.WaitForExit(20_000), "the shell should exit once its foreground child returns");
+            Assert.True(SpinWait.SpinUntil(() => lines.Count >= 2, 5000), string.Join("; ", lines));
             string childLine = lines.Single(line => line.StartsWith("child:", StringComparison.Ordinal));
             Assert.True(int.TryParse(childLine.AsSpan("child:".Length), out escaped));
+
+            // Fail HERE, naming the real cause, if the escape never happened. A child
+            // that lost the race or failed to exec otherwise surfaces as "the pipe cannot
+            // be at EOF", which points at the drain instead of at the child.
+            Assert.True(
+                PosixSpawn.kill(escaped, 0) == 0,
+                $"the escaped child {escaped} was already dead before the drain check; "
+                + $"stderr: {string.Join("; ", errors)}");
 
             var sw = Stopwatch.StartNew();
             bool drained = p.WaitForDrain(500);

--- a/TensorSharp.AgentHost/CodeExec/ShellSession.cs
+++ b/TensorSharp.AgentHost/CodeExec/ShellSession.cs
@@ -64,6 +64,13 @@ namespace TensorSharp.AgentHost.CodeExec
             _shell.Kind == ShellKind.PowerShell ? "env.txt" : "env.sh");
 
         /// <summary>
+        /// The same path, for a test that has to corrupt the saved environment on
+        /// purpose. Exposed rather than letting a test re-spell the leaf name, which
+        /// would quietly stop testing anything the day the name changed.
+        /// </summary>
+        internal string EnvironmentFilePath => EnvFile;
+
+        /// <summary>
         /// The directory the next command will start in — the work directory until
         /// something <c>cd</c>s, and whatever it left behind after that.
         /// </summary>
@@ -601,7 +608,12 @@ namespace TensorSharp.AgentHost.CodeExec
         /// <summary>Forget the working directory and the environment. Used by tests and by a reset.</summary>
         public void Reset()
         {
-            foreach (string file in new[] { CwdFile, EnvFile })
+            // The reset marker goes with the file it describes. Left behind, a later
+            // command reads it as "the environment you exported was thrown away" when
+            // nothing of the sort happened on that command. The Exists probe stays: on
+            // Windows a File.Delete of a path that is not there costs more than asking
+            // whether it is, and the marker is normally not there.
+            foreach (string file in new[] { CwdFile, EnvFile, EnvFile + ".reset" })
             {
                 try { if (File.Exists(file)) File.Delete(file); }
                 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }

--- a/TensorSharp.AgentHost/Skills/SkillSandbox.cs
+++ b/TensorSharp.AgentHost/Skills/SkillSandbox.cs
@@ -215,15 +215,38 @@ namespace TensorSharp.AgentHost.Skills
         {
             ISkillSandbox? sandbox = Detect();
             if (sandbox == null)
-                return OperatingSystem.IsLinux()
-                    ? "no safe OS sandbox available: " + BubblewrapSandbox.AvailabilityError
-                    : "no OS sandbox available on this platform";
+                return NoSandboxSummary(
+                    OperatingSystem.IsLinux() ? BubblewrapSandbox.AvailabilityError : string.Empty);
 
             IReadOnlyList<string> gaps = sandbox.Capabilities.Gaps();
             return gaps.Count == 0
                 ? $"{sandbox.Name}: {sandbox.Describe()}"
                 : $"{sandbox.Name}: {sandbox.Describe()}. NOT confined: {string.Join("; ", gaps)}";
         }
+
+        /// <summary>
+        /// The "nothing on this host can confine a child process" line. It always
+        /// carries the literal phrase <c>no OS sandbox</c> — the phrase the shell tool
+        /// and the skill runner also use, and the one an operator greps their logs for —
+        /// and names <paramref name="reason"/> whenever the host can say why.
+        ///
+        /// <para>
+        /// Split out of <see cref="DescribeHost"/> because each branch is reachable only
+        /// on one shape of host: the Linux wording can be edited on Windows or macOS
+        /// with nothing there to run it, which is how <c>"no safe OS sandbox available"</c>
+        /// shipped and broke the test that pins this phrase on a Linux box with no
+        /// bubblewrap. Here it is pinned by value on every platform. The distinction the
+        /// dropped adjective was reaching for survives in the reason: an unusably old
+        /// bubblewrap names its version, an absent one says it is not installed, and
+        /// those are different jobs to fix.
+        /// </para>
+        /// </summary>
+        /// <param name="reason">Why nothing is confining this host, or empty when there
+        /// is nothing to add beyond the platform having no mechanism at all.</param>
+        internal static string NoSandboxSummary(string reason) =>
+            string.IsNullOrWhiteSpace(reason)
+                ? "no OS sandbox available on this platform"
+                : "no OS sandbox available: " + reason;
     }
 
     /// <summary>
@@ -539,8 +562,16 @@ namespace TensorSharp.AgentHost.Skills
         /// (it is the skill root the operator configured plus a GUID), but a stray quote
         /// would silently truncate the profile and widen the sandbox, so it is escaped
         /// rather than trusted.
+        ///
+        /// <para>
+        /// Internal rather than private so a test can build the rule it expects with the
+        /// SAME escaping the profile was written with. A test that spelled the path out
+        /// raw matched on every platform whose separator is not itself the escape
+        /// character, and only on the one where it is did the expectation and the
+        /// profile disagree.
+        /// </para>
         /// </summary>
-        private static string Quote(string path) =>
+        internal static string Quote(string path) =>
             "\"" + path.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
 
         private sealed class NullCleanup : IDisposable


### PR DESCRIPTION
Fixes #191. Unblocks #190.

`InferenceWeb.Tests` has been red on `ubuntu-latest` for every PR, not just #190: `main` at c8548aa reports `Failed: 3, Passed: 2765` ([run 33699866534](https://github.com/zhongkaifu/TensorSharp/actions/runs/33699866534)). All three failures are host-dependent **tests**, not product defects, and none of them are caused by the change in #190.

Reproduced on WSL Ubuntu 24.04 — bash 5.2, no bubblewrap, i.e. the same host shape as `ubuntu-latest` — where the three failures appear byte-for-byte as CI reports them.

## The three failures

### `DescribeHost_NamesTheSandboxOrSaysThereIsNone`

The Linux no-sandbox branch opened `"no safe OS sandbox available: "`, while the test pins the phrase `"no OS sandbox"` that `ShellRunner` and `SkillScriptRunner` both use. That branch is reachable **only on a Linux host without bubblewrap**, so no other platform could ever catch the drift.

The wording is restored, and the branch is split into `SkillSandboxFactory.NoSandboxSummary(reason)` so a new test can pin both spellings **by value on every platform**. The reason still names *why*, because "bubblewrap is not installed" and "bubblewrap 0.9.0 is below the 0.12.0 floor" are different jobs to fix — both spellings were exercised.

### `AnEnvironmentValueWithANewline_DoesNotBreakTheNextCommand`

The test asserted `"was reset"` — an artifact only `sh`/`dash` ever produce. `ShellProgram` prefers **bash**, and bash ≥ 4.4 writes a newline-valued export as a *single* ANSI-C-quoted line:

```
declare -x NOTE=$'a\nPATH=b'
```

so the save-side line filter cuts nothing, the file stays valid, and no reset ever happens. The assertion could only pass on a POSIX host with no modern bash.

It now asserts the contract that holds everywhere — the value comes back **whole or gone, never half**, and the record's second line never becomes `PATH` — and a new `ACorruptSavedEnvironment_IsResetAndSaidOutLoud` seeds the truncated record directly, so the reset announcement stays pinned on bash and dash alike.

### `DrainingIsBoundedWhenSomethingElseHoldsThePipe`

A **race**, not a host quirk. `sh -c` runs without job control, so `setsid sleep 30 &` is forked *into* the launch group and leaves it only once it has exec'd `setsid(1)` and that has called `setsid(2)` — while `SpawnedProcess.StartReaper` SIGKILLs the whole launch group the instant the shell exits. Instrumented locally: the reaper won 2 runs in 3, the escapee died, both pipes reached EOF, and the drain "succeeded" for a reason unrelated to what the test checks.

The shell now outlives the escape, and an explicit liveness check fails with the real cause if it ever does not, instead of surfacing as a confusing "the pipe cannot be at EOF".

## Folded in from #190

@vvdb-architecture correctly diagnosed a separate **Windows-only** failure in `ExactReadableFilesAndAdditionalWritableRoots_ArePinnedOnEveryPlatform`: the assertions spelled host paths out raw, which cannot match on Windows because `SeatbeltSandbox.BuildProfile` escapes every backslash. Confirmed — it is the only failure of those four classes on Windows.

Fixed as reported, but routed through the production quoter (`SeatbeltSandbox.Quote`, now `internal`) rather than a copy of it in the test, and the whole rule including closing parens is pinned. A new `SbplPathQuoting_EscapesBackslashesBeforeQuotes` pins the escaping itself by value, so expectation and emission cannot drift into agreeing about something wrong. #190 can be closed in favour of this, or merged first — in which case delete the private `Quote` helper it adds.

## One production fix

`ShellSession.Reset()` now clears the `.reset` marker along with the files it describes. A marker left behind is consumed by a *later* command, which then reports an environment reset that never happened — the "reported a constraint that was not the real one" shape this suite exists to catch.

## Verification

| | before | after |
|---|---|---|
| Windows, CI filter | 1 failure in the four classes (#190's) | **2771 / 2771** |
| Linux (WSL Ubuntu 24.04) | 3 failures, identical to CI | **0**, and 10/10 repeat runs |

Also checked on Linux: both shells (bash → the value survives intact; dash → it is dropped and the reset is announced), and both no-sandbox shapes (bubblewrap absent, and bubblewrap 0.9.0 rejected by the version floor).

Every new or changed assertion was **mutation-tested** — reintroducing the defect it guards makes it fail:

- suppress the reset announcement → `ACorruptSavedEnvironment_IsResetAndSaidOutLoud` fails;
- restore the saved environment without the trial-source guard (the original defect) → the newline test fails on a dash host;
- remove the setsid escape → the drain test fails.

A/B micro-benchmark of the touched paths (3 reps per side against `main`): `DescribeHost`, `SeatbeltSandbox.BuildProfile` and the `ShellRunner.Run` round-trip are all within run-to-run noise on both OSes. The one measurable delta is `ShellSession.Reset()` on Windows, 38.5 → ~59 µs, for the extra `File.Exists` on the marker; it is unchanged on Linux (~1.7 µs) and the method has no production callers. Dropping the `Exists` probe to pay it back measured *worse* on Windows, so the probe stays.

## Noted, not fixed

`SpawnedProcess.Kill()` signals `-_pid` unguarded after the reaper has already `waitpid`'d the leader, so a late `Dispose()` can SIGKILL a **recycled** pid's whole process group; the `getpgid(_pid) == _pid` guard does not help, because a recycled pid that leads its own group passes it. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
