### PR TITLE
Add hunyuan-dense so Hy-MT2 GGUFs can run

### DIFF
--- a/InferenceWeb.Tests/HunyuanDenseChatTemplateTests.cs
+++ b/InferenceWeb.Tests/HunyuanDenseChatTemplateTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Zhongkai Fu. All rights reserved.
+// https://github.com/zhongkaifu/TensorSharp
+//
+// This file is part of TensorSharp.
+//
+// TensorSharp is licensed under the BSD-3-Clause license found in the LICENSE file in the root directory of this source tree.
+using System.Collections.Generic;
+using TensorSharp.AgentHost.Skills;
+using TensorSharp.Runtime;
+
+namespace InferenceWeb.Tests;
+
+public class HunyuanDenseChatTemplateTests
+{
+    [Fact]
+    public void UserTurn_GetsBosAndGenerationPrompt()
+    {
+        string prompt = ChatTemplate.RenderHunyuanDense(
+        [
+            new ChatMessage { Role = "user", Content = "Hello" },
+        ]);
+
+        Assert.Equal("<｜hy_begin▁of▁sentence｜><｜hy_User｜>Hello<｜hy_Assistant｜>", prompt);
+    }
+
+    [Fact]
+    public void SystemThenUser_MatchesOfficialHyMt2Jinja()
+    {
+        string prompt = ChatTemplate.RenderHunyuanDense(
+        [
+            new ChatMessage { Role = "system", Content = "You are a translator." },
+            new ChatMessage { Role = "user", Content = "Hello" },
+        ]);
+
+        Assert.Equal(
+            "<｜hy_begin▁of▁sentence｜>You are a translator.<｜hy_place▁holder▁no▁3｜><｜hy_User｜>Hello<｜hy_Assistant｜>",
+            prompt);
+    }
+
+    [Fact]
+    public void AssistantHistory_ClosesWithPlaceholderTwo()
+    {
+        string prompt = ChatTemplate.RenderHunyuanDense(
+        [
+            new ChatMessage { Role = "user", Content = "Hi" },
+            new ChatMessage { Role = "assistant", Content = "你好" },
+            new ChatMessage { Role = "user", Content = "Thanks" },
+        ]);
+
+        Assert.Equal(
+            "<｜hy_begin▁of▁sentence｜><｜hy_User｜>Hi<｜hy_Assistant｜>你好<｜hy_place▁holder▁no▁2｜><｜hy_User｜>Thanks<｜hy_Assistant｜>",
+            prompt);
+    }
+
+    [Fact]
+    public void WithoutGenerationPrompt_EndsWithPlaceholderEight()
+    {
+        string prompt = ChatTemplate.RenderHunyuanDense(
+        [
+            new ChatMessage { Role = "user", Content = "Hello" },
+        ], addGenerationPrompt: false);
+
+        Assert.Equal("<｜hy_begin▁of▁sentence｜><｜hy_User｜>Hello<｜hy_place▁holder▁no▁8｜>", prompt);
+    }
+
+    [Fact]
+    public void Protocol_BypassesJinjaAndOffersNoTools()
+    {
+        ChatProtocol protocol = ChatProtocolRegistry.For("hunyuan-dense");
+        Assert.NotNull(protocol);
+        Assert.True(protocol.PreferOwnRenderer(new ChatRenderRequest([], true, "hunyuan-dense", null, false)));
+        Assert.False(protocol.RendersToolDeclarations);
+        Assert.False(protocol.RendersToolResultMessages);
+        Assert.False(SkillCapabilities.For("hunyuan-dense").ToolsRendered);
+    }
+}

--- a/TensorSharp.Models/Architecture/BuiltInArchitectures.cs
+++ b/TensorSharp.Models/Architecture/BuiltInArchitectures.cs
@@ -34,6 +34,7 @@ namespace TensorSharp.Models.Architecture
             ModelArchitectureRegistry.Register(GptOssArchitecture.Descriptor);
             ModelArchitectureRegistry.Register(NemotronArchitecture.Descriptor);
             ModelArchitectureRegistry.Register(Mistral3Architecture.Descriptor);
