### PR TITLE
(Minor)TensorSharp.Core is nullable-enabled and warning free

### DIFF
--- a/TensorSharp.Core/Core/TensorResultBuilder.cs
+++ b/TensorSharp.Core/Core/TensorResultBuilder.cs
@@ -14,12 +14,12 @@ namespace TensorSharp.Core
     public static class TensorResultBuilder
     {
         // If a maybeResult is null, a new tensor will be constructed using the device id and element type of newTemplate
-        public static Tensor GetWriteTarget(Tensor maybeResult, Tensor newTemplate, bool requireContiguous, params long[] requiredSizes)
+        public static Tensor GetWriteTarget(Tensor? maybeResult, Tensor newTemplate, bool requireContiguous, params long[] requiredSizes)
         {
             return GetWriteTarget(maybeResult, newTemplate.Allocator, newTemplate.ElementType, requireContiguous, (ReadOnlySpan<long>)requiredSizes);
         }
 
-        public static Tensor GetWriteTarget(Tensor maybeResult, Tensor newTemplate, bool requireContiguous, ReadOnlySpan<long> requiredSizes)
+        public static Tensor GetWriteTarget(Tensor? maybeResult, Tensor newTemplate, bool requireContiguous, ReadOnlySpan<long> requiredSizes)
         {
             return GetWriteTarget(maybeResult, newTemplate.Allocator, newTemplate.ElementType, requireContiguous, requiredSizes);
         }
@@ -29,7 +29,7 @@ namespace TensorSharp.Core
             return GetWriteTarget(maybeResult, allocatorForNew, elementTypeForNew, requireContiguous, (ReadOnlySpan<long>)requiredSizes);
         }
 
-        public static Tensor GetWriteTarget(Tensor maybeResult, IAllocator allocatorForNew, DType elementTypeForNew, bool requireContiguous, ReadOnlySpan<long> requiredSizes)
+        public static Tensor GetWriteTarget(Tensor? maybeResult, IAllocator allocatorForNew, DType elementTypeForNew, bool requireContiguous, ReadOnlySpan<long> requiredSizes)
         {
             if (maybeResult != null)
             {

--- a/TensorSharp.Core/Cpu/CpuRandom.cs
+++ b/TensorSharp.Core/Cpu/CpuRandom.cs
@@ -24,7 +24,7 @@ namespace TensorSharp.Cpu
 
 
         // allArgs should start with a null placeholder for the RNG object
-        private static void InvokeWithRng(int? seed, MethodInfo method, params object[] allArgs)
+        private static void InvokeWithRng(int? seed, MethodInfo method, params object?[] allArgs)
         {
             if (!seed.HasValue)
             {

--- a/TensorSharp.Core/Cpu/MatrixMultiplication.cs
+++ b/TensorSharp.Core/Cpu/MatrixMultiplication.cs
@@ -913,7 +913,7 @@ namespace TensorSharp.Cpu
             }
             else
             {
-                throw new NotSupportedException("CPU vector dot product with element type " + result.ElementType + " not supported");
+                throw new NotSupportedException("CPU vector dot product with element type " + writeTarget.ElementType + " not supported");
             }
 
             return writeTarget;
@@ -949,11 +949,11 @@ namespace TensorSharp.Cpu
             }
         }
 
-        public static Tensor Mul_M_V(Tensor result, Tensor lhs, Tensor rhs)
+        public static Tensor Mul_M_V(Tensor? result, Tensor lhs, Tensor rhs)
         {
             if (lhs.ElementType != rhs.ElementType || (result != null && result.ElementType != lhs.ElementType))
             {
-                throw new InvalidOperationException($"All tensors must have the same element type  lhs = '{lhs.ElementType}', rhs = '{rhs.ElementType}' result = '{result.ElementType}'");
+                throw new InvalidOperationException($"All tensors must have the same element type  lhs = '{lhs.ElementType}', rhs = '{rhs.ElementType}' result = '{(result == null ? "null": result.ElementType.ToString())}'");
             }
 
             if (result != null && (result.Storage is CpuStorage))
@@ -1009,7 +1009,7 @@ namespace TensorSharp.Cpu
                 }
                 else
                 {
-                    throw new NotSupportedException("CPU Matrix-Vector multiplication with element type " + result.ElementType + " not supported");
+                    throw new NotSupportedException("CPU Matrix-Vector multiplication with element type " + writeTarget.ElementType + " not supported");
                 }
             }
             finally
@@ -1268,9 +1268,9 @@ namespace TensorSharp.Cpu
             BlasOp bOp = default(BlasOp);
             bool copyC = false;
 
-            Tensor aClone = null;
-            Tensor bClone = null;
-            Tensor cClone = null;
+            Tensor? aClone = null;
+            Tensor? bClone = null;
+            Tensor? cClone = null;
 
 
             if (c.Strides[1] == 1 &&

--- a/TensorSharp.Core/Cpu/NativeWrapper.cs
+++ b/TensorSharp.Core/Cpu/NativeWrapper.cs
@@ -20,7 +20,9 @@ namespace TensorSharp.Cpu
     {
         public static MethodInfo GetMethod(string name)
         {
-            return typeof(CpuOpsNative).GetMethod(name, BindingFlags.Public | BindingFlags.Static);
+            var method = typeof(CpuOpsNative).GetMethod(name, BindingFlags.Public | BindingFlags.Static);
+            ArgumentNullException.ThrowIfNull(method);
+            return method;
         }
 
         public static Tensor InvokeNullableResultElementwise(MethodInfo method, params object[] args)
@@ -80,7 +82,7 @@ namespace TensorSharp.Cpu
             return resultTensor;
         }
 
-        public static void InvokeTypeMatch(MethodInfo method, params object[] args)
+        public static void InvokeTypeMatch(MethodInfo method, params object?[] args)
         {
             IEnumerable<Tensor> tensors = args.OfType<Tensor>();
             if (tensors.Any())
@@ -112,7 +114,7 @@ namespace TensorSharp.Cpu
             });
         }
 
-        public static void Invoke(MethodInfo method, params object[] args)
+        public static void Invoke(MethodInfo method, params object?[] args)
         {
             List<TensorRef64> freeListTensor = new List<TensorRef64>();
             List<IntPtr> freeListPtr = new List<IntPtr>();
@@ -140,8 +142,7 @@ namespace TensorSharp.Cpu
                 }
 
                 //return method.Invoke(null, args);
-                int result = (int)method.Invoke(null, args);
-                if (result != 0)
+                if (method.Invoke(null, args) is not int result  || result != 0)
                 {
                     throw new ApplicationException(GetLastError());
                 }
@@ -168,7 +169,7 @@ namespace TensorSharp.Cpu
             }
         }
 