+            ModelArchitectureRegistry.Register(HunyuanDenseArchitecture.Descriptor);
             ModelArchitectureRegistry.Register(MuseGlimmerArchitecture.Descriptor);
             ModelArchitectureRegistry.Register(DeepSeek4Architecture.Descriptor);
             ModelArchitectureRegistry.Register(GlmDsaArchitecture.Descriptor);

--- a/TensorSharp.Models/Models/HunyuanDense/HunyuanDenseArchitecture.cs
+++ b/TensorSharp.Models/Models/HunyuanDense/HunyuanDenseArchitecture.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Zhongkai Fu. All rights reserved.
+// https://github.com/zhongkaifu/TensorSharp
+//
+// This file is part of TensorSharp.
+//
+// TensorSharp is licensed under the BSD-3-Clause license found in the LICENSE file in the root directory of this source tree.
+using TensorSharp.Models.Architecture;
+
+namespace TensorSharp.Models
+{
+    /// <summary>Hunyuan dense (Hy-MT / Hunyuan-1.8B-style) architecture plug-in.</summary>
+    internal static class HunyuanDenseArchitecture
+    {
+        public static ModelArchitectureDescriptor Descriptor { get; } = new()
+        {
+            Id = "hunyuan-dense",
+            DisplayName = "Hunyuan Dense",
+            Aliases = ["hunyuan-dense"],
+            Factory = c => new HunyuanDenseModel(c.GgufPath, c.Backend, c.TpDegree, c.TpGroup),
+            MultiGpu = MultiGpuMode.SingleDevice,
+            MultiGpuLimitation =
+                "hunyuan-dense has no tensor-parallel or layer-split path yet; extra GPUs stay idle.",
+        };
+    }
+}

--- a/TensorSharp.Models/Models/HunyuanDense/HunyuanDenseModel.cs
+++ b/TensorSharp.Models/Models/HunyuanDense/HunyuanDenseModel.cs
@@ -1,0 +1,485 @@
+// Copyright (c) Zhongkai Fu. All rights reserved.
+// https://github.com/zhongkaifu/TensorSharp
+//
+// This file is part of TensorSharp.
+//
+// TensorSharp is licensed under the BSD-3-Clause license found in the LICENSE file in the root directory of this source tree.
+using System;
+using System.Diagnostics;
+using TensorSharp;
+using TensorSharp.GGML;
+
+namespace TensorSharp.Models
+{
+    /// <summary>
+    /// Hunyuan dense transformer (GGUF <c>hunyuan-dense</c>).
+    /// Matches llama.cpp's hunyuan-vl text graph: RMSNorm → QKV → NeoX RoPE →
+    /// per-head Q/K RMSNorm → GQA attention → SwiGLU. QK-norm is AFTER RoPE,
+    /// the opposite of Qwen 3.5.
+    /// </summary>
+    public sealed class HunyuanDenseModel : ModelBase
+    {
+        private Tensor[] _kvCacheK;
+        private Tensor[] _kvCacheV;
+        private bool[] _layerQkvFused;
+        private bool[] _layerGateUpFused;
+        private int _attnKeyLen;
+        private int _attnValLen;
+        private int _ropeDim;
+        private int _kvCacheCapacity;
+
+        public HunyuanDenseModel(string ggufPath, BackendType backend, int tpDegree = 1, ITensorParallelGroup tpGroup = null)
+            : base(ggufPath, backend, tpDegree, tpGroup)
+        {
+            string arch = _gguf.GetString("general.architecture") ?? "hunyuan-dense";
+            Config = new ModelConfig { Architecture = arch };
+            ParseBaseConfig();
+
+            _attnKeyLen = Config.KeyLength > 0 ? Config.KeyLength : Config.HeadDim;
+            _attnValLen = Config.ValueLength > 0 ? Config.ValueLength : _attnKeyLen;
+            if (_attnKeyLen != _attnValLen)
+            {
+                throw new NotSupportedException(
+                    $"hunyuan-dense expects equal key/value head dims, got key={_attnKeyLen} value={_attnValLen}.");
+            }
+
+            _ropeDim = (int)_gguf.GetUint32($"{arch}.rope.dimension_count", (uint)_attnKeyLen);
+            ApplyHunyuanRopeBase(arch);
+            ParseTokenizer();
+
+            Console.WriteLine($"Model: {arch}, Layers={Config.NumLayers}, Hidden={Config.HiddenSize}, " +
+                $"Heads={Config.NumHeads}, KVHeads={Config.NumKVHeads}, KeyLen={_attnKeyLen}, " +
+                $"ValLen={_attnValLen}, Vocab={Config.VocabSize}");
+            Console.WriteLine($"RoPE base={Config.RopeBase}, scale={Config.RopeScale}, dim={_ropeDim} (NeoX, then QK-norm)");
+
+            LoadWeights();
+            FuseQKVWeights();
+            FuseGateUpWeights();
+            PrepareCudaQuantizedWeightsForInference();
+            PrecomputeLayerFlags();
+
+            int maxContextLength = ResolveConfiguredContextLength();
+            int initialCacheLength = ResolveInitialCacheAllocationLength(maxContextLength);
+            if (initialCacheLength < maxContextLength)
+            {
+                Console.WriteLine(
+                    $"Initial {_backend} KV cache allocation: {initialCacheLength} tokens (grows on demand up to {maxContextLength}).");
+            }
+
+            InitKVCache(initialCacheLength, maxContextLength);
+        }
+
+        protected override bool SupportsSplitGateUpFfn => true;
+
+        public override void PrepareForPrefill(int requiredContextTokens)
+            => EnsureCacheCapacity(requiredContextTokens);
+
+        /// <summary>
+        /// llama.cpp hunyuan-vl: <c>base = rope_theta * alpha^(dim / (dim - 2))</c>
+        /// when XDRoPE / NTK alpha is present. Hy-MT2 Q4 ships <c>scaling.type=none</c>.
+        /// </summary>
+        private void ApplyHunyuanRopeBase(string arch)
+        {
+            float alpha = _gguf.GetFloat32($"{arch}.rope.scaling.alpha", 0f);
+            if (alpha <= 0f || _attnKeyLen <= 2)
+                return;
+
+            Config.RopeBase *= MathF.Pow(alpha, (float)_attnKeyLen / (float)(_attnKeyLen - 2));
+            Console.WriteLine($"  Applied Hunyuan NTK RoPE alpha={alpha}, effective base={Config.RopeBase}");
+        }
+
+        private unsafe void FuseQKVWeights()
+        {
+            int fused = 0;
+            for (int l = 0; l < Config.NumLayers; l++)
+            {
+                string qName = $"blk.{l}.attn_q.weight";
+                string kName = $"blk.{l}.attn_k.weight";
+                string vName = $"blk.{l}.attn_v.weight";
+                string qkvName = $"blk.{l}.attn_qkv.weight";
+
+                if (_quantWeights.TryGetValue(qName, out QuantizedWeight qw) &&
+                    _quantWeights.TryGetValue(kName, out QuantizedWeight kw) &&
+                    _quantWeights.TryGetValue(vName, out QuantizedWeight vw) &&
+                    qw.GgmlType == kw.GgmlType && kw.GgmlType == vw.GgmlType &&
+                    qw.Ne0 == kw.Ne0 && kw.Ne0 == vw.Ne0)
+                {
+                    if (!TryCreateFusedQuantizedWeight(out QuantizedWeight fusedWeight, qw, kw, vw))
+                        continue;
+
+                    _quantWeights[qkvName] = fusedWeight;
+                    _quantWeights.Remove(qName); qw.Dispose();
+                    _quantWeights.Remove(kName); kw.Dispose();
+                    _quantWeights.Remove(vName); vw.Dispose();
+                    fused++;
+                }
+                else if (_weights.TryGetValue(qName, out Tensor qf) &&
+                         _weights.TryGetValue(kName, out Tensor kf) &&
+                         _weights.TryGetValue(vName, out Tensor vf))
+                {
+                    int qDim = (int)qf.Sizes[0];
+                    int kDim = (int)kf.Sizes[0];
+                    int vDim = (int)vf.Sizes[0];
+                    int inDim = (int)qf.Sizes[1];
+                    Tensor fusedTensor = new Tensor(_allocator, DType.Float32, qDim + kDim + vDim, inDim);
+                    using (Tensor s0 = fusedTensor.Narrow(0, 0, qDim)) Ops.Copy(s0, qf);
+                    using (Tensor s1 = fusedTensor.Narrow(0, qDim, kDim)) Ops.Copy(s1, kf);
+                    using (Tensor s2 = fusedTensor.Narrow(0, qDim + kDim, vDim)) Ops.Copy(s2, vf);
+                    _weights[qkvName] = fusedTensor;
+                    _weights.Remove(qName); qf.Dispose();
+                    _weights.Remove(kName); kf.Dispose();
+                    _weights.Remove(vName); vf.Dispose();
+                    fused++;
+                }
+            }
+            if (fused > 0)
+                Console.WriteLine($"  Fused projections: {fused} QKV");
+        }
+
+        private void PrecomputeLayerFlags()
+        {
+            int numLayers = Config.NumLayers;
+            _layerQkvFused = new bool[numLayers];
+            _layerGateUpFused = new bool[numLayers];
+            for (int l = 0; l < numLayers; l++)
+            {
+                string qkvName = $"blk.{l}.attn_qkv.weight";
+                _layerQkvFused[l] = _quantWeights.ContainsKey(qkvName) || _weights.ContainsKey(qkvName);
+
+                string gateUpName = $"blk.{l}.ffn_gate_up.weight";
+                _layerGateUpFused[l] = _quantWeights.ContainsKey(gateUpName) || _weights.ContainsKey(gateUpName);
+
+                if (!_weights.ContainsKey($"blk.{l}.attn_q_norm.weight") ||
+                    !_weights.ContainsKey($"blk.{l}.attn_k_norm.weight"))
+                {
+                    throw new InvalidOperationException(
+                        $"hunyuan-dense layer {l} is missing attn_q_norm / attn_k_norm weights.");
+                }
+            }
+        }
+
+        private void InitKVCache(int initialSeqLen, int maxSeqLen)
+        {
+            _maxContextLength = maxSeqLen;
+            _kvCacheCapacity = initialSeqLen;
+            ApplyModelAlignedKvCacheDefault(_quantWeights);
+            DType kvDtype = _kvCacheDtype.ToDType();
+            _kvCacheK = new Tensor[Config.NumLayers];
+            _kvCacheV = new Tensor[Config.NumLayers];
+            for (int l = 0; l < Config.NumLayers; l++)
+            {
+                _kvCacheK[l] = new Tensor(_allocator, kvDtype, Config.NumKVHeads, initialSeqLen, _attnKeyLen);
+                _kvCacheV[l] = new Tensor(_allocator, kvDtype, Config.NumKVHeads, initialSeqLen, _attnValLen);
+                InitializeCacheTensor(_kvCacheK[l]);
+                InitializeCacheTensor(_kvCacheV[l]);
+            }
+            _cacheSeqLen = 0;
+        }
+
+        private void EnsureCacheCapacity(int requiredSeqLen)
+        {
+            if (requiredSeqLen <= _kvCacheCapacity)
+                return;
+            if (requiredSeqLen > _maxContextLength)
+            {
+                throw new InvalidOperationException(
+                    $"Requested sequence length {requiredSeqLen} exceeds configured max context {_maxContextLength}.");
+            }
+
+            int newCapacity = Math.Max(_kvCacheCapacity, 1);
+            while (newCapacity < requiredSeqLen)
+                newCapacity = Math.Min(_maxContextLength, newCapacity * 2);
+
+            DType kvDtype = _kvCacheDtype.ToDType();
+            for (int l = 0; l < Config.NumLayers; l++)
+            {
+                Tensor newK = new Tensor(_allocator, kvDtype, Config.NumKVHeads, newCapacity, _attnKeyLen);
+                Tensor newV = new Tensor(_allocator, kvDtype, Config.NumKVHeads, newCapacity, _attnValLen);
+                InitializeCacheTensor(newK);
+                InitializeCacheTensor(newV);
+
+                if (_cacheSeqLen > 0)
+                {
+                    using Tensor srcK = _kvCacheK[l].Narrow(1, 0, _cacheSeqLen);
+                    using Tensor dstK = newK.Narrow(1, 0, _cacheSeqLen);
+                    Ops.Copy(dstK, srcK);
+
+                    using Tensor srcV = _kvCacheV[l].Narrow(1, 0, _cacheSeqLen);
+                    using Tensor dstV = newV.Narrow(1, 0, _cacheSeqLen);
+                    Ops.Copy(dstV, srcV);
+                }
+
+                _kvCacheK[l].Dispose();
+                _kvCacheV[l].Dispose();
+                _kvCacheK[l] = newK;
+                _kvCacheV[l] = newV;
+            }
+
+            _kvCacheCapacity = newCapacity;
+            Console.WriteLine($"Expanded hunyuan-dense attention cache to {newCapacity} tokens.");
+        }
+
+        protected override void ResetKVCacheCore()
+        {
+            _cacheSeqLen = 0;
+            _linearTicks = _attnTicks = _normTicks = _embTicks = _lmHeadTicks = _logitsCopyTicks = 0;
+            _forwardCount = 0;
+            _forwardSw.Reset();
+            if (_kvCacheK == null)
+                return;
+            for (int l = 0; l < Config.NumLayers; l++)
+            {
+                ResetCacheTensor(_kvCacheK[l]);
+                ResetCacheTensor(_kvCacheV[l]);
+            }
+        }
+
+        protected override float[] ForwardCore(int[] tokens)
+        {
+            _forwardSw.Start();
+            int seqLen = tokens.Length;
+            int startPos = _cacheSeqLen;
+            EnsureCacheCapacity(startPos + seqLen);
+
+            long t1 = Stopwatch.GetTimestamp();
+            Tensor hidden = Embedding(tokens);
+            _embTicks += Stopwatch.GetTimestamp() - t1;
+
+            for (int layer = 0; layer < Config.NumLayers; layer++)
+                hidden = TransformerBlock(hidden, layer, seqLen, startPos);
+
+            Tensor normed = RMSNormOp(hidden, "output_norm.weight");
+            hidden.Dispose();
+
+            Tensor lastHidden;
+            if (seqLen > 1)
+            {
+                using Tensor narrowed = normed.Narrow(0, seqLen - 1, 1);
+                lastHidden = Ops.NewContiguous(narrowed);
+            }
+            else
+            {
+                lastHidden = normed.CopyRef();
+            }
+            normed.Dispose();
+
+            long t2 = Stopwatch.GetTimestamp();
+            Tensor logitsTensor = LinearForward(lastHidden, "output.weight")
+                ?? LinearForward(lastHidden, "token_embd.weight");
+            _lmHeadTicks += Stopwatch.GetTimestamp() - t2;
+            lastHidden.Dispose();
+
+            long t3 = Stopwatch.GetTimestamp();
+            _logitsBuffer = TensorToFloatArray(logitsTensor);
+            _logitsCopyTicks += Stopwatch.GetTimestamp() - t3;
+            logitsTensor.Dispose();
+
+            _cacheSeqLen += seqLen;
+            _forwardCount++;
+            _forwardSw.Stop();
+            return _logitsBuffer;
+        }
+
+        private Tensor TransformerBlock(Tensor hidden, int layer, int seqLen, int startPos)
+        {
+            string p = $"blk.{layer}.";
+            Tensor normed = RMSNormOp(hidden, p + "attn_norm.weight");
+            Tensor attnOut = Attention(normed, layer, seqLen, startPos);
+            normed.Dispose();
+
+            Ops.Add(hidden, hidden, attnOut);
+            attnOut.Dispose();
+
+            if (_layerGateUpFused[layer] &&
+                TryFusedDenseSwiGLUFFNInto(hidden, p + "ffn_norm.weight", p + "ffn_gate_up.weight", p + "ffn_down.weight"))
+            {
+                return hidden;
+            }
+
+            Tensor ffnNormed = RMSNormOp(hidden, p + "ffn_norm.weight");
+            Tensor ffnOut = FFNLayer(ffnNormed, layer, seqLen);
+            ffnNormed.Dispose();
+            Ops.Add(hidden, hidden, ffnOut);
+            ffnOut.Dispose();
+            return hidden;
+        }
+
+        private Tensor FFNLayer(Tensor input, int layer, int seqLen)
+        {
+            string p = $"blk.{layer}.";
+            if (_layerGateUpFused[layer])
+                return FFN(input, p + "ffn_gate_up.weight", p + "ffn_down.weight", seqLen);
+
+            Tensor gate = LinearForward(input, p + "ffn_gate.weight");
+            Tensor up = LinearForward(input, p + "ffn_up.weight");
+            Ops.SiLUMul(gate, gate, up);
+            up.Dispose();
+            Tensor down = LinearForward(gate, p + "ffn_down.weight");
+            gate.Dispose();
+            return down;
+        }
+
+        private Tensor Attention(Tensor input, int layer, int seqLen, int startPos)
+        {
+            int numHeads = Config.NumHeads;
+            int numKVHeads = Config.NumKVHeads;
+            int headDim = _attnKeyLen;
+            int qDim = numHeads * headDim;
+            int kDim = numKVHeads * headDim;
+            int totalSeqLen = startPos + seqLen;
+            float scale = 1.0f / MathF.Sqrt(headDim);
+            string p = $"blk.{layer}.";
+
+            Tensor qTensor;
+            Tensor kTensor;
+            Tensor vTensor;
+            if (_layerQkvFused[layer])
+            {
+                Tensor qkvFused = LinearForward(input, p + "attn_qkv.weight");
+                if (seqLen == 1)
+                {
+                    qTensor = qkvFused.Narrow(1, 0, qDim);
+                    kTensor = qkvFused.Narrow(1, qDim, kDim);
+                    vTensor = qkvFused.Narrow(1, qDim + kDim, kDim);
+                    qkvFused.Dispose();
+                }
+                else
+                {
+                    using (Tensor qView = qkvFused.Narrow(1, 0, qDim))
+                        qTensor = Ops.NewContiguous(qView);
+                    using (Tensor kView = qkvFused.Narrow(1, qDim, kDim))
+                        kTensor = Ops.NewContiguous(kView);
+                    using (Tensor vView = qkvFused.Narrow(1, qDim + kDim, kDim))
+                        vTensor = Ops.NewContiguous(vView);
+                    qkvFused.Dispose();
+                }
+            }
+            else
+            {
+                qTensor = LinearForward(input, p + "attn_q.weight");
+                kTensor = LinearForward(input, p + "attn_k.weight");
+                vTensor = LinearForward(input, p + "attn_v.weight");
+            }
+
+            // NeoX RoPE first, then per-head Q/K RMSNorm. Do not use Qwen35's
+            // fused QKNorm+RoPE kernel — that applies the norm before rotation.
+            ApplyNeoXRoPE(qTensor, numHeads, seqLen, startPos);
+            ApplyNeoXRoPE(kTensor, numKVHeads, seqLen, startPos);
+            ApplyQKNorm(qTensor, _weights[p + "attn_q_norm.weight"], numHeads, seqLen);
+            ApplyQKNorm(kTensor, _weights[p + "attn_k_norm.weight"], numKVHeads, seqLen);
+
+            long t0 = Stopwatch.GetTimestamp();
+            if (seqLen == 1)
+            {
+                CopyToCacheDecode(_kvCacheK[layer], kTensor, _kvCacheV[layer], vTensor,
+                    numKVHeads, headDim, startPos);
+                kTensor.Dispose();
+                vTensor.Dispose();
+
+                Tensor attnResult = new Tensor(_allocator, DType.Float32, 1, numHeads * headDim);
+                AttentionDecodePureCS(qTensor, _kvCacheK[layer], _kvCacheV[layer],
+                    attnResult, numHeads, numKVHeads, headDim, totalSeqLen, scale);
+                qTensor.Dispose();
+                _attnTicks += Stopwatch.GetTimestamp() - t0;
+
+                Tensor decodeOut = LinearForward(attnResult, p + "attn_output.weight");
+                attnResult.Dispose();
+                return decodeOut;
+            }
+
+            Tensor qHeads = ReshapeToHeads(qTensor, numHeads, seqLen, headDim);
+            qTensor.Dispose();
+            Tensor kHeads = ReshapeToHeads(kTensor, numKVHeads, seqLen, headDim);
+            kTensor.Dispose();
+            Tensor vHeads = ReshapeToHeads(vTensor, numKVHeads, seqLen, _attnValLen);
+            vTensor.Dispose();
+
+            CopyToCache(_kvCacheK[layer], kHeads, startPos, seqLen);
+            CopyToCache(_kvCacheV[layer], vHeads, startPos, seqLen);
+            kHeads.Dispose();
+            vHeads.Dispose();
+
+            int groupSize = numHeads / numKVHeads;
+            Tensor kExpanded = ExpandKVHeads(_kvCacheK[layer], groupSize, totalSeqLen);
+            Tensor vExpanded = ExpandKVHeads(_kvCacheV[layer], groupSize, totalSeqLen);
+
+            using Tensor kT = kExpanded.Transpose(1, 2);
+            Tensor scores = new Tensor(_allocator, DType.Float32, numHeads, seqLen, totalSeqLen);
+            Ops.AddmmBatch(scores, 0, scores, scale, qHeads, kT);
+            qHeads.Dispose();
+            kExpanded.Dispose();
+
+            if (IsGgmlBackend)
+            {
+                GgmlBasicOps.AttentionSoftmaxWithSinks(
+                    scores, sinks: null,
+                    numHeads: numHeads, seqLen: seqLen, kvLen: totalSeqLen,
+                    maskStartPos: startPos, slidingWindow: 0, scale: 1.0f);
+            }
+            else
+            {
+                Ops.AddCausalMask(scores, seqLen, startPos, float.NegativeInfinity);
+                Ops.Softmax(scores, scores);
+            }
+
+            Tensor attnOut = new Tensor(_allocator, DType.Float32, numHeads, seqLen, _attnValLen);
+            Ops.AddmmBatch(attnOut, 0, attnOut, 1.0f, scores, vExpanded);
+            scores.Dispose();
+            vExpanded.Dispose();
+
+            Tensor flatOutput = ReshapeFromHeads(attnOut, numHeads, seqLen, _attnValLen);
+            attnOut.Dispose();
+            _attnTicks += Stopwatch.GetTimestamp() - t0;
+
+            Tensor output = LinearForward(flatOutput, p + "attn_output.weight");
+            flatOutput.Dispose();
+            return output;
+        }
+
+        private void ApplyNeoXRoPE(Tensor data, int numHeads, int seqLen, int startPos)
+        {
+            int headDim = _attnKeyLen;
+            int totalRows = seqLen * numHeads;
+            int[] positions = new int[totalRows];
+            for (int s = 0; s < seqLen; s++)
+            {
+                for (int h = 0; h < numHeads; h++)
+                    positions[s * numHeads + h] = startPos + s;
+            }
+
+            using Tensor posTensor = CreateIntTensorOn(data.Storage.Allocator, positions, totalRows);
+            using Tensor reshaped = data.View(1, seqLen, numHeads, headDim);
+            Ops.RoPEEx(reshaped, reshaped, posTensor, _ropeDim, 2, 0,
+                Config.RopeBase, 1.0f / Config.RopeScale,
+                0.0f, 1.0f, 0.0f, 0.0f);
+        }
+
+        private void ApplyQKNorm(Tensor data, Tensor alpha, int numHeads, int seqLen)
+        {
+            int headDim = _attnKeyLen;
+            if (seqLen == 1 && _backend != BackendType.Mlx && _backend != BackendType.Cuda)
+            {
+                RMSNormInPlaceCpu(data, alpha, numHeads, headDim, Config.Eps);
+                return;
+            }
+
+            using Tensor reshaped = data.View(seqLen * numHeads, headDim);
+            Ops.RMSNorm(reshaped, reshaped, alpha, null, Config.Eps);
+        }
+
+        public override void Dispose()
+        {
+            if (_kvCacheK != null)
+            {
+                foreach (Tensor t in _kvCacheK)
+                    t?.Dispose();
+            }
+            if (_kvCacheV != null)
+            {
+                foreach (Tensor t in _kvCacheV)
+                    t?.Dispose();
+            }
+            base.Dispose();
+        }
+    }
+}