-        private static string GetLastError()
+        private static string? GetLastError()
         {
             IntPtr strPtr = CpuOpsNative.TS_GetLastError();
             return Marshal.PtrToStringAnsi(strPtr);

--- a/TensorSharp.Core/DType.cs
+++ b/TensorSharp.Core/DType.cs
@@ -116,7 +116,7 @@ namespace TensorSharp
 
     public static class DTypeBuilder
     {
-        public static DType FromCLRType(Type type)
+        public static DType FromCLRType(Type? type)
         {
             if (type == typeof(Half))
             {

--- a/TensorSharp.Core/OpConstraint.cs
+++ b/TensorSharp.Core/OpConstraint.cs
@@ -13,7 +13,7 @@ namespace TensorSharp
 {
     public abstract class OpConstraint
     {
-        public abstract bool SatisfiedFor(object[] args);
+        public abstract bool SatisfiedFor(object?[] args);
     }
 
     public class ArgCountConstraint : OpConstraint
@@ -22,7 +22,7 @@ namespace TensorSharp
 
         public ArgCountConstraint(int argCount) { this.argCount = argCount; }
 
-        public override bool SatisfiedFor(object[] args)
+        public override bool SatisfiedFor(object?[] args)
         {
             return args.Length == argCount;
         }
@@ -41,7 +41,7 @@ namespace TensorSharp
             this.allowNull = allowNull;
         }
 
-        public override bool SatisfiedFor(object[] args)
+        public override bool SatisfiedFor(object?[] args)
         {
             if (allowNull && args[argIndex] == null)
             {
@@ -52,8 +52,9 @@ namespace TensorSharp
                 return false;
             }
 
-            Storage argStorage = ((Tensor)args[argIndex]).Storage;
-            return argStorage.GetType() == requiredType;
+            // it could be that args[argIndex] is null and allowNull is true,
+            Storage? argStorage = ((Tensor?)args[argIndex])?.Storage;
+            return argStorage?.GetType() == requiredType;
         }
     }
 }

--- a/TensorSharp.Core/OpRegistry.cs
+++ b/TensorSharp.Core/OpRegistry.cs
@@ -14,14 +14,14 @@ using System.Reflection;
 
 namespace TensorSharp
 {
-    public delegate object OpHandler(object[] args);
+    public delegate object? OpHandler(object?[] args);
 
     public static class OpRegistry
     {
         private class OpInstance
         {
-            public OpHandler handler;
-            public IEnumerable<OpConstraint> constraints;
+            public required OpHandler handler;
+            public required IEnumerable<OpConstraint> constraints;
         }
 
         private static readonly Dictionary<string, List<OpInstance>> opInstances = new Dictionary<string, List<OpInstance>>();
@@ -38,7 +38,7 @@ namespace TensorSharp
         {
             OpInstance newInstance = new OpInstance() { handler = handler, constraints = constraints };
 
-            if (opInstances.TryGetValue(opName, out List<OpInstance> instanceList))
+            if (opInstances.TryGetValue(opName, out List<OpInstance>? instanceList))
             {
                 instanceList.Add(newInstance);
             }
@@ -61,13 +61,13 @@ namespace TensorSharp
         ///
         /// Null (and therefore free) unless a backend opts in.
         /// </summary>
-        public static Action<object[]> PreInvokeHook;
+        public static Action<object?[]>? PreInvokeHook;
 
-        public static object Invoke(string opName, params object[] args)
+        public static object? Invoke(string opName, params object?[] args)
         {
             PreInvokeHook?.Invoke(args);
 
-            if (opInstances.TryGetValue(opName, out List<OpInstance> instanceList))
+            if (opInstances.TryGetValue(opName, out List<OpInstance>? instanceList))
             {
                 foreach (OpInstance instance in instanceList)
                 {
@@ -96,7 +96,8 @@ namespace TensorSharp
 
                 foreach (Type type in types)
                 {
-                    object instance = Activator.CreateInstance(type);
+                    object? instance = Activator.CreateInstance(type);
+                    ArgumentNullException.ThrowIfNull(instance);
 
                     IEnumerable<Tuple<MethodInfo, IEnumerable<RegisterOp>>> methods = type.MethodsWithAttribute<RegisterOp>(false);
                     foreach (Tuple<MethodInfo, IEnumerable<RegisterOp>> method in methods)

--- a/TensorSharp.Core/OpRegistryAttributes.cs
+++ b/TensorSharp.Core/OpRegistryAttributes.cs
@@ -29,7 +29,7 @@ namespace TensorSharp
             OpName = opName;
         }
 
-        protected static object InvokeRegisteredMethod(object instance, MethodInfo method, object[] args)
+        protected static object? InvokeRegisteredMethod(object instance, MethodInfo method, object?[] args)
         {
             try
             {

--- a/TensorSharp.Core/Ops.cs
+++ b/TensorSharp.Core/Ops.cs
@@ -53,24 +53,26 @@ namespace TensorSharp
             return TensorConcatenation.Concat(result, dimension, inputs);
         }
 
+        // Note: the null-forgiving operator is used in those cases where we can safely assume that the result of an Invoke() operation will never be null (verifying this assumption at runtime is computationally too expensive).
+
         public static void Copy(Tensor result, Tensor src) { OpRegistry.Invoke("copy", result, src); }
         public static void Fill(Tensor result, float value) { OpRegistry.Invoke("fill", result, value); }
 
-        public static Tensor Dot(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("dot", result, lhs, rhs); }
-        public static Tensor Addmm(Tensor result, float beta, Tensor src, float alpha, Tensor m1, Tensor m2) { return (Tensor)OpRegistry.Invoke("addmm", result, beta, src, alpha, m1, m2); }
+        public static Tensor Dot(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("dot", result, lhs, rhs)!; }
+        public static Tensor Addmm(Tensor result, float beta, Tensor src, float alpha, Tensor m1, Tensor m2) { return (Tensor)OpRegistry.Invoke("addmm", result, beta, src, alpha, m1, m2)!; }
 
-        public static Tensor AddmmBatch(Tensor result, float beta, Tensor src, float alpha, Tensor m1, Tensor m2) { return (Tensor)OpRegistry.Invoke("addmmbatch", result, beta, src, alpha, m1, m2); }
+        public static Tensor AddmmBatch(Tensor result, float beta, Tensor src, float alpha, Tensor m1, Tensor m2) { return (Tensor)OpRegistry.Invoke("addmmbatch", result, beta, src, alpha, m1, m2)!; }
 
-        public static Tensor Abs(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("abs", result, src); }
-        public static Tensor Neg(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("neg", result, src); }
-        public static Tensor Sign(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("sign", result, src); }
+        public static Tensor Abs(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("abs", result, src)!; }
+        public static Tensor Neg(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("neg", result, src)!; }
+        public static Tensor Sign(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("sign", result, src)!; }
 
 
 
-        public static Tensor SiLU(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("SiLU", result, src); }
-        public static Tensor GELU(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("GELU", result, src); }
+        public static Tensor SiLU(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("SiLU", result, src)!; }
+        public static Tensor GELU(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("GELU", result, src)!; }
 
-        public static Tensor SiLUMul(Tensor result, Tensor gate, Tensor up) { return (Tensor)OpRegistry.Invoke("SiLUMul", result, gate, up); }
+        public static Tensor SiLUMul(Tensor result, Tensor gate, Tensor up) { return (Tensor)OpRegistry.Invoke("SiLUMul", result, gate, up)!; }
 
         /// <summary>
         /// Clamped SwiGLU: result = clamp(up, -limit, +limit) * SiLU(min(gate, limit)).
@@ -82,21 +84,19 @@ namespace TensorSharp
         /// because SiLU already saturates on the negative side, while the up
         /// projection is clamped on both.
         /// </summary>
-        public static Tensor SiLUMulClamp(Tensor result, Tensor gate, Tensor up, float limit) { return (Tensor)OpRegistry.Invoke("SiLUMulClamp", result, gate, up, limit); }
+        public static Tensor SiLUMulClamp(Tensor result, Tensor gate, Tensor up, float limit) { return (Tensor)OpRegistry.Invoke("SiLUMulClamp", result, gate, up, limit)!; }
 
-        public static Tensor SiLUMulSplit(Tensor result, Tensor gateUp, int halfDim) { return (Tensor)OpRegistry.Invoke("SiLUMulSplit", result, gateUp, halfDim); }
-        public static Tensor GELUMul(Tensor result, Tensor gate, Tensor up) { return (Tensor)OpRegistry.Invoke("GELUMul", result, gate, up); }
-        public static Tensor SigmoidMul(Tensor result, Tensor x, Tensor gate) { return (Tensor)OpRegistry.Invoke("SigmoidMul", result, x, gate); }
-
-
+        public static Tensor SiLUMulSplit(Tensor result, Tensor gateUp, int halfDim) { return (Tensor)OpRegistry.Invoke("SiLUMulSplit", result, gateUp, halfDim)!; }
+        public static Tensor GELUMul(Tensor result, Tensor gate, Tensor up) { return (Tensor)OpRegistry.Invoke("GELUMul", result, gate, up)!; }
+        public static Tensor SigmoidMul(Tensor result, Tensor x, Tensor gate) { return (Tensor)OpRegistry.Invoke("SigmoidMul", result, x, gate)!; }
 
 
 
 
 
-        public static Tensor Relu(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("relu", result, src); }
 
 
+        public static Tensor Relu(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("relu", result, src)!; }
 
 
 
@@ -106,103 +106,105 @@ namespace TensorSharp
 
 
 
-        public static Tensor Exp(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("exp", result, src); }
-        public static Tensor Log(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("log", result, src); }
-        public static Tensor Log1p(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("log1p", result, src); }
-        public static Tensor Floor(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("floor", result, src); }
-        public static Tensor Ceil(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("ceil", result, src); }
-        public static Tensor Round(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("round", result, src); }
-        public static Tensor Trunc(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("trunc", result, src); }
-        public static Tensor Frac(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("frac", result, src); }
-
-        public static Tensor Cos(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("cos", result, src); }
-        public static Tensor Tan(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("tan", result, src); }
-
-        public static Tensor Asin(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("asin", result, src); }
-        public static Tensor Acos(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("acos", result, src); }
-        public static Tensor Atan(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("atan", result, src); }
-
-        public static Tensor Sinh(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("sinh", result, src); }
-        public static Tensor Cosh(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("cosh", result, src); }
-        public static Tensor Tanh(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("tanh", result, src); }
-
-        public static Tensor Sigmoid(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("sigmoid", result, src); }
 
 
+        public static Tensor Exp(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("exp", result, src)!; }
+        public static Tensor Log(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("log", result, src)!; }
+        public static Tensor Log1p(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("log1p", result, src)!; }
+        public static Tensor Floor(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("floor", result, src)!; }
+        public static Tensor Ceil(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("ceil", result, src)!; }
+        public static Tensor Round(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("round", result, src)!; }
+        public static Tensor Trunc(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("trunc", result, src)!; }
+        public static Tensor Frac(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("frac", result, src)!; }
 
+        public static Tensor Cos(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("cos", result, src)!; }
+        public static Tensor Tan(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("tan", result, src)!; }
 
+        public static Tensor Asin(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("asin", result, src)!; }
+        public static Tensor Acos(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("acos", result, src)!; }
+        public static Tensor Atan(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("atan", result, src)!; }
+
+        public static Tensor Sinh(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("sinh", result, src)!; }
+        public static Tensor Cosh(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("cosh", result, src)!; }
+        public static Tensor Tanh(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("tanh", result, src)!; }
+
+        public static Tensor Sigmoid(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("sigmoid", result, src)!; }
 
 
 
 
-        public static Tensor MulMulAdd(Tensor result, Tensor x, Tensor y, Tensor z, Tensor w) { return (Tensor)OpRegistry.Invoke("mulmuladd", result, x, y, z, w); }
-
-        public static Tensor AddMul(Tensor result, Tensor x, Tensor y, Tensor z) { return (Tensor)OpRegistry.Invoke("addmul", result, x, y, z); }
-        public static Tensor AddMulV(Tensor result, Tensor x, Tensor y, float z) { return (Tensor)OpRegistry.Invoke("addmulv", result, x, y, z); }
-
-        public static Tensor AddDiv(Tensor result, Tensor x, Tensor y, Tensor z) { return (Tensor)OpRegistry.Invoke("adddiv", result, x, y, z); }
 
 
 
 
-        public static Tensor Atan2(Tensor result, Tensor srcY, Tensor srcX) { return (Tensor)OpRegistry.Invoke("atan2", result, srcY, srcX); }
-        public static Tensor Pow(Tensor result, Tensor src, float value) { return (Tensor)OpRegistry.Invoke("pow", result, src, value); }
-        public static Tensor Tpow(Tensor result, float value, Tensor src) { return (Tensor)OpRegistry.Invoke("tpow", result, value, src); }
-        public static Tensor Lerp(Tensor result, Tensor srcA, Tensor srcB, float weight) { return (Tensor)OpRegistry.Invoke("lerp", result, srcA, srcB); }
-        public static Tensor Clamp(Tensor result, Tensor src, float min, float max) { return (Tensor)OpRegistry.Invoke("clamp", result, src, min, max); }
+        public static Tensor MulMulAdd(Tensor result, Tensor x, Tensor y, Tensor z, Tensor w) { return (Tensor)OpRegistry.Invoke("mulmuladd", result, x, y, z, w)!; }
 
-        public static Tensor Add(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("addv", result, lhs, rhs); }
-        public static Tensor Sub(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("subv", result, lhs, rhs); }
-        public static Tensor Sub(Tensor result, float lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("rsubv", result, lhs, rhs); }
-        public static Tensor Mul(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("mulv", result, lhs, rhs); }
-        public static Tensor Div(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("divv", result, lhs, rhs); }
-        public static Tensor Div(Tensor result, float lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("rdivv", result, lhs, rhs); }
+        public static Tensor AddMul(Tensor result, Tensor x, Tensor y, Tensor z) { return (Tensor)OpRegistry.Invoke("addmul", result, x, y, z)!; }
+        public static Tensor AddMulV(Tensor result, Tensor x, Tensor y, float z) { return (Tensor)OpRegistry.Invoke("addmulv", result, x, y, z)!; }
 
-        public static Tensor GreaterThan(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("gtValue", result, lhs, rhs); }
-        public static Tensor LessThan(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("ltValue", result, lhs, rhs); }
-        public static Tensor GreaterOrEqual(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("geValue", result, lhs, rhs); }
-        public static Tensor LessOrEqual(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("leValue", result, lhs, rhs); }
-        public static Tensor EqualTo(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("eqValue", result, lhs, rhs); }
-        public static Tensor NotEqual(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("neValue", result, lhs, rhs); }
-
-        public static Tensor Add(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("addt", result, lhs, rhs); }
-        public static Tensor Sub(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("subt", result, lhs, rhs); }
-        public static Tensor Mul(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("mult", result, lhs, rhs); }
-        public static Tensor Div(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("divt", result, lhs, rhs); }
+        public static Tensor AddDiv(Tensor result, Tensor x, Tensor y, Tensor z) { return (Tensor)OpRegistry.Invoke("adddiv", result, x, y, z)!; }
 
 
 
-        public static Tensor GreaterThan(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("gtTensor", result, lhs, rhs); }
-        public static Tensor LessThan(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("ltTensor", result, lhs, rhs); }
-        public static Tensor GreaterOrEqual(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("geTensor", result, lhs, rhs); }
-        public static Tensor LessOrEqual(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("leTensor", result, lhs, rhs); }
-        public static Tensor EqualTo(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("eqTensor", result, lhs, rhs); }
-        public static Tensor NotEqual(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("neTensor", result, lhs, rhs); }
+
+        public static Tensor Atan2(Tensor result, Tensor srcY, Tensor srcX) { return (Tensor)OpRegistry.Invoke("atan2", result, srcY, srcX)!; }
+        public static Tensor Pow(Tensor result, Tensor src, float value) { return (Tensor)OpRegistry.Invoke("pow", result, src, value)!; }
+        public static Tensor Tpow(Tensor result, float value, Tensor src) { return (Tensor)OpRegistry.Invoke("tpow", result, value, src)!; }
+        public static Tensor Lerp(Tensor result, Tensor srcA, Tensor srcB, float weight) { return (Tensor)OpRegistry.Invoke("lerp", result, srcA, srcB, weight)!; }
+        public static Tensor Clamp(Tensor result, Tensor src, float min, float max) { return (Tensor)OpRegistry.Invoke("clamp", result, src, min, max)!; }
+
+        public static Tensor Add(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("addv", result, lhs, rhs)!; }
+        public static Tensor Sub(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("subv", result, lhs, rhs)!; }
+        public static Tensor Sub(Tensor result, float lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("rsubv", result, lhs, rhs)!; }
+        public static Tensor Mul(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("mulv", result, lhs, rhs)!; }
+        public static Tensor Div(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("divv", result, lhs, rhs)!; }
+        public static Tensor Div(Tensor result, float lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("rdivv", result, lhs, rhs)!; }
+
+        public static Tensor GreaterThan(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("gtValue", result, lhs, rhs)!; }
+        public static Tensor LessThan(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("ltValue", result, lhs, rhs)!; }
+        public static Tensor GreaterOrEqual(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("geValue", result, lhs, rhs)!; }
+        public static Tensor LessOrEqual(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("leValue", result, lhs, rhs)!; }
+        public static Tensor EqualTo(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("eqValue", result, lhs, rhs)!; }
+        public static Tensor NotEqual(Tensor result, Tensor lhs, float rhs) { return (Tensor)OpRegistry.Invoke("neValue", result, lhs, rhs)!; }
+
+        public static Tensor Add(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("addt", result, lhs, rhs)!; }
+        public static Tensor Sub(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("subt", result, lhs, rhs)!; }
+        public static Tensor Mul(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("mult", result, lhs, rhs)!; }
+        public static Tensor Div(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("divt", result, lhs, rhs)!; }
 
 
-        public static Tensor Sum(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("sum", result, src, dimension); }
-        public static Tensor Prod(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("prod", result, src, dimension); }
-        public static Tensor Min(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("min", result, src, dimension); }
-        public static Tensor Max(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("max", result, src, dimension); }
-        public static Tensor Argmin(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("argmin", result, src, dimension); }
-        public static Tensor Argmax(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("argmax", result, src, dimension); }
 
-        public static Tensor Mean(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("mean", result, src, dimension); }
-        public static Tensor Norm(Tensor result, Tensor src, int dimension, float value) { return (Tensor)OpRegistry.Invoke("norm", result, src, dimension, value); }
-        public static Tensor Std(Tensor result, Tensor src, int dimension, bool normByN) { return (Tensor)OpRegistry.Invoke("std", result, src, dimension, normByN); }
-        public static Tensor Var(Tensor result, Tensor src, int dimension, bool normByN) { return (Tensor)OpRegistry.Invoke("var", result, src, dimension, normByN); }
-
-        public static Tensor Softmax(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("softmax", result, src); }
+        public static Tensor GreaterThan(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("gtTensor", result, lhs, rhs)!; }
+        public static Tensor LessThan(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("ltTensor", result, lhs, rhs)!; }
+        public static Tensor GreaterOrEqual(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("geTensor", result, lhs, rhs)!; }
+        public static Tensor LessOrEqual(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("leTensor", result, lhs, rhs)!; }
+        public static Tensor EqualTo(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("eqTensor", result, lhs, rhs)!; }
+        public static Tensor NotEqual(Tensor result, Tensor lhs, Tensor rhs) { return (Tensor)OpRegistry.Invoke("neTensor", result, lhs, rhs)!; }
 
 
-        public static Tensor IndexSelect(Tensor result, Tensor src, Tensor indice, bool isAdd = false) { return (Tensor)OpRegistry.Invoke("indexselect", result, src, indice, isAdd); }
+        public static Tensor Sum(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("sum", result, src, dimension)!; }
+        public static Tensor Prod(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("prod", result, src, dimension)!; }
+        public static Tensor Min(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("min", result, src, dimension)!; }
+        public static Tensor Max(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("max", result, src, dimension)!; }
+        public static Tensor Argmin(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("argmin", result, src, dimension)!; }
+        public static Tensor Argmax(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("argmax", result, src, dimension)!; }
+
+        public static Tensor Mean(Tensor result, Tensor src, int dimension) { return (Tensor)OpRegistry.Invoke("mean", result, src, dimension)!; }
+        public static Tensor Norm(Tensor result, Tensor src, int dimension, float value) { return (Tensor)OpRegistry.Invoke("norm", result, src, dimension, value)!; }
+        public static Tensor Std(Tensor result, Tensor src, int dimension, bool normByN) { return (Tensor)OpRegistry.Invoke("std", result, src, dimension, normByN)!; }
+        public static Tensor Var(Tensor result, Tensor src, int dimension, bool normByN) { return (Tensor)OpRegistry.Invoke("var", result, src, dimension, normByN)!; }
+
+        public static Tensor Softmax(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("softmax", result, src)!; }
+
+
+        public static Tensor IndexSelect(Tensor result, Tensor src, Tensor indice, bool isAdd = false) { return (Tensor)OpRegistry.Invoke("indexselect", result, src, indice, isAdd)!; }
 
         /// <summary>
         /// Repeat each slice along <paramref name="dim"/> <paramref name="repeats"/> times consecutively.
         /// Input must be contiguous. Result shape is the same as src except dimension <paramref name="dim"/>
         /// is multiplied by <paramref name="repeats"/>.
         /// </summary>
-        public static Tensor RepeatInterleave(Tensor result, Tensor src, int repeats, int dim) { return (Tensor)OpRegistry.Invoke("repeat_interleave", result, src, repeats, dim); }
+        public static Tensor RepeatInterleave(Tensor result, Tensor src, int repeats, int dim) { return (Tensor)OpRegistry.Invoke("repeat_interleave", result, src, repeats, dim)!; }
 
         /// <summary>
         /// In-place causal mask: for each logical row t (with period <paramref name="seqLen"/> across outer dims),
@@ -213,10 +215,10 @@ namespace TensorSharp
 
 
 
-        public static Tensor RoPE(Tensor result, Tensor src, int seqLen, int rowOffset) { return (Tensor)OpRegistry.Invoke("rope", result, src, seqLen, rowOffset); }
+        public static Tensor RoPE(Tensor result, Tensor src, int seqLen, int rowOffset) { return (Tensor)OpRegistry.Invoke("rope", result, src, seqLen, rowOffset)!; }
         public static Tensor RoPEEx(Tensor result, Tensor src, Tensor positions, int ropeDim, int mode, int originalContextLength, float freqBase, float freqScale, float extFactor = 0.0f, float attnFactor = 1.0f, float betaFast = 0.0f, float betaSlow = 0.0f, bool addToResult = false, bool invertPositions = false)
         {
-            return (Tensor)OpRegistry.Invoke("rope_ex", result, src, positions, ropeDim, mode, originalContextLength, freqBase, freqScale, extFactor, attnFactor, betaFast, betaSlow, addToResult, invertPositions);
+            return (Tensor)OpRegistry.Invoke("rope_ex", result, src, positions, ropeDim, mode, originalContextLength, freqBase, freqScale, extFactor, attnFactor, betaFast, betaSlow, addToResult, invertPositions)!;
         }
 
 
@@ -226,29 +228,29 @@ namespace TensorSharp
 
 
 
-        public static Tensor LayerNorm(Tensor result, Tensor src, Tensor alpha, Tensor beta, float eps = 1e-09f) { return (Tensor)OpRegistry.Invoke("layernorm", result, src, alpha, beta, eps); }
+        public static Tensor LayerNorm(Tensor result, Tensor src, Tensor alpha, Tensor beta, float eps = 1e-09f) { return (Tensor)OpRegistry.Invoke("layernorm", result, src, alpha, beta, eps)!; }
 
 
         public static Tensor ScaledDotProductAttention(Tensor result, Tensor query, Tensor key, Tensor value, Tensor mask, float scale)
         {
-            return (Tensor)OpRegistry.Invoke("scaled_dot_product_attention", result, query, key, value, mask, scale);
+            return (Tensor)OpRegistry.Invoke("scaled_dot_product_attention", result, query, key, value, mask, scale)!;
         }
 
 
-        public static Tensor RMSNorm(Tensor result, Tensor src, Tensor alpha, Tensor beta, float eps = 1e-09f) { return (Tensor)OpRegistry.Invoke("rmsnorm", result, src, alpha, beta, eps); }
+        public static Tensor RMSNorm(Tensor result, Tensor src, Tensor alpha, Tensor beta, float eps = 1e-09f) { return (Tensor)OpRegistry.Invoke("rmsnorm", result, src, alpha, beta, eps)!; }
 
 
 
 
-        public static Tensor SumAll(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("sumall", result, src); }
-        public static Tensor ProdAll(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("prodall", result, src); }
-        public static Tensor MinAll(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("minall", result, src); }
-        public static Tensor MaxAll(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("maxall", result, src); }
+        public static Tensor SumAll(Tensor? result, Tensor src) { return (Tensor)OpRegistry.Invoke("sumall", result, src)!; }
+        public static Tensor ProdAll(Tensor? result, Tensor src) { return (Tensor)OpRegistry.Invoke("prodall", result, src)!; }
+        public static Tensor MinAll(Tensor? result, Tensor src) { return (Tensor)OpRegistry.Invoke("minall", result, src)!; }
+        public static Tensor MaxAll(Tensor? result, Tensor src) { return (Tensor)OpRegistry.Invoke("maxall", result, src)!; }
 
-        public static Tensor MeanAll(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("meanall", result, src); }
-        public static Tensor NormAll(Tensor result, Tensor src, float value) { return (Tensor)OpRegistry.Invoke("normall", result, src, value); }
-        public static Tensor StdAll(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("stdall", result, src); }
-        public static Tensor VarAll(Tensor result, Tensor src) { return (Tensor)OpRegistry.Invoke("varall", result, src); }
+        public static Tensor MeanAll(Tensor? result, Tensor src) { return (Tensor)OpRegistry.Invoke("meanall", result, src)!; }
+        public static Tensor NormAll(Tensor? result, Tensor src, float value) { return (Tensor)OpRegistry.Invoke("normall", result, src, value)!; }
+        public static Tensor StdAll(Tensor? result, Tensor src) { return (Tensor)OpRegistry.Invoke("stdall", result, src)!; }
+        public static Tensor VarAll(Tensor? result, Tensor src) { return (Tensor)OpRegistry.Invoke("varall", result, src)!; }
 
 
         public static float SumAll(Tensor src) { using (Tensor resultTensor = SumAll(null, src)) { return resultTensor.GetElementAsFloat(0); } }
@@ -263,13 +265,13 @@ namespace TensorSharp
 
 
      //   public static Tensor IndexSelect(Tensor result, Tensor src, int dim, Tensor indices) { return (Tensor)OpRegistry.Invoke("index_select", result, src, dim, indices); }
-        public static Tensor Gather(Tensor result, Tensor src, int dim, Tensor indices) { return (Tensor)OpRegistry.Invoke("gather", result, src, dim, indices); }
-        public static Tensor Scatter(Tensor result, Tensor src, int dim, Tensor indices) { return (Tensor)OpRegistry.Invoke("scatter", result, src, dim, indices); }
+        public static Tensor Gather(Tensor result, Tensor src, int dim, Tensor indices) { return (Tensor)OpRegistry.Invoke("gather", result, src, dim, indices)!; } 
+        public static Tensor Scatter(Tensor result, Tensor src, int dim, Tensor indices) { return (Tensor)OpRegistry.Invoke("scatter", result, src, dim, indices)!; }
 
 
-        public static Tensor ScatterAdd(Tensor result, Tensor src, int dim, Tensor indices) { return (Tensor)OpRegistry.Invoke("scatter_add", result, src, dim, indices); }
+        public static Tensor ScatterAdd(Tensor result, Tensor src, int dim, Tensor indices) { return (Tensor)OpRegistry.Invoke("scatter_add", result, src, dim, indices)!; } 
 
-        public static Tensor ScatterFill(Tensor result, float value, int dim, Tensor indices) { return (Tensor)OpRegistry.Invoke("scatter_fill", result, value, dim, indices); }
+        public static Tensor ScatterFill(Tensor result, float value, int dim, Tensor indices) { return (Tensor)OpRegistry.Invoke("scatter_fill", result, value, dim, indices)!; }
 
 
 

--- a/TensorSharp.Core/Tensor.cs
+++ b/TensorSharp.Core/Tensor.cs
@@ -111,9 +111,9 @@ namespace TensorSharp
             }
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            Tensor o = obj as Tensor;
+            Tensor? o = obj as Tensor;
             if (o == null)
             {
                 return false;

--- a/TensorSharp.Core/TensorApplyCPU.cs
+++ b/TensorSharp.Core/TensorApplyCPU.cs
@@ -710,7 +710,8 @@ namespace TensorSharp
 
 			}
 
-			ApplyDim2(result, indices, dim, func);
+			// the assumption here is that the result and indices are not null. The compiler can't guarantee this because of the null tests in the if() statement above.
+			ApplyDim2(result!, indices!, dim, func);
 		}
 
 

--- a/TensorSharp.Core/TensorSharp.Core.csproj
+++ b/TensorSharp.Core/TensorSharp.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
@@ -13,7 +13,7 @@
          TensorSharp.Core, so consumer `using` statements are unaffected.
          Do not "fix" this back to the default without checking id ownership. -->
     <PackageId>TensorSharp.Tensors</PackageId>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <Description>Core tensor primitives, CPU operations, memory management, storage, and device abstractions for TensorSharp.</Description>
     <PackageTags>$(TensorSharpPackageTags);core;ops;memory;device;cpu</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
I don't like warnings and it gives me an opportunity to work with the code and inspect it more closely.

As a result, `TensorSharp.Core` now compiles without warnings and has nullability enabled.