--- a/TensorSharp.Runtime/ChatProtocolRegistry.cs
+++ b/TensorSharp.Runtime/ChatProtocolRegistry.cs
@@ -280,6 +280,18 @@ namespace TensorSharp.Runtime
 
             Register(new ChatProtocol
             {
+                Id = "hunyuan-dense",
+                Architectures = new[] { "hunyuan-dense" },
+                Render = r => ChatTemplate.RenderHunyuanDense(r.Messages, r.AddGenerationPrompt),
+                // Official Hy-MT2 jinja (BOS + add_generation_prompt). The
+                // renderer never emits tool declarations or role:"tool" results.
+                RendersToolDeclarations = false,
+                RendersToolResultMessages = false,
+                PreferOwnRenderer = _ => true,
+            });
+
+            Register(new ChatProtocol
+            {
                 Id = "mistral3",
                 Architectures = new[] { "mistral3" },
                 Render = r => ChatTemplate.RenderMistral3(r.Messages, r.AddGenerationPrompt),

--- a/TensorSharp.Runtime/ChatTemplate.cs
+++ b/TensorSharp.Runtime/ChatTemplate.cs
@@ -1428,6 +1428,59 @@ namespace TensorSharp.Runtime
         /// Uses [SYSTEM_PROMPT]...[/SYSTEM_PROMPT] for system messages
         /// and [INST]...[/INST] for user messages.
         /// </summary>
+        /// <summary>
+        /// Hunyuan dense / Hy-MT2 chat framing, matching
+        /// <c>tencent/Hy-MT2-1.8B</c> <c>chat_template.jinja</c>.
+        /// Always opens with BOS; user turns do not carry the assistant marker —
+        /// that is appended only when <paramref name="addGenerationPrompt"/> is set.
+        /// llama.cpp's <c>LLM_CHAT_TEMPLATE_HUNYUAN_DENSE</c> (Hunyuan-4B-Instruct)
+        /// omits BOS and glues the assistant marker onto the user turn; Hy-MT2
+        /// does not.
+        /// </summary>
+        public static string RenderHunyuanDense(List<ChatMessage> messages, bool addGenerationPrompt = true)
+        {
+            var sb = new StringBuilder();
+            int startIdx = 0;
+
+            if (messages.Count > 0 && messages[0] != null && messages[0].Role == "system")
+            {
+                sb.Append("<｜hy_begin▁of▁sentence｜>");
+                sb.Append(messages[0].Content);
+                sb.Append("<｜hy_place▁holder▁no▁3｜>");
+                startIdx = 1;
+            }
+            else
+            {
+                sb.Append("<｜hy_begin▁of▁sentence｜>");
+            }
+
+            for (int i = startIdx; i < messages.Count; i++)
+            {
+                ChatMessage msg = messages[i];
+                if (msg == null)
+                    continue;
+
+                if (msg.Role == "user")
+                {
+                    sb.Append("<｜hy_User｜>");
+                    sb.Append(msg.Content);
+                }
+                else if (msg.Role == "assistant")
+                {
+                    sb.Append("<｜hy_Assistant｜>");
+                    sb.Append(msg.Content);
+                    sb.Append("<｜hy_place▁holder▁no▁2｜>");
+                }
+            }
+
+            if (addGenerationPrompt)
+                sb.Append("<｜hy_Assistant｜>");
+            else
+                sb.Append("<｜hy_place▁holder▁no▁8｜>");
+
+            return sb.ToString();
+        }
+
         public static string RenderMistral3(List<ChatMessage> messages, bool addGenerationPrompt = true)
         {
             var sb = new StringBuilder();


### PR DESCRIPTION
## Summary
- Register `hunyuan-dense` (Hy-MT2 / Hunyuan dense text) through the architecture + chat-protocol seams. Official Q4 GGUFs previously failed at load with `Unsupported architecture`.
- Forward matches llama.cpp's hunyuan-vl text graph: RMSNorm → QKV → NeoX RoPE → per-head Q/K RMSNorm → GQA → SwiGLU. QK-norm is after RoPE (the opposite of Qwen 3.5).
- Chat template follows `tencent/Hy-MT2-1.8B` `chat_template.jinja` (BOS + `add_generation_prompt`), not llama.cpp's Hunyuan-4B-Instruct hardcoded template, which dropped BOS and produced off-task replies.
- First cut is `SingleDevice`: no TP, no fused whole-model graph, no continuous batch. CPU ggml is slower than llama.cpp on this path; correctness was checked on `Hy-MT2-1.8B-Q4_K_M` (`Hello` → `你好`; official translation prompt produces Chinese).

## Test plan
- [x] `HunyuanDenseChatTemplateTests` (BOS, system, multi-turn, no-tools protocol)
- [x] `TensorParallelSupportGateTests` / `SkillCapabilityConsistencyTests` still pass with the new registration
- [x] `--backend cpu` / `ggml_cpu` load + translate on `Hy-MT2-1.8B-Q4_K_M.gguf`
- [ ] GPU path (`ggml_cuda` / `cuda`) — not exercised on the authoring machine
- [ ] Long-context / chunked prefill (model advertises 262k; KV grows on demand